### PR TITLE
Output variable placement (draft)

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -619,6 +619,9 @@ public:
     llvm::Constant* constant128(uint64_t i);
     llvm::Constant* constant128(uint64_t left, uint64_t right);
 
+    // Return an llvm::value holding an explicit signed int64_t constant.
+    llvm::Constant* constanti64(int64_t i);
+
     /// Return an llvm::Value holding the given size_t constant.
     llvm::Constant* constant(size_t i);
 
@@ -705,6 +708,11 @@ public:
     /// If ptrtype is NULL, just return a void*.
     llvm::Value *offset_ptr (llvm::Value *ptr, int offset,
                              llvm::Type *ptrtype=NULL);
+
+    /// Generate a pointer that is (ptrtype)((char *)ptr + offset).
+    /// If ptrtype is NULL, just return a void*.
+    llvm::Value *offset_ptr (llvm::Value *ptr, llvm::Value* offset,
+                             llvm::Type *ptrtype=nullptr);
 
     void assume_ptr_is_aligned(llvm::Value *ptr, unsigned alignment);
 

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -98,6 +98,20 @@ using OIIO::span;
 using OIIO::cspan;
 
 
+// N.B. SymArena is not really "configuration", but we cram it here for
+// lack of a better home.
+
+/// The different memory arenas where symbols may live on the app side
+enum class SymArena {
+    Unknown = 0,        // Unknown/uninitialized value
+    Absolute,           // Absolute address
+    Heap,               // Belongs to context heap
+    Outputs             // Belongs to output arena
+    // ShaderGlobals,   // RESERVED
+    // UserData,        // RESERVED
+};
+
+
 
 /////////////////////////////////////////////////////////////////////////
 // Define various macros and templates that need to be different for

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -97,7 +97,7 @@ Symbol::valuesourcename() const
 std::ostream&
 Symbol::print_vals(std::ostream& out, int maxvals) const
 {
-    if (!data())
+    if (!data() /* TODO: arena() != SymArena::Absolute */)
         return out;
     TypeDesc t = typespec().simpletype();
     int n      = std::min(int(t.aggregate * t.numelements()), maxvals);

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -118,19 +118,19 @@ public:
         : Symbol(n, TypeDesc::TypeString, SymTypeConst)
     {
         m_val.s = val.c_str();
-        m_data  = &m_val.s;
+        set_dataptr(SymArena::Absolute, &m_val.s);
     }
     ConstantSymbol(ustring n, int val)
         : Symbol(n, TypeDesc::TypeInt, SymTypeConst)
     {
         m_val.i = val;
-        m_data  = &m_val.i;
+        set_dataptr(SymArena::Absolute, &m_val.i);
     }
     ConstantSymbol(ustring n, float val)
         : Symbol(n, TypeDesc::TypeFloat, SymTypeConst)
     {
         m_val.f = val;
-        m_data  = &m_val.f;
+        set_dataptr(SymArena::Absolute, &m_val.f);
     }
     ConstantSymbol(ustring n, TypeDesc type, float x, float y, float z)
         : Symbol(n, type, SymTypeConst)
@@ -138,21 +138,21 @@ public:
         m_val.v[0] = x;
         m_val.v[1] = y;
         m_val.v[2] = z;
-        m_data     = &m_val.v;
+        set_dataptr(SymArena::Absolute, &m_val.v);
     }
     ConstantSymbol(ustring n, TypeDesc type) : Symbol(n, type, SymTypeConst)
     {
         if (type == TypeDesc::FLOAT)
-            m_data = &m_val.f;
+            set_dataptr(SymArena::Absolute, &m_val.f);
         else if (type == TypeDesc::INT)
-            m_data = &m_val.i;
+            set_dataptr(SymArena::Absolute, &m_val.i);
         else if (type == TypeDesc::STRING)
-            m_data = &m_val.s;
+            set_dataptr(SymArena::Absolute, &m_val.s);
         else if (equivalent(type, TypeDesc::TypeVector))
-            m_data = &m_val.v;
+            set_dataptr(SymArena::Absolute, &m_val.v);
         else {
-            OSL_DASSERT(m_data == nullptr);
-            m_data      = new char[type.size()];
+            OSL_DASSERT(arena() == SymArena::Unknown);
+            set_dataptr(SymArena::Absolute, new char[type.size()]);
             m_free_data = true;
         }
     }

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -298,6 +298,12 @@ public:
     llvm::Value *groupdata_field_ptr (int fieldnum,
                                       TypeDesc type = TypeDesc::UNKNOWN);
 
