### PR TITLE
change how strings are handled n OptiX 7

### DIFF
--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -104,6 +104,7 @@ MY_CMAKE_FLAGS += -DOSL_NAMESPACE_INCLUDE_PATCH=1
 REZ_PACKAGE_ROOT ?= /shots/spi/home/software/packages
 SPCOMP2_ROOT ?= /shots/spi/home/lib/SpComp2
 
+MY_CMAKE_FLAGS += -DOSL_EXTRA_NVCC_ARGS="--compiler-bindir=/opt/rh/devtoolset-6/root/bin/gcc"
 
 ## Rhel7 (current)
 ifeq (${SP_OS}, rhel7)
@@ -284,7 +285,6 @@ ifeq (${SP_OS}, rhel7)
     OPTIX_VERSION ?= 7.1.0
     # CUDA_TOOLKIT_ROOT_DIR = $(shell rez-env -b cuda-${CUDA_VERSION} ${SPI_COMPILER_PLATFORM} -c "echo '$CUDA_TOOLKIT_ROOT'")
     CUDA_TOOLKIT_ROOT_DIR ?= /shots/spi/home/lib/arnold/rhel7/cuda_${CUDA_VERSION}
-    CUDA_EXTRA_LIBS ?= ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libnvrtc.so
     OptiX_ROOT ?= /shots/spi/home/lib/arnold/rhel7/optix_${OPTIX_VERSION}
     OPTIXHOME = ${OptiX_ROOT}
     MY_CMAKE_FLAGS += -DUSE_OPTIX=${USE_OPTIX} \

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -135,6 +135,7 @@ if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
     add_compile_options ("-Wno-unused-private-field")
     add_compile_options ("-Wno-tautological-compare")
     add_compile_options ("-Wno-unknown-pragmas")
+    add_compile_options ("-Wno-format-security")
     # disable warning about unused command line arguments
     add_compile_options ("-Qunused-arguments")
     # Don't warn if we ask it not to warn about warnings it doesn't know

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
+set ($OSL_EXTRA_NVCC_ARGS "" CACHE STRING "Custom args passed to nvcc when compiling CUDA code")
+
 # Compile a CUDA file to PTX using NVCC
 function ( NVCC_COMPILE cuda_src ptx_generated extra_nvcc_args )
     get_filename_component ( cuda_src_we ${cuda_src} NAME_WE )
@@ -26,8 +28,9 @@ function ( NVCC_COMPILE cuda_src ptx_generated extra_nvcc_args )
             ${LLVM_COMPILE_FLAGS}
             -DOSL_USE_FAST_MATH=1
             -m64 -arch ${CUDA_TARGET_ARCH} -ptx
-            --std=c++11 -dc -O3 --use_fast_math --expt-relaxed-constexpr
+            --std=c++14 -dc -O3 --use_fast_math --expt-relaxed-constexpr
             ${extra_nvcc_args}
+            ${OSL_EXTRA_NVCC_ARGS}
             ${cuda_src} -o ${cuda_ptx}
         MAIN_DEPENDENCY ${cuda_src}
         DEPENDS ${cuda_src} ${cuda_headers} oslexec

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -40,9 +40,21 @@ namespace pvt {
 class ShadingSystemImpl;
 }
 