+    /// Return the output base pointer.
+    llvm::Value *output_base_ptr () const { return m_llvm_output_base_ptr; }
+
+    /// Return the shade index
+    llvm::Value *shadeindex () const { return m_llvm_shadeindex; }
+
     /// Return a ref to the bool where the "layer_run" flag is stored for
     /// the specified layer.
     llvm::Value *layer_run_ref (int layer);
@@ -445,6 +451,8 @@ private:
     std::map<const Symbol*,int> m_param_order_map;
     llvm::Value *m_llvm_shaderglobals_ptr;
     llvm::Value *m_llvm_groupdata_ptr;
+    llvm::Value *m_llvm_output_base_ptr;
+    llvm::Value *m_llvm_shadeindex;
     llvm::BasicBlock * m_exit_instance_block;  // exit point for the instance
     llvm::Type *m_llvm_type_sg;  // LLVM type of ShaderGlobals struct
     llvm::Type *m_llvm_type_groupdata;  // LLVM type of group data

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -484,7 +484,7 @@ ShaderInstance::copy_code_from_master (ShaderGroup &group)
                 si->connected_down (m_instoverrides[i].connected_down());
                 si->lockgeom (m_instoverrides[i].lockgeom());
                 si->dataoffset (m_instoverrides[i].dataoffset());
-                si->data (param_storage(i));
+                si->set_dataptr(SymArena::Absolute, param_storage(i));
             }
             if (shadingsys().is_renderer_output (layername(), si->name(), &group)) {
                 si->renderer_output (true);

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -131,21 +131,21 @@ ShaderMaster::resolve_syms ()
             m_lastparam = i+1;
             if (s.dataoffset() >= 0) {
                 if (s.typespec().simpletype().basetype == TypeDesc::INT)
-                    s.data (&(m_idefaults[s.dataoffset()]));
+                    s.set_dataptr(SymArena::Absolute, &(m_idefaults[s.dataoffset()]));
                 else if (s.typespec().simpletype().basetype == TypeDesc::FLOAT)
-                    s.data (&(m_fdefaults[s.dataoffset()]));
+                    s.set_dataptr(SymArena::Absolute, &(m_fdefaults[s.dataoffset()]));
                 else if (s.typespec().simpletype().basetype == TypeDesc::STRING)
-                    s.data (&(m_sdefaults[s.dataoffset()]));
+                    s.set_dataptr(SymArena::Absolute, &(m_sdefaults[s.dataoffset()]));
             }
         }
         if (s.symtype() == SymTypeConst) {
             if (s.dataoffset() >= 0) {
                 if (s.typespec().simpletype().basetype == TypeDesc::INT)
-                    s.data (&(m_iconsts[s.dataoffset()]));
+                    s.set_dataptr(SymArena::Absolute, &(m_iconsts[s.dataoffset()]));
                 else if (s.typespec().simpletype().basetype == TypeDesc::FLOAT)
-                    s.data (&(m_fconsts[s.dataoffset()]));
+                    s.set_dataptr(SymArena::Absolute, &(m_fconsts[s.dataoffset()]));
                 else if (s.typespec().simpletype().basetype == TypeDesc::STRING)
-                    s.data (&(m_sconsts[s.dataoffset()]));
+                    s.set_dataptr(SymArena::Absolute, &(m_sconsts[s.dataoffset()]));
             }
         }
         ++i;

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -274,7 +274,7 @@ RuntimeOptimizer::add_constant (const TypeSpec &type, const void *data,
         } else {
             OSL_ASSERT (0 && "unsupported type for add_constant");
         }
-        newconst.data (newdata);
+        newconst.set_dataptr(SymArena::Absolute, newdata);
         ind = add_symbol (newconst);
         m_all_consts.push_back (ind);
     }
@@ -1353,7 +1353,7 @@ RuntimeOptimizer::make_param_use_instanceval (Symbol *R, string_view why)
     else if (Rtype.basetype == TypeDesc::STRING)
         Rdefault = &inst()->m_sparams[R->dataoffset()];
     OSL_DASSERT(Rdefault != NULL);
-    R->data (Rdefault);
+    R->set_dataptr(SymArena::Absolute, Rdefault);
 
     // Get rid of any init ops
     if (R->has_init_ops()) {

--- a/src/testrender/cuda/wrapper.cu
+++ b/src/testrender/cuda/wrapper.cu
@@ -43,8 +43,8 @@ rtDeclareVariable (float,      t_hit,        rtIntersectionDistance, );
 rtBuffer<float3,2> output_buffer;
 
 // Function pointers for the OSL shader
-rtDeclareVariable (rtCallableProgramId<void (void*, void*)>, osl_init_func, , );
-rtDeclareVariable (rtCallableProgramId<void (void*, void*)>, osl_group_func, ,);
+rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, int)>, osl_init_func, , );
+rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, int)>, osl_group_func, ,);
 
 RT_PROGRAM void any_hit_shadow()
 {
@@ -373,8 +373,8 @@ extern "C" __global__  void __closesthit__closest_hit_osl()
     // Run the OSL group and init functions
     const unsigned int shaderInitOpIdx = 2u + 2u * sg.shaderID + 0u;
     const unsigned int shaderGroupIdx  = 2u + 2u * sg.shaderID + 1u;
-    optixDirectCall<void, ShaderGlobals*, void *>(shaderInitOpIdx, &sg, params); // call osl_init_func
-    optixDirectCall<void, ShaderGlobals*, void *>(shaderGroupIdx , &sg, params); // call osl_group_func
+    optixDirectCall<void, ShaderGlobals*, void *, void*, int>(shaderInitOpIdx, &sg, params, nullptr, 0); // call osl_init_func
+    optixDirectCall<void, ShaderGlobals*, void *, void*, int>(shaderGroupIdx , &sg, params, nullptr, 0); // call osl_group_func
 
     float3 result = process_closure ((OSL::ClosureColor*) sg.Ci);
     uint3 launch_dims  = optixGetLaunchDimensions();

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -30,8 +30,8 @@ rtDeclareVariable (int,   flipv, , );
 // Buffers
 rtBuffer<float3,2> output_buffer;
 
-rtDeclareVariable (rtCallableProgramId<void (void*, void*)>, osl_init_func, , );
-rtDeclareVariable (rtCallableProgramId<void (void*, void*)>, osl_group_func, ,);
+rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, int)>, osl_init_func, , );
+rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, int)>, osl_group_func, ,);
 
 RT_PROGRAM void raygen()
 {
@@ -188,8 +188,8 @@ extern "C" __global__ void __raygen__()
     sg.renderstate = &closure_pool[0];
 
     // Run the OSL group and init functions
-    optixDirectCall<void, ShaderGlobals*, void *>(0u, &sg, params); // call osl_init_func
-    optixDirectCall<void, ShaderGlobals*, void *>(1u, &sg, params); // call osl_group_func
+    optixDirectCall<void, ShaderGlobals*, void *, void*, int>(0u, &sg, params, nullptr, 0); // call osl_init_func
+    optixDirectCall<void, ShaderGlobals*, void *, void*, int>(1u, &sg, params, nullptr, 0); // call osl_group_func
 
     float* f_output = (float*)params;
     int pixel = launch_index.y * launch_dims.x + launch_index.x;

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -1126,11 +1126,15 @@ OptixGridRenderer::finalize_pixel_buffer ()
     const void* buffer_ptr = m_optix_ctx[buffer_name]->getBuffer()->map();
     if (! buffer_ptr)
         errhandler().severe ("Unable to map buffer %s", buffer_name);
-    outputbuf(0)->set_pixels (OIIO::ROI::All(), OIIO::TypeFloat, buffer_ptr);
+    OIIO::ImageBuf* buf = outputbuf(0);
+    if (buf)
+        buf->set_pixels (OIIO::ROI::All(), OIIO::TypeFloat, buffer_ptr);
 #else
     std::vector<float> tmp_buff(m_xres * m_yres * 3);
     CUDA_CHECK (cudaMemcpy (tmp_buff.data(), reinterpret_cast<void *>(d_output_buffer), m_xres * m_yres * 3 * sizeof(float), cudaMemcpyDeviceToHost));
-    outputbuf(0)->set_pixels (OIIO::ROI::All(), OIIO::TypeFloat, tmp_buff.data());
+    OIIO::ImageBuf* buf = outputbuf(0);
+    if (buf)
+        buf->set_pixels (OIIO::ROI::All(), OIIO::TypeFloat, tmp_buff.data());
 #endif
 #endif
 }

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -604,8 +604,9 @@ SimpleRenderer::add_output (string_view varname, string_view filename,
     // FIXME: use name to figure out
     OIIO::ImageSpec spec(m_xres, m_yres, nchannels, datatype);
     m_outputvars.emplace_back(varname);
-    m_outputbufs.emplace_back(new OIIO::ImageBuf(filename, spec));
-    OIIO::ImageBufAlgo::zero (*m_outputbufs.back());
+    m_outputbufs.emplace_back(new OIIO::ImageBuf(filename, spec,
+                                                 OIIO::InitializePixels::Yes));
+    // OIIO::ImageBufAlgo::zero (*m_outputbufs.back());
     return true;
 }
 

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -91,8 +91,16 @@ public:
                              TypeDesc datatype = OIIO::TypeFloat,
                              int nchannels = 3);
 