+#if defined(__CUDA_ARCH__) && OPTIX_VERSION >= 70000
+#  define STRINGIFY(x) XSTR(x)
+#  define XSTR(x) #x
+#  define STRING_PARAMS(x)  UStringHash::Hash(STRINGIFY(x))
+#else
+#  define STRING_PARAMS(x)  StringParams::x
+#endif
+
 namespace Strings {
 #ifdef __CUDA_ARCH__
-    #define STRDECL(str,var_name) extern __device__ ustring var_name;
+# if OPTIX_VERSION >= 70000
+#  define STRDECL(str,var_name)
+#else
+#  define STRDECL(str,var_name) extern __device__ ustring var_name;
+#endif
 #else
     // Any strings referenced inside of a libsoslexec/wide/*.cpp
     // or liboslnoise/wide/*.cpp will need OSLEXECPUBLIC

--- a/src/include/OSL/strdecls.h
+++ b/src/include/OSL/strdecls.h
@@ -142,3 +142,5 @@ STRDECL("AdobeRGB", AdobeRGB)
 STRDECL("colorsystem", colorsystem)
 STRDECL("arraylength", arraylength)
 STRDECL("unknown", unknown)
+STRDECL("ERROR: Unknown color space transformation \"%s\" -> \"%s\"\n",
+        ErrorColorTransform)

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -236,9 +236,9 @@ osl_transform_triple (void *sg_, void *Pin, int Pin_derivs,
     Matrix44 M;
     int ok;
     Pin_derivs &= Pout_derivs;   // ignore derivs if output doesn't need it
-    if (HDSTR(from) == StringParams::common)
+    if (HDSTR(from) == STRING_PARAMS(common))
         ok = osl_get_inverse_matrix (sg, &M, (const char *)to);
-    else if (HDSTR(to) == StringParams::common)
+    else if (HDSTR(to) == STRING_PARAMS(common))
         ok = osl_get_matrix (sg, &M, (const char *)from);
     else
         ok = osl_get_from_to_matrix (sg, &M, (const char *)from,

--- a/src/liboslexec/opnoise.cpp
+++ b/src/liboslexec/opnoise.cpp
@@ -676,30 +676,30 @@ struct GenericNoise {
     template<class R, class S> OSL_HOSTDEVICE
     inline void operator() (StringParam name, Dual2<R> &result, const Dual2<S> &s,
                             ShaderGlobals *sg, const NoiseParams *opt) const {
-        if (name == StringParams::uperlin || name == StringParams::noise) {
+        if (name == STRING_PARAMS(uperlin) || name == STRING_PARAMS(noise)) {
             Noise noise;
             noise(result, s);
-        } else if (name == StringParams::perlin || name == StringParams::snoise) {
+        } else if (name == STRING_PARAMS(perlin) || name == STRING_PARAMS(snoise)) {
             SNoise snoise;
             snoise(result, s);
-        } else if (name == StringParams::simplexnoise || name == StringParams::simplex) {
+        } else if (name == STRING_PARAMS(simplexnoise) || name == STRING_PARAMS(simplex)) {
             SimplexNoise simplexnoise;
             simplexnoise(result, s);
-        } else if (name == StringParams::usimplexnoise || name == StringParams::usimplex) {
+        } else if (name == STRING_PARAMS(usimplexnoise) || name == STRING_PARAMS(usimplex)) {
             USimplexNoise usimplexnoise;
             usimplexnoise(result, s);
-        } else if (name == StringParams::cell) {
+        } else if (name == STRING_PARAMS(cell)) {
             CellNoise cellnoise;
             cellnoise(result.val(), s.val());
             result.clear_d();
-        } else if (name == StringParams::gabor) {
+        } else if (name == STRING_PARAMS(gabor)) {
             GaborNoise gnoise;
             gnoise (name, result, s, sg, opt);
-        } else if (name == StringParams::null) {
+        } else if (name == STRING_PARAMS(null)) {
             NullNoise noise; noise(result, s);
-        } else if (name == StringParams::unull) {
+        } else if (name == STRING_PARAMS(unull)) {
             UNullNoise noise; noise(result, s);
-        } else if (name == StringParams::hash) {
+        } else if (name == STRING_PARAMS(hash)) {
             HashNoise hashnoise;
             hashnoise(result.val(), s.val());
             result.clear_d();
@@ -718,30 +718,30 @@ struct GenericNoise {
                             const Dual2<S> &s, const Dual2<T> &t,
                             ShaderGlobals *sg, const NoiseParams *opt) const {
 
-        if (name == StringParams::uperlin || name == StringParams::noise) {
+        if (name == STRING_PARAMS(uperlin) || name == STRING_PARAMS(noise)) {
             Noise noise;
             noise(result, s, t);
-        } else if (name == StringParams::perlin || name == StringParams::snoise) {
+        } else if (name == STRING_PARAMS(perlin) || name == STRING_PARAMS(snoise)) {
             SNoise snoise;
             snoise(result, s, t);
-        } else if (name == StringParams::simplexnoise || name == StringParams::simplex) {
+        } else if (name == STRING_PARAMS(simplexnoise) || name == STRING_PARAMS(simplex)) {
             SimplexNoise simplexnoise;
             simplexnoise(result, s, t);
-        } else if (name == StringParams::usimplexnoise || name == StringParams::usimplex) {
+        } else if (name == STRING_PARAMS(usimplexnoise) || name == STRING_PARAMS(usimplex)) {
             USimplexNoise usimplexnoise;
             usimplexnoise(result, s, t);
-        } else if (name == StringParams::cell) {
+        } else if (name == STRING_PARAMS(cell)) {
             CellNoise cellnoise;
             cellnoise(result.val(), s.val(), t.val());
             result.clear_d();
-        } else if (name == StringParams::gabor) {
+        } else if (name == STRING_PARAMS(gabor)) {
             GaborNoise gnoise;
             gnoise (name, result, s, t, sg, opt);
-        } else if (name == StringParams::null) {
+        } else if (name == STRING_PARAMS(null)) {
             NullNoise noise; noise(result, s, t);
-        } else if (name == StringParams::unull) {
+        } else if (name == STRING_PARAMS(unull)) {
             UNullNoise noise; noise(result, s, t);
-        } else if (name == StringParams::hash) {
+        } else if (name == STRING_PARAMS(hash)) {
             HashNoise hashnoise;
             hashnoise(result.val(), s.val(), t.val());
             result.clear_d();
@@ -771,20 +771,20 @@ struct GenericPNoise {
     inline void operator() (StringParam name, Dual2<R> &result, const Dual2<S> &s,
                             const S &sp,
                             ShaderGlobals *sg, const NoiseParams *opt) const {
-        if (name == StringParams::uperlin || name == StringParams::noise) {
+        if (name == STRING_PARAMS(uperlin) || name == STRING_PARAMS(noise)) {
             PeriodicNoise noise;
             noise(result, s, sp);
-        } else if (name == StringParams::perlin || name == StringParams::snoise) {
+        } else if (name == STRING_PARAMS(perlin) || name == STRING_PARAMS(snoise)) {
             PeriodicSNoise snoise;
             snoise(result, s, sp);
-        } else if (name == StringParams::cell) {
+        } else if (name == STRING_PARAMS(cell)) {
             PeriodicCellNoise cellnoise;
             cellnoise(result.val(), s.val(), sp);
             result.clear_d();
-        } else if (name == StringParams::gabor) {
+        } else if (name == STRING_PARAMS(gabor)) {
             GaborPNoise gnoise;
             gnoise (name, result, s, sp, sg, opt);
-        } else if (name == StringParams::hash) {
+        } else if (name == STRING_PARAMS(hash)) {
             PeriodicHashNoise hashnoise;
             hashnoise(result.val(), s.val(), sp);
             result.clear_d();
@@ -803,20 +803,20 @@ struct GenericPNoise {
                             const Dual2<S> &s, const Dual2<T> &t,
                             const S &sp, const T &tp,
                             ShaderGlobals *sg, const NoiseParams *opt) const {
-        if (name == StringParams::uperlin || name == StringParams::noise) {
+        if (name == STRING_PARAMS(uperlin) || name == STRING_PARAMS(noise)) {
             PeriodicNoise noise;
             noise(result, s, t, sp, tp);
-        } else if (name == StringParams::perlin || name == StringParams::snoise) {
+        } else if (name == STRING_PARAMS(perlin) || name == STRING_PARAMS(snoise)) {
             PeriodicSNoise snoise;
             snoise(result, s, t, sp, tp);
-        } else if (name == StringParams::cell) {
+        } else if (name == STRING_PARAMS(cell)) {
             PeriodicCellNoise cellnoise;
             cellnoise(result.val(), s.val(), t.val(), sp, tp);
             result.clear_d();
-        } else if (name == StringParams::gabor) {
+        } else if (name == STRING_PARAMS(gabor)) {
             GaborPNoise gnoise;
             gnoise (name, result, s, t, sp, tp, sg, opt);
-        } else if (name == StringParams::hash) {
+        } else if (name == STRING_PARAMS(hash)) {
             PeriodicHashNoise hashnoise;
             hashnoise(result.val(), s.val(), t.val(), sp, tp);
             result.clear_d();

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -17,7 +17,14 @@
 
 // Pull in the modified Imath headers and the OSL_HOSTDEVICE macro
 #ifdef __CUDACC__
+#include <optix.h>
 #include <OSL/oslconfig.h>
+#endif
+
+#ifdef __CUDACC__
+#if OPTIX_VERSION >= 70000
+#include "string_hash.h"
+#endif
 #endif
 
 #include <OpenImageIO/ustring.h>
@@ -1233,7 +1240,12 @@ public:
     bool empty_instance () const {
         return (symbols().size() == 0 &&
                 (ops().size() == 0 ||
-                 (ops().size() == 1 && ops()[0].opname() == Strings::end)));
+#if defined(__CUDA_ARCH__) && OPTIX_VERSION >= 70000
+                 (ops().size() == 1 && UStringHash::Hash(ops()[0].opname().c_str()) == STRING_PARAMS(end))
+#else
+                 (ops().size() == 1 && ops()[0].opname() == Strings::end)
+#endif
+                 ));
     }
 
     /// Make our own version of the code and args from the master.
@@ -1972,13 +1984,13 @@ inline int
 tex_interp_to_code (StringParam modename)
 {
     int mode = -1;
-    if (modename == StringParams::smartcubic)
+    if (modename == STRING_PARAMS(smartcubic))
         mode = TextureOpt::InterpSmartBicubic;
-    else if (modename == StringParams::linear)
+    else if (modename == STRING_PARAMS(linear))
         mode = TextureOpt::InterpBilinear;
-    else if (modename == StringParams::cubic)
+    else if (modename == STRING_PARAMS(cubic))
         mode = TextureOpt::InterpBicubic;
-    else if (modename == StringParams::closest)
+    else if (modename == STRING_PARAMS(closest))
         mode = TextureOpt::InterpClosest;
     return mode;
 }

--- a/src/liboslexec/splineimpl.h
+++ b/src/liboslexec/splineimpl.h
@@ -88,15 +88,15 @@ struct SplineInterp {
 
     OSL_HOSTDEVICE static SplineInterp create(StringParam basis_name)
     {
-        if (basis_name == StringParams::catmullrom)
+        if (basis_name == STRING_PARAMS(catmullrom))
             return { gBasisSet[kCatmullRom], false };
-        if (basis_name == StringParams::bezier)
+        if (basis_name == STRING_PARAMS(bezier))
             return { gBasisSet[kBezier], false };
-        if (basis_name == StringParams::bspline)
+        if (basis_name == STRING_PARAMS(bspline))
             return { gBasisSet[kBSpline], false };
-        if (basis_name == StringParams::hermite)
+        if (basis_name == STRING_PARAMS(hermite))
             return { gBasisSet[kHermite], false };
-        if (basis_name == StringParams::constant)
+        if (basis_name == STRING_PARAMS(constant))
             return { gBasisSet[kConstant], true };
 
         // Default to linear

--- a/src/liboslexec/string_hash.h
+++ b/src/liboslexec/string_hash.h
@@ -1,0 +1,32 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+#pragma once
+
+#include <OpenImageIO/oiioversion.h>
+#include <OpenImageIO/detail/farmhash.h>
+
+namespace pvt {
+
+OIIO_CONSTEXPR14 inline size_t pvtstrlen(const char *s) {
+    if (s == nullptr)
+        return 0;
+    size_t  len = 0;
+    while (s[len] != 0)
+        len++;
+    return len;
+}
+
+}
+
+namespace UStringHash {
+OIIO_CONSTEXPR14 inline size_t Hash(const char* s)
+{
+  size_t len = pvt::pvtstrlen(s);
+
+  return len ? OIIO::farmhash::inlined::Hash(s, len)
+             : 0;
+}
+}
+

--- a/src/testrender/cuda/optix_raytracer.cu
+++ b/src/testrender/cuda/optix_raytracer.cu
@@ -110,11 +110,24 @@ extern "C" __global__ void __miss__()
 }
 
 
+extern __device__ char *test_str_1;
+extern __device__ char *test_str_2;
+
+extern "C" __global__ void __raygen__setglobals()
+{
+    // Set global variables
+    OSL::pvt::osl_printf_buffer_start    = render_params.osl_printf_buffer_start;
+    OSL::pvt::osl_printf_buffer_end      = render_params.osl_printf_buffer_end;
+    OSL::pvt::s_color_system             = render_params.color_system;
+    OSL::pvt::test_str_1                 = render_params.test_str_1;
+    OSL::pvt::test_str_2                 = render_params.test_str_2;
+}
+extern "C" __global__ void __miss__setglobals() { }
+
 extern "C" __global__ void __raygen__()
 {
     uint3 launch_dims  = optixGetLaunchDimensions();
     uint3 launch_index = optixGetLaunchIndex();
-
     const float3 eye = render_params.eye;
     const float3 dir = render_params.dir;
     const float3 cx  = render_params.cx ;
@@ -142,11 +155,6 @@ extern "C" __global__ void __raygen__()
                 1,
                 0);
 }
-
-
-extern __device__ char *test_str_1;
-extern __device__ char *test_str_2;
-
 
 // Because clang++ 9.0 seems to have trouble with some of the texturing "intrinsics"
 // let's do the texture look-ups in this file.

--- a/src/testrender/cuda/rend_lib.h
+++ b/src/testrender/cuda/rend_lib.h
@@ -6,6 +6,9 @@
 
 #if (OPTIX_VERSION < 70000)
 #include <optix_math.h>
+#else
+#include <OSL/oslexec.h>
+#include "../../liboslexec/string_hash.h"
 #endif
 #include <OSL/device_string.h>
 
@@ -13,17 +16,32 @@ OSL_NAMESPACE_ENTER
 // Create an OptiX variable for each of the 'standard' strings declared in
 // <OSL/strdecls.h>.
 namespace DeviceStrings {
-#if (OPTIX_VERSION < 70000)
+#if OPTIX_VERSION < 70000
 #define STRDECL(str,var_name)                           \
     rtDeclareVariable(OSL_NAMESPACE::DeviceString, var_name, , );
+#   define STRING_PARAMS(x)  StringParams::x
 #else
-#define STRDECL(str,var_name)                           \
-    extern __device__ OSL_NAMESPACE::DeviceString var_name;
+#   define STRINGIFY(x) XSTR(x)
+#   define XSTR(x) #x
+#   define STRING_PARAMS(x)  UStringHash::Hash(STRINGIFY(x))
+// Don't declare anything
+#   define STRDECL(str,var_name) 
+
 #endif
 
 #include <OSL/strdecls.h>
 #undef STRDECL
 }
+
+#if OPTIX_VERSION >= 70000
+namespace pvt {
+extern __device__ CUdeviceptr s_color_system;
+extern __device__ CUdeviceptr osl_printf_buffer_start;
+extern __device__ CUdeviceptr osl_printf_buffer_end;
+extern __device__ uint64_t test_str_1;
+extern __device__ uint64_t test_str_2;
+}
+#endif
 OSL_NAMESPACE_EXIT
 
 namespace {  // anonymous namespace

--- a/src/testrender/cuda/wrapper.cu
+++ b/src/testrender/cuda/wrapper.cu
@@ -317,7 +317,7 @@ float3 process_closure (const OSL::ClosureColor* closure_tree)
             const char* mem = (const char*)((OSL::ClosureComponent*) cur)->data();
             const char* dist_str = *(const char**) &mem[0];
 
-            if (HDSTR(dist_str) == OSL::DeviceStrings::default_)
+            if (HDSTR(dist_str) == STRING_PARAMS(default))
                 return make_float3(0.0f, 1.0f, 1.0f);
             else
                 return make_float3(1.0f, 0.0f, 1.0f);

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -9,7 +9,9 @@
 #include <OSL/device_string.h>
 #include "optix_compat.h"
 #include "simpleraytracer.h"
+#if OPTIX_VERSION < 70000
 #include "optix_stringtable.h"
+#endif
 #include "render_params.h"
 
 OSL_NAMESPACE_ENTER
@@ -26,10 +28,16 @@ public:
 
     uint64_t register_string (const std::string& str, const std::string& var_name)
     {
-        uint64_t addr = m_str_table.addString (ustring(str), ustring(var_name));
+        ustring ustr = ustring(str);
+#if OPTIX_VERSION < 70000
+        uint64_t addr = m_str_table.addString (ustr, ustring(var_name));
         if (!var_name.empty())
             register_global (var_name, addr);
         return addr;
+#else
+        m_hash_map[ustr.hash()] = ustr.c_str();
+        return 0;
+#endif
     }
 
     uint64_t register_global (const std::string& str, uint64_t value);
@@ -68,11 +76,15 @@ public:
     optix::Context& context()              { return m_optix_ctx; }
     optix::Context& operator -> ()         { return context(); }
 
+#if (OPTIX_VERSION >= 70000)
+    void processPrintfBuffer(void *buffer_data, size_t buffer_size);
+#endif
+
 private:
     optix::Context m_optix_ctx = nullptr;
-    OptiXStringTable m_str_table;
 
 #if (OPTIX_VERSION < 70000)
+    OptiXStringTable m_str_table;
     optix::Program m_program = nullptr;
     optix::Program sphere_intersect = nullptr;
     optix::Program sphere_bounds = nullptr;
@@ -82,12 +94,19 @@ private:
     CUstream                m_cuda_stream;
     OptixTraversableHandle  m_travHandle;
     OptixShaderBindingTable m_optix_sbt = {};
+    OptixShaderBindingTable m_setglobals_optix_sbt = {};
     OptixPipeline           m_optix_pipeline = {};
     CUdeviceptr             d_output_buffer;
     CUdeviceptr             d_launch_params = 0;
     CUdeviceptr             d_quads_list    = 0;
     CUdeviceptr             d_spheres_list  = 0;
     int                     m_xres, m_yres;
+    CUdeviceptr             d_osl_printf_buffer;
+    CUdeviceptr             d_color_system;
+    uint64_t                test_str_1;
+    uint64_t                test_str_2;
+    const unsigned long     OSL_PRINTF_BUFFER_SIZE = 8 * 1024 * 1024;
+    std::unordered_map<uint64_t, const char *> m_hash_map;
 
     bool load_optix_module (const char*                        filename,
                             const OptixModuleCompileOptions*   module_compile_options,

--- a/src/testrender/render_params.h
+++ b/src/testrender/render_params.h
@@ -16,6 +16,12 @@ struct RenderParams
 
     CUdeviceptr traversal_handle;
     CUdeviceptr output_buffer;
+    CUdeviceptr osl_printf_buffer_start;
+    CUdeviceptr osl_printf_buffer_end; 
+    CUdeviceptr color_system;
+    // for used-data tests
+    uint64_t test_str_1;
+    uint64_t test_str_2;
 };
 
 struct PrimitiveParams {

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -115,6 +115,18 @@ extern "C" __global__ void __anyhit__()
     // do nothing
 }
 
+extern "C" __global__ void __raygen__setglobals()
+{
+
+    // Set global variables
+    OSL::pvt::osl_printf_buffer_start    = render_params.osl_printf_buffer_start;
+    OSL::pvt::osl_printf_buffer_end      = render_params.osl_printf_buffer_end;
+    OSL::pvt::s_color_system             = render_params.color_system;
+    OSL::pvt::test_str_1                 = render_params.test_str_1;
+    OSL::pvt::test_str_2                 = render_params.test_str_2;
+}
+extern "C" __global__ void __miss__setglobals() { }
+
 extern "C" __global__ void __raygen__()
 {
     uint3 launch_dims  = optixGetLaunchDimensions();

--- a/src/testshade/render_params.h
+++ b/src/testshade/render_params.h
@@ -7,6 +7,12 @@ struct RenderParams
     float invh;
     CUdeviceptr output_buffer;
     bool flipv;
+    CUdeviceptr osl_printf_buffer_start;
+    CUdeviceptr osl_printf_buffer_end;
+    CUdeviceptr color_system;                                                
+    // for used-data tests
+    uint64_t test_str_1;
+    uint64_t test_str_2;
 };
 #endif
 


### PR DESCRIPTION
## Description

This patch changes how strings are handled in the OptiX 7 codepath.  Strings are now handled as hashes which are computed at compile time.  This means a few things:
   * strings are no longer copied to the GPU
   * we no longer have to create a special CUDA file that contains string pointers (which removes the libnvrtc dependency -- hooray!)
   * strings are now hashed with a `constexpr` hash function which requires c++14.  Because we don't have CUDA programs that depend on runtime values (ie. pointers to GPU memory),  I'm hoping compilation should be smoother overall.
   * `osl_printf()` output is now handled by the CPU.  `osl_printf()` copies shaders' `printf()` output to a GPU buffer.  After rendering, the CPU reads this buffer and handles all the output.  This means that all strings in the GPU code need to be "registered" with the host program.   See `testshade` and `testrender` for the appropriate changes.
   * because we no longer have a run-time compiled CUDA module to store global variables, I've now added extra `optixLaunch()` calls to `testshade` and `testrender` to set global variables via the pipeline launch parameters.

The OptiX 6 codepath should be untouched.

## Tests

Because strings are no longer copied to the CPU, we don't have access to their lengths nor can we reference individual characters.  As such, the `testoptix.optix` test now fails due to differing text output (the images are fine).

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