+    // Get the output ImageBuf by index
     OIIO::ImageBuf* outputbuf (int index) {
         return index < (int)m_outputbufs.size() ? m_outputbufs[index].get() : nullptr;
+    }
+    // Get the output ImageBuf by name
+    OIIO::ImageBuf* outputbuf (string_view name) {
+        for (size_t i = 0; i < m_outputbufs.size(); ++i)
+            if (m_outputvars[i] == name)
+                return m_outputbufs[i].get();
+        return nullptr;
     }
     ustring outputname (int index) const { return m_outputvars[index]; }
     size_t noutputs () const { return m_outputbufs.size(); }

--- a/testsuite/example-deformer/ref/out.txt
+++ b/testsuite/example-deformer/ref/out.txt
@@ -1,83 +1,23 @@
 Compiled getP.osl -> getP.oso
 Compiled vadd.osl -> vadd.oso
 Compiled vfBm3d.osl -> vfBm3d.oso
-i = 0
-Undeformed P = (0 0 0)  amplitude = 0
-Deformed (0 0 0)  -->  (0 0 0)
-
-i = 1
-Undeformed P = (0.1 0 0)  amplitude = 0.000125
-Deformed (0.1 0 0)  -->  (0.0999991 -9.45666e-07 -1.12243e-05)
-
-i = 2
-Undeformed P = (0.2 0 0)  amplitude = 0.001
-Deformed (0.2 0 0)  -->  (0.199954 -4.5502e-05 -0.000139523)
-
-i = 3
-Undeformed P = (0.3 0 0)  amplitude = 0.003375
-Deformed (0.3 0 0)  -->  (0.299622 -0.000378342 -0.000453787)
-
-i = 4
-Undeformed P = (0.4 0 0)  amplitude = 0.008
-Deformed (0.4 0 0)  -->  (0.398504 -0.00149629 -0.000648592)
-
-i = 5
-Undeformed P = (0.5 0 0)  amplitude = 0.015625
-Deformed (0.5 0 0)  -->  (0.496164 -0.00383594 0)
-
-i = 6
-Undeformed P = (0.6 0 0)  amplitude = 0.027
-Deformed (0.6 0 0)  -->  (0.592761 -0.00723896 0.002189)
-
-i = 7
-Undeformed P = (0.7 0 0)  amplitude = 0.042875
-Deformed (0.7 0 0)  -->  (0.689429 -0.0105711 0.00576478)
-
-i = 8
-Undeformed P = (0.8 0 0)  amplitude = 0.064
-Deformed (0.8 0 0)  -->  (0.788158 -0.0118416 0.00892945)
-
-i = 9
-Undeformed P = (0.9 0 0)  amplitude = 0.091125
-Deformed (0.9 0 0)  -->  (0.891128 -0.00887187 0.00818247)
-
-i = 10
-Undeformed P = (1 0 0)  amplitude = 0.125
-Deformed (1 0 0)  -->  (1 0 0)
-
-i = 11
-Undeformed P = (1.1 0 0)  amplitude = 0.166375
-Deformed (1.1 0 0)  -->  (1.11746 0.0149395 -0.0174569)
-
-i = 12
-Undeformed P = (1.2 0 0)  amplitude = 0.216
-Deformed (1.2 0 0)  -->  (1.24979 0.0301369 -0.0497937)
-
-i = 13
-Undeformed P = (1.3 0 0)  amplitude = 0.274625
-Deformed (1.3 0 0)  -->  (1.3985 0.0369248 -0.0984964)
-
-i = 14
-Undeformed P = (1.4 0 0)  amplitude = 0.343
-Deformed (1.4 0 0)  -->  (1.55611 0.0278084 -0.156115)
-
-i = 15
-Undeformed P = (1.5 0 0)  amplitude = 0.421875
-Deformed (1.5 0 0)  -->  (1.70714 0 -0.207141)
-
-i = 16
-Undeformed P = (1.6 0 0)  amplitude = 0.512
-Deformed (1.6 0 0)  -->  (1.83303 -0.0415099 -0.233034)
-
-i = 17
-Undeformed P = (1.7 0 0)  amplitude = 0.614125
-Deformed (1.7 0 0)  -->  (1.92026 -0.0825725 -0.220261)
-
-i = 18
-Undeformed P = (1.8 0 0)  amplitude = 0.729
-Deformed (1.8 0 0)  -->  (1.96805 -0.101712 -0.168054)
-
-i = 19
-Undeformed P = (1.9 0 0)  amplitude = 0.857375
-Deformed (1.9 0 0)  -->  (1.98996 -0.0769869 -0.0899601)
-
+ 0: Undeformed P = (0 0 0)  -->  Deformed (0 0 0)
+ 1: Undeformed P = (0.1 0 0)  -->  Deformed (0.0999991 -9.45666e-07 -1.12243e-05)
+ 2: Undeformed P = (0.2 0 0)  -->  Deformed (0.199954 -4.5502e-05 -0.000139523)
+ 3: Undeformed P = (0.3 0 0)  -->  Deformed (0.299622 -0.000378342 -0.000453787)
+ 4: Undeformed P = (0.4 0 0)  -->  Deformed (0.398504 -0.00149629 -0.000648592)
+ 5: Undeformed P = (0.5 0 0)  -->  Deformed (0.496164 -0.00383594 0)
+ 6: Undeformed P = (0.6 0 0)  -->  Deformed (0.592761 -0.00723896 0.002189)
+ 7: Undeformed P = (0.7 0 0)  -->  Deformed (0.689429 -0.0105711 0.00576478)
+ 8: Undeformed P = (0.8 0 0)  -->  Deformed (0.788158 -0.0118416 0.00892945)
+ 9: Undeformed P = (0.9 0 0)  -->  Deformed (0.891128 -0.00887187 0.00818247)
+10: Undeformed P = (1 0 0)  -->  Deformed (1 0 0)
+11: Undeformed P = (1.1 0 0)  -->  Deformed (1.11746 0.0149395 -0.0174569)
+12: Undeformed P = (1.2 0 0)  -->  Deformed (1.24979 0.0301369 -0.0497937)
+13: Undeformed P = (1.3 0 0)  -->  Deformed (1.3985 0.0369248 -0.0984964)
+14: Undeformed P = (1.4 0 0)  -->  Deformed (1.55611 0.0278084 -0.156115)
+15: Undeformed P = (1.5 0 0)  -->  Deformed (1.70714 0 -0.207141)
+16: Undeformed P = (1.6 0 0)  -->  Deformed (1.83303 -0.0415099 -0.233034)
+17: Undeformed P = (1.7 0 0)  -->  Deformed (1.92026 -0.0825725 -0.220261)
+18: Undeformed P = (1.8 0 0)  -->  Deformed (1.96805 -0.101712 -0.168054)
+19: Undeformed P = (1.9 0 0)  -->  Deformed (1.98996 -0.0769869 -0.0899601)

--- a/testsuite/group-outputs/ref/out.txt
+++ b/testsuite/group-outputs/ref/out.txt
@@ -1,6 +1,5 @@
 Compiled test.osl -> test.oso
 
-Marking group outputs, not global renderer outputs.
 Output a to a.exr
 Output b to b.exr
 Output c to c.exr

--- a/testsuite/layers-entry/ref/out.txt
+++ b/testsuite/layers-entry/ref/out.txt
@@ -5,7 +5,6 @@ Connect B.out to E.in
 Connect E.out to F.in
 Connect E.out to G.in
 
-Marking group outputs, not global renderer outputs.
 Output D.out to out.exr
 (node G) enter layer 6 G node
 (node A) enter layer 0 A node
@@ -33,7 +32,6 @@ Connect B.out to E.in
 Connect E.out to F.in
 Connect E.out to G.in
 
-Marking group outputs, not global renderer outputs.
 Entry layers: B(1) F(5) E(4)
 Output D.out to out.exr
 (node B) checking for already-run layer 1 B node
@@ -59,10 +57,9 @@ Connect B.out to E.in
 Connect E.out to F.in
 Connect E.out to G.in
 
-Marking group outputs, not global renderer outputs.
 Entry layers: B(1) F(5) E(4)
-Entry outputs: E.out
 Output D.out to out.exr
+Entry outputs: E.out
 (node E) checking for already-run layer 4 E node
 (node E) enter layer 4 E node
 Running layer E:


### PR DESCRIPTION
Up until now, client apps declare which output variables are "renderer
outputs" before shader groups are compiled, and also after a shader is
executed, it is up to the app to extract the individual output values
and do with them what it needs to do. Those outputs live on the shader
heap (the temp storage used to run the shader), and information about
where it lives on the heap can be retrieved via find_symbol() and
symbol_address().

New paradigm:

Various inputs and outputs of shaders live in different memory arenas,
and for those inputs/outputs, the app declares (prior to shader group
compilation) which arena it lives in, its offset within the arena, and
the stride between entries (for different shades, such as different
rays in flight, different points on a mesh, pixels in an image, etc.).
The shader JITs into code that automatically pull inputs from their
sources and copy outputs to their destinations with no need for client
app code to call find_symbol or symbol_address or do any extra data
copies.

This symbol location data is communicated to the shading system through
new calls to add_symlocs() passing a new struct called a SymLocationDesc,
which has the aformentioned arena, offset, stride, etc.

Right now, the only supported arena is Outputs, and the actual call
signature to execute(), and to the shader JIT code itself, includes
extra parameters for the base pointer to the output arena (this could
conceivably change from shade to shade) and the integer shade index of
this shade.

I've tried to set this up in a general way, so that additional arenas
will be added later -- places where ShaderGlobals can be customized,
UserData, etc. Also there are placeholders for being able to talk about
absolute addreses and offsets into the heap, though I don't use them
at the moment. Some of the flexibility may be later removed as we learn
more about how we want to use this.

To show it in action, I have modified the "osldeformer" example to use
this new method to place the outputs directly where we want them.
It's just storing results into an array. The output arena base pointer
is the start of the array, the offset of the single output is 0, and
the stride is the size of each array element (one 3-float point).

As a much more complex example, testshade also uses the new technique
(unless you use --no-output-placement, but I'm not sure how long I'll
keep that). This is a good example of storing to images. Testshade thinks
of itself as shading pixels in an image, so there is an ImageBuf for every
renderer output (think of it like an AOV). The output arena base pointer
is the address of the (0,0) pixel of the ImageBuf for the first AOV; the
"offset" of each output variable is the address difference between that
AOV's first ImageBuf pixel and the arena base pointer, the stride is the
pixel data size for each output, and the shadeindex is the pixel index of
that shade.

It all works. Crazy!

OK, not quite all. Here's what hasn't been done yet:

  * testrender does not yet use the new API (only testshade)
  * GPU (have only tried CPU so far)
  * Batch shading -- I don't want to mess with this while Alex is
    still integrating all his work. We'll go back and catch the batch
    shading up after he's all done.

I will probably tackle some of these by amending this PR, though some may
wait for a separate one if it looks hairy. Also, there is admittedly some
cruft and scaffolding and leftovers from early ideas that didn't pan out,
that I will clean up over time.

All the old calls should still work, so this ought not to be a source
compatibility break for renderers using OSL. Not at this point, anyway.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

