### PR TITLE
PR/BatchedBackend

### DIFF
--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -22,6 +22,8 @@ set (lib_src
           llvm_gen.cpp llvm_instance.cpp llvm_util.cpp
           batched_analysis.cpp
           batched_backendllvm.cpp
+          batched_llvm_gen.cpp
+          batched_llvm_instance.cpp
           ../liboslnoise/gabornoise.cpp
           ../liboslnoise/simplexnoise.cpp
     )

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -2,8 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
-#include "oslexec_pvt.h"
 #include <type_traits>
+
+#include "batched_backendllvm.h"
+#include "oslexec_pvt.h"
+
+#include <llvm/ADT/Twine.h>
+#include <llvm/IR/Constant.h>
+#include <llvm/IR/Type.h>
+#include <llvm/Support/raw_os_ostream.h>
 
 using namespace OSL;
 using namespace OSL::pvt;
@@ -110,8 +117,1843 @@ is_shader_global_uniform_by_name(ustring name)
     return false;
 }
 
-// Implementation for BatchedBackendLLVM will be added here in future PR.
-// That implementation will make use of IsShaderGlobalUniformByName
+BatchedBackendLLVM::BatchedBackendLLVM(ShadingSystemImpl& shadingsys,
+                                       ShaderGroup& group, ShadingContext* ctx,
+                                       int width)
+    : OSOProcessorBase(shadingsys, group, ctx)
+    , ll(ctx->llvm_thread_info(), llvm_debug(), width)
+    , m_width(width)
+    , m_library_selector(nullptr)
+    , m_stat_total_llvm_time(0)
+    , m_stat_llvm_setup_time(0)
+    , m_stat_llvm_irgen_time(0)
+    , m_stat_llvm_opt_time(0)
+    , m_stat_llvm_jit_time(0)
+{
+    m_wide_arg_prefix = "W";
+    switch (vector_width()) {
+    case 16: m_true_mask_value = Mask<16>(true).value(); break;
+    case 8: m_true_mask_value = Mask<8>(true).value(); break;
+    default: OSL_ASSERT(0 && "unsupported vector width");
+    }
+}
+
+
+
+BatchedBackendLLVM::~BatchedBackendLLVM() {}
+
+
+
+int
+BatchedBackendLLVM::llvm_debug() const
+{
+    if (shadingsys().llvm_debug() == 0)
+        return 0;
+    if (!shadingsys().debug_groupname().empty()
+        && shadingsys().debug_groupname() != group().name()) {
+        return 0;
+    }
+    if (inst() && !shadingsys().debug_layername().empty()
+        && shadingsys().debug_layername() != inst()->layername())
+        return 0;
+    return shadingsys().llvm_debug();
+}
+
+
+void
+BatchedBackendLLVM::set_inst(int layer)
+{
+    OSOProcessorBase::set_inst(layer);  // parent does the heavy lifting
+    ll.debug(llvm_debug());
+}
+
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_pass_type(const TypeSpec& typespec)
+{
+    if (typespec.is_closure_based())
+        return (llvm::Type*)ll.type_void_ptr();
+    TypeDesc t     = typespec.simpletype().elementtype();
+    llvm::Type* lt = NULL;
+    if (t == TypeDesc::FLOAT)
+        lt = ll.type_float();
+    else if (t == TypeDesc::INT)
+        lt = ll.type_int();
+    else if (t == TypeDesc::STRING)
+        lt = (llvm::Type*)ll.type_string();
+    else if (t.aggregate == TypeDesc::VEC3)
+        lt = (llvm::Type*)ll.type_void_ptr();  //llvm_type_triple_ptr();
+    else if (t.aggregate == TypeDesc::MATRIX44)
+        lt = (llvm::Type*)ll.type_void_ptr();  //llvm_type_matrix_ptr();
+    else if (t == TypeDesc::NONE)
+        lt = ll.type_void();
+    else if (t == TypeDesc::PTR)
+        lt = (llvm::Type*)ll.type_void_ptr();
+    else if (t == TypeDesc::LONGLONG)
+        lt = ll.type_longlong();
+    else {
+        std::cerr << "Bad llvm_pass_type(" << typespec.c_str() << ")\n";
+        OSL_ASSERT(0 && "not handling this type yet");
+    }
+    if (t.arraylen) {
+        OSL_ASSERT(0 && "should never pass an array directly as a parameter");
+    }
+    return lt;
+}
+
+llvm::Type*
+BatchedBackendLLVM::llvm_pass_wide_type(const TypeSpec& typespec)
+{
+    if (typespec.is_closure_based())
+        return (llvm::Type*)ll.type_void_ptr();
+    TypeDesc t     = typespec.simpletype().elementtype();
+    llvm::Type* lt = NULL;
+    if (t == TypeDesc::FLOAT)
+        lt = (llvm::Type*)ll.type_void_ptr();  // ll.type_wide_float();
+    else if (t == TypeDesc::INT)
+        lt = (llvm::Type*)ll.type_void_ptr();  // ll.type_wide_int();
+    else if (t == TypeDesc::STRING)
+        lt = (llvm::Type*)
+                 ll.type_void_ptr();  // (llvm::Type *) ll.type_wide_ string();
+    else if (t.aggregate == TypeDesc::VEC3)
+        lt = (llvm::Type*)ll.type_void_ptr();  //llvm_type_wide_triple_ptr();
+    else if (t.aggregate == TypeDesc::MATRIX44)
+        lt = (llvm::Type*)ll.type_void_ptr();  //llvm_type_wide_matrix_ptr();
+    else if (t == TypeDesc::NONE)
+        lt = ll.type_void();
+    else if (t == TypeDesc::PTR)
+        lt = (llvm::Type*)ll.type_void_ptr();
+    else if (t == TypeDesc::LONGLONG)
+        lt = (llvm::Type*)ll.type_void_ptr();  // ll.type_wide_longlong();
+    else {
+        std::cerr << "Bad llvm_pass_type(" << typespec.c_str() << ")\n";
+        OSL_ASSERT(0 && "not handling this type yet");
+    }
+    if (t.arraylen) {
+        OSL_ASSERT(0 && "should never pass an array directly as a parameter");
+    }
+    return lt;
+}
+
+
+
+void
+BatchedBackendLLVM::llvm_assign_zero(const Symbol& sym)
+{
+    llvm::Value* zero;
+
+    const TypeSpec& t = sym.typespec();
+    TypeSpec elemtype = t.elementtype();
+    if (elemtype.is_float_based()) {
+        if (sym.is_uniform())
+            zero = ll.constant(0.0f);
+        else
+            zero = ll.wide_constant(0.0f);
+    } else if (elemtype.is_int_based()) {
+        if (sym.is_uniform())
+            zero = ll.constant(0);
+        else
+            zero = ll.wide_constant(0);
+    } else if (elemtype.is_string_based()) {
+        if (sym.is_uniform())
+            zero = ll.constant(ustring());
+        else
+            zero = ll.wide_constant(ustring());
+    } else {
+        OSL_ASSERT(0 && "Unsupported element type");
+        zero = nullptr;
+    }
+
+    int num_elements = t.numelements();
+    for (int a = 0; a < num_elements; ++a) {
+        int numDeriv = sym.has_derivs() ? 3 : 1;
+        for (int d = 0; d < numDeriv; ++d) {
+            llvm::Value* arrind = t.simpletype().arraylen ? ll.constant(a)
+                                                          : NULL;
+            for (int c = 0; c < t.aggregate(); ++c) {
+                llvm_store_value(zero, sym, d, arrind, c);
+            }
+        }
+    }
+}
+
+
+
+void
+BatchedBackendLLVM::llvm_zero_derivs(const Symbol& sym)
+{
+    const TypeSpec& t = sym.typespec();
+
+    if (t.is_closure_based())
+        return;  // Closures don't have derivs
+
+    TypeSpec elemtype = t.elementtype();
+    if (sym.has_derivs() && elemtype.is_float_based()) {
+        llvm::Value* zero;
+        if (sym.is_uniform())
+            zero = ll.constant(0.0f);
+        else
+            zero = ll.wide_constant(0.0f);
+
+        int start_array_index = -1;
+        int end_array_index   = start_array_index + 1;
+        if (t.is_array()) {
+            // TODO: investigate doing a memset for arrays & matrices,
+            // but not for simple aggregates
+            start_array_index = 0;
+            end_array_index   = t.arraylength();
+        }
+
+        for (int arrayindex = start_array_index; arrayindex < end_array_index;
+             ++arrayindex) {
+            llvm::Value* arrind = arrayindex >= 0 ? ll.constant(arrayindex)
+                                                  : NULL;
+
+            for (int c = 0; c < t.aggregate(); ++c)
+                llvm_store_value(zero, sym, 1, arrind, c);
+            for (int c = 0; c < t.aggregate(); ++c)
+                llvm_store_value(zero, sym, 2, arrind, c);
+        }
+    }
+}
+
+
+
+void
+BatchedBackendLLVM::llvm_zero_derivs(const Symbol& sym, llvm::Value* count)
+{
+    if (sym.typespec().is_closure_based())
+        return;  // Closures don't have derivs
+    // Same thing as the above version but with just the first count derivs
+    TypeSpec elemtype = sym.typespec().elementtype();
+    if (sym.has_derivs() && elemtype.is_float_based()) {
+        OSL_ASSERT(
+            sym.is_uniform());  // TODO: handle varying case and remove OSL_ASSERT
+        size_t esize = sym.typespec().simpletype().elementsize();
+        size_t align = sym.typespec().simpletype().basesize();
+        count        = ll.op_mul(count, ll.constant((int)esize));
+        ll.op_memset(llvm_void_ptr(sym, 1), 0, count, (int)align);  // X derivs
+        ll.op_memset(llvm_void_ptr(sym, 2), 0, count, (int)align);  // Y derivs
+    }
+}
+
+int
+BatchedBackendLLVM::ShaderGlobalNameToIndex(ustring name, bool& is_uniform)
+{
+    for (int i = 0; i < int(sizeof(fields) / sizeof(fields[0])); ++i)
+        if (name == fields[i]) {
+            is_uniform = field_is_uniform[i];
+            return i;
+        }
+    OSL_DEV_ONLY(std::cout << "ShaderGlobalNameToIndex failed with " << name
+                           << std::endl);
+    return -1;
+}
+
+llvm::Value*
+BatchedBackendLLVM::llvm_global_symbol_ptr(ustring name, bool& is_uniform)
+{
+    // Special case for globals -- they live in the ShaderGlobals struct,
+    // we use the name of the global to find the index of the field within
+    // the ShaderGlobals struct.
+    int sg_index = ShaderGlobalNameToIndex(name, is_uniform);
+    OSL_ASSERT(sg_index >= 0);
+    return ll.void_ptr(ll.GEP(sg_ptr(), 0, sg_index));
+}
+
+llvm::Value*
+BatchedBackendLLVM::getLLVMSymbolBase(const Symbol& sym)
+{
+    Symbol* dealiased = sym.dealias();
+
+    bool is_uniform = sym.is_uniform();
+
+    if (sym.symtype() == SymTypeGlobal) {
+        llvm::Value* result = llvm_global_symbol_ptr(sym.name(), is_uniform);
+        OSL_ASSERT(result);
+        if (is_uniform) {
+            result = ll.ptr_to_cast(result,
+                                    llvm_type(sym.typespec().elementtype()));
+        } else {
+            result = ll.ptr_to_cast(result, llvm_wide_type(
+                                                sym.typespec().elementtype()));
+        }
+        return result;
+    }
+
+    if (sym.symtype() == SymTypeParam || sym.symtype() == SymTypeOutputParam) {
+        // Special case for params -- they live in the group data
+        int fieldnum = m_param_order_map[&sym];
+        return groupdata_field_ptr(fieldnum,
+                                   sym.typespec().elementtype().simpletype(),
+                                   is_uniform);
+    }
+
+    std::string mangled_name         = dealiased->mangled();
+    AllocationMap::iterator map_iter = named_values().find(mangled_name);
+    if (map_iter == named_values().end()) {
+        shadingcontext()->errorf(
+            "Couldn't find symbol '%s' (unmangled = '%s'). Did you forget to allocate it?",
+            mangled_name.c_str(), dealiased->name().c_str());
+        return 0;
+    }
+    return (llvm::Value*)map_iter->second;
+}
+
+llvm::Value*
+BatchedBackendLLVM::llvm_alloca(const TypeSpec& type, bool derivs,
+                                bool is_uniform, bool forceBool,
+                                const std::string& name)
+{
+    OSL_DEV_ONLY(std::cout << "llvm_alloca " << name);
+    TypeDesc t = llvm_typedesc(type);
+    int n      = derivs ? 3 : 1;
+    OSL_DEV_ONLY(std::cout << " n=" << n << " t.size()=" << t.size());
+    m_llvm_local_mem += t.size() * n;
+    if (is_uniform) {
+        OSL_DEV_ONLY(std::cout << " as UNIFORM " << std::endl);
+        if (forceBool) {
+            return ll.op_alloca(ll.type_bool(), n, name);
+        } else {
+            return ll.op_alloca(t, n, name);
+        }
+    } else {
+        OSL_DEV_ONLY(std::cout << " as VARYING " << std::endl);
+        if (forceBool) {
+            return ll.op_alloca(ll.type_native_mask(), n, name);
+        } else {
+            return ll.wide_op_alloca(t, n, name);
+        }
+    }
+}
+
+BatchedBackendLLVM::TempScope::TempScope(BatchedBackendLLVM& backend)
+    : m_backend(backend)
+{
+    m_backend.m_temp_scopes.push_back(this);
+}
+
+BatchedBackendLLVM::TempScope::~TempScope()
+{
+    OSL_ASSERT(!m_backend.m_temp_scopes.empty()
+               && m_backend.m_temp_scopes.back() == this);
+    OSL_MAYBE_UNUSED int temp_count = static_cast<int>(
+        m_backend.m_temp_allocs.size());
+    // Any temps we used will no longer be needed,
+    // so we can mark them to be reused
+    for (int temp_index : m_in_use_indices) {
+        OSL_DASSERT(temp_index < temp_count && temp_index >= 0);
+        m_backend.m_temp_allocs[temp_index].in_use = false;
+    }
+    m_backend.m_temp_scopes.pop_back();
+}
+
+llvm::Value*
+BatchedBackendLLVM::getOrAllocateTemp(const TypeSpec& type, bool derivs,
+                                      bool is_uniform, bool forceBool,
+                                      const std::string& name)
+{
+    OSL_ASSERT(
+        !m_temp_scopes.empty()
+        && "an instance of BatchedBackendLLVM::TempScope must exist higher up on the stack");
+
+    // Check to see if we have a free temp meeting the request
+    // using simple reverse linear search
+    int temp_count = static_cast<int>(m_temp_allocs.size());
+    for (int temp_index = temp_count - 1; temp_index >= 0; --temp_index) {
+        TempAlloc& temp_alloc = m_temp_allocs[temp_index];
+        if (!temp_alloc.in_use && temp_alloc.derivs == derivs
+            && temp_alloc.is_uniform == is_uniform
+            && temp_alloc.forceBool == forceBool) {
+            // If we are forcing bool, we don't care about the actual type requested
+            if (forceBool || temp_alloc.type == type) {
+                llvm::Value* cached_alloc = temp_alloc.llvm_value;
+
+                m_temp_scopes.back()->m_in_use_indices.push_back(temp_index);
+                temp_alloc.in_use = true;
+                return cached_alloc;
+            }
+        }
+    }
+
+    // No free temp matched the request, so allocate one
+    // NOTE: the name will be of the 1st user of the temp, it may get reused out of
+    // the cache for other purposes than named.  Debatable if the name should be dropped
+    // it may hurt more than help
+    llvm::Value* allocation = llvm_alloca(type, derivs, is_uniform, forceBool,
+                                          name);
+    m_temp_allocs.push_back(TempAlloc { true /*in_use*/, derivs, is_uniform,
+                                        forceBool, type, allocation });
+    m_temp_scopes.back()->m_in_use_indices.push_back(temp_count);
+    return allocation;
+}
+
+llvm::Value*
+BatchedBackendLLVM::getOrAllocateLLVMSymbol(const Symbol& sym)
+{
+    OSL_DASSERT(
+        (sym.symtype() == SymTypeLocal || sym.symtype() == SymTypeTemp
+         || sym.symtype() == SymTypeConst)
+        && "getOrAllocateLLVMSymbol should only be for local, tmp, const");
+    Symbol* dealiased                = sym.dealias();
+    std::string mangled_name         = dealiased->mangled();
+    AllocationMap::iterator map_iter = named_values().find(mangled_name);
+
+    if (map_iter == named_values().end()) {
+        bool is_uniform = sym.is_uniform();
+        bool forceBool  = sym.forced_llvm_bool();
+
+        llvm::Value* a = llvm_alloca(sym.typespec(), sym.has_derivs(),
+                                     is_uniform, forceBool, mangled_name);
+        named_values()[mangled_name] = a;
+        return a;
+    }
+    return map_iter->second;
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_get_pointer(const Symbol& sym, int deriv,
+                                     llvm::Value* arrayindex)
+{
+    bool has_derivs = sym.has_derivs();
+    if (!has_derivs && deriv != 0) {
+        // Return NULL for request for pointer to derivs that don't exist
+        return ll.ptr_cast(ll.void_ptr_null(),
+                           ll.type_ptr(llvm_type(sym.typespec().elementtype())));
+    }
+
+    llvm::Value* result = NULL;
+    if (sym.symtype() == SymTypeConst) {
+        // For constants, start with *OUR* pointer to the constant values.
+        result
+            = ll.ptr_cast(ll.constant_ptr(sym.data()),
+                          // Constants by definition should always be UNIFORM
+                          ll.type_ptr(llvm_type(sym.typespec().elementtype())));
+
+    } else {
+        // Start with the initial pointer to the variable's memory location
+        result = getLLVMSymbolBase(sym);
+#ifdef OSL_DEV
+        std::cerr << " llvm_get_pointer(" << sym.name() << ") result=";
+        {
+            llvm::raw_os_ostream os_cerr(std::cerr);
+            ll.llvm_typeof(result)->print(os_cerr);
+        }
+        std::cerr << std::endl;
+#endif
+    }
+    if (!result)
+        return NULL;  // Error
+
+    // If it's an array or we're dealing with derivatives, step to the
+    // right element.
+    TypeDesc t = sym.typespec().simpletype();
+    if (t.arraylen || has_derivs) {
+#ifdef OSL_DEV
+        std::cout << "llvm_get_pointer we're dealing with an array("
+                  << t.arraylen << ") or has_derivs(" << has_derivs
+                  << ")<<-------" << std::endl;
+        std::cout << "arrayindex=" << arrayindex << " deriv=" << deriv
+                  << " t.arraylen=" << t.arraylen;
+        std::cout << " is_uniform=" << sym.is_uniform() << std::endl;
+#endif
+
+        int d = deriv * std::max(1, t.arraylen);
+        if (arrayindex)
+            arrayindex = ll.op_add(arrayindex, ll.constant(d));
+        else
+            arrayindex = ll.constant(d);
+        result = ll.GEP(result, arrayindex);
+    }
+
+    return result;
+}
+
+llvm::Value*
+BatchedBackendLLVM::llvm_widen_value_into_temp(const Symbol& sym, int deriv)
+{
+    OSL_ASSERT(
+        !m_temp_scopes.empty()
+        && "An instance of BatchedBackendLLVM::TempScope must exist higher up in the call stack");
+    OSL_ASSERT(sym.is_uniform() == true);
+    const TypeSpec& t = sym.typespec();
+
+    TypeDesc symType = t.simpletype();
+    OSL_ASSERT(symType.is_unknown() == false);
+
+    llvm::Value* widePtr       = getOrAllocateTemp(t, false /*derivs*/,
+                                             false /*is_uniform*/);
+    auto disable_masked_stores = ll.create_masking_scope(false);
+    for (int c = 0; c < t.aggregate(); ++c) {
+        // NOTE: we use the passed deriv to load, but store to value (deriv==0)
+        llvm::Value* v = llvm_load_value(sym, deriv, c, TypeDesc::UNKNOWN,
+                                         /*is_uniform*/ false);
+        llvm_store_value(v, widePtr, t, 0, NULL, c);
+    }
+    return ll.void_ptr(widePtr);
+}
+
+llvm::Value*
+BatchedBackendLLVM::llvm_load_value(const Symbol& sym, int deriv,
+                                    llvm::Value* arrayindex, int component,
+                                    TypeDesc cast, bool op_is_uniform,
+                                    bool index_is_uniform)
+{
+    // A uniform symbol can be broadcast into a varying value.
+    // But a varying symbol can NOT be loaded into a uniform value.
+    OSL_ASSERT(!op_is_uniform || sym.is_uniform());
+    bool has_derivs = sym.has_derivs();
+    if (!has_derivs && deriv != 0) {
+        // Regardless of what object this is, if it doesn't have derivs but
+        // we're asking for them, return 0.  Integers don't have derivs
+        // so we don't need to worry about that case.
+        if (op_is_uniform) {
+            return ll.constant(0.0f);
+        } else {
+            return ll.wide_constant(0.0f);
+        }
+    }
+
+    // arrayindex should be non-NULL if and only if sym is an array
+    OSL_ASSERT(sym.typespec().is_array() == (arrayindex != NULL));
+
+    if (sym.is_constant() && !sym.typespec().is_array() && !arrayindex) {
+        // Shortcut for simple constants
+        if (sym.typespec().is_float()) {
+            if (cast == TypeDesc::TypeInt)
+                if (op_is_uniform) {
+                    return ll.constant((int)*(float*)sym.data());
+                } else {
+                    return ll.wide_constant((int)*(float*)sym.data());
+                }
+            else if (op_is_uniform) {
+                return ll.constant(*(float*)sym.data());
+            } else {
+                return ll.wide_constant(*(float*)sym.data());
+            }
+        }
+        if (sym.typespec().is_int()) {
+            if (cast == TypeDesc::TypeFloat)
+                if (op_is_uniform) {
+                    return ll.constant((float)*(int*)sym.data());
+                } else {
+                    return ll.wide_constant((float)*(int*)sym.data());
+                }
+            else {
+                if (op_is_uniform) {
+                    return ll.constant(*(int*)sym.data());
+                } else {
+                    return ll.wide_constant(*(int*)sym.data());
+                }
+            }
+        }
+        if (sym.typespec().is_triple() || sym.typespec().is_matrix()) {
+            if (op_is_uniform) {
+                return ll.constant(((float*)sym.data())[component]);
+            } else {
+                return ll.wide_constant(((float*)sym.data())[component]);
+            }
+        }
+        if (sym.typespec().is_string()) {
+            if (op_is_uniform) {
+                return ll.constant(*(ustring*)sym.data());
+            } else {
+                return ll.wide_constant(*(ustring*)sym.data());
+            }
+        }
+        OSL_ASSERT(0 && "unhandled constant type");
+    }
+
+    OSL_DEV_ONLY(std::cout << "  llvm_load_value " << sym.typespec().string()
+                           << " cast " << cast << std::endl);
+    return llvm_load_value(llvm_get_pointer(sym), sym.typespec(), deriv,
+                           arrayindex, component, cast, op_is_uniform,
+                           index_is_uniform, sym.forced_llvm_bool());
+}
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_load_mask(const Symbol& cond)
+{
+    OSL_ASSERT(cond.is_varying());
+    OSL_ASSERT(cond.typespec().is_int());
+    llvm::Value* llvm_mask = nullptr;
+    llvm::Value* llvm_mask_or_wide_int
+        = llvm_load_value(cond, /*deriv*/ 0, /*component*/ 0,
+                          /*cast*/ TypeDesc::UNKNOWN, /*op_is_uniform*/ false);
+    if (cond.forced_llvm_bool()) {
+        // The llvm_load_value + TypeDesc::UNKNOWN will check and convert to llvm mask already
+        llvm_mask = llvm_mask_or_wide_int;
+    } else {
+        OSL_ASSERT(ll.llvm_typeof(llvm_mask_or_wide_int) == ll.type_wide_int());
+        llvm_mask = ll.op_int_to_bool(llvm_mask_or_wide_int);
+    }
+
+    OSL_ASSERT(ll.llvm_typeof(llvm_mask) == ll.type_wide_bool());
+    return llvm_mask;
+}
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
+                                    int deriv, llvm::Value* arrayindex,
+                                    int component, TypeDesc cast,
+                                    bool op_is_uniform, bool index_is_uniform,
+                                    bool symbol_forced_boolean)
+{
+    if (!ptr)
+        return NULL;  // Error
+
+    if (index_is_uniform) {
+        // If it's an array or we're dealing with derivatives, step to the
+        // right element.
+        TypeDesc t = type.simpletype();
+        if (t.arraylen || deriv) {
+            int d = deriv * std::max(1, t.arraylen);
+            llvm::Value* elem;
+            if (arrayindex)
+                elem = ll.op_add(arrayindex, ll.constant(d));
+            else
+                elem = ll.constant(d);
+            ptr = ll.GEP(ptr, elem);
+        }
+
+        // If it's multi-component (triple or matrix), step to the right field
+        if (!type.is_closure_based() && t.aggregate > 1) {
+            OSL_DEV_ONLY(std::cout << "step to the right field " << component
+                                   << std::endl);
+            ptr = ll.GEP(ptr, 0, component);
+        }
+
+        // Now grab the value
+        llvm::Value* result;
+        result = ll.op_load(ptr);
+
+        if (type.is_closure_based())
+            return result;
+
+        // We may have bool masquarading as int's and need to promote them for
+        // use in any int arithmetic
+        if (type.is_int() && symbol_forced_boolean) {
+            // We only need to convert wide native masks
+            // and op_is_uniform doesn't guarantee that the symbol it self
+            // in non-unform, it could just be a single bool (vs. mask).
+            if (!op_is_uniform && (ll.llvm_typeof(result) != ll.type_bool())) {
+                // We just loaded a native mask need to convert it
+                // to a vector of bools
+                result = ll.native_to_llvm_mask(result);
+            }
+
+            if (cast != TypeDesc::UNKNOWN) {
+                if (cast == TypeDesc::TypeInt) {
+                    result = ll.op_bool_to_int(result);
+                } else if (cast == TypeDesc::TypeFloat) {
+                    result = ll.op_bool_to_float(result);
+                }
+            }
+        }
+
+        // Handle int<->float type casting
+        if (type.is_float_based() && cast == TypeDesc::TypeInt)
+            result = ll.op_float_to_int(result);
+        else if (type.is_int() && cast == TypeDesc::TypeFloat)
+            result = ll.op_int_to_float(result);
+        else if (type.is_string() && cast == TypeDesc::LONGLONG)
+            result = ll.ptr_to_cast(result, ll.type_longlong());
+
+        if (!op_is_uniform) {
+            // TODO:  remove this assert once we have confirmed correct handling off all the
+            // different data types.  Using OSL_ASSERT as a checklist to verify what we have
+            // handled so far during development
+            OSL_ASSERT(
+                cast == TypeDesc::UNKNOWN || cast == TypeDesc::TypeColor
+                || cast == TypeDesc::TypeVector || cast == TypeDesc::TypePoint
+                || cast == TypeDesc::TypeNormal || cast == TypeDesc::TypeFloat
+                || cast == TypeDesc::TypeInt || cast == TypeDesc::TypeString
+                || cast == TypeDesc::TypeMatrix || cast == TypeDesc::LONGLONG);
+
+            if ((ll.llvm_typeof(result) == ll.type_bool())
+                || (ll.llvm_typeof(result) == ll.type_float())
+                || (ll.llvm_typeof(result) == ll.type_triple())
+                || (ll.llvm_typeof(result) == ll.type_int())
+                || (ll.llvm_typeof(result) == (llvm::Type*)ll.type_string())
+                || (ll.llvm_typeof(result) == ll.type_matrix())
+                || (ll.llvm_typeof(result) == ll.type_longlong())) {
+                result = ll.widen_value(result);
+            } else {
+#ifdef OSL_DEV
+                if (!((ll.llvm_typeof(result) == ll.type_wide_float())
+                      || (ll.llvm_typeof(result) == ll.type_wide_int())
+                      || (ll.llvm_typeof(result) == ll.type_wide_matrix())
+                      || (ll.llvm_typeof(result) == ll.type_wide_triple())
+                      || (ll.llvm_typeof(result) == ll.type_wide_string())
+                      || (ll.llvm_typeof(result) == ll.type_wide_bool()))) {
+                    OSL_DEV_ONLY(std::cout << ">>>>>>>>>>>>>> TYPENAME OF "
+                                           << ll.llvm_typenameof(result)
+                                           << std::endl);
+                }
+#endif
+                OSL_ASSERT(
+                    (ll.llvm_typeof(result) == ll.type_wide_float())
+                    || (ll.llvm_typeof(result) == ll.type_wide_int())
+                    || (ll.llvm_typeof(result) == ll.type_wide_triple())
+                    || (ll.llvm_typeof(result) == ll.type_wide_string())
+                    || (ll.llvm_typeof(result) == ll.type_wide_bool())
+                    || (ll.llvm_typeof(result) == ll.type_wide_matrix())
+                    || (ll.llvm_typeof(result) == ll.type_wide_longlong()));
+            }
+        }
+        return result;
+    } else {
+        OSL_ASSERT(!op_is_uniform);
+        OSL_ASSERT(nullptr != arrayindex);
+        // If it's an array or we're dealing with derivatives, step to the
+        // right element.
+        TypeDesc t = type.simpletype();
+        if (t.arraylen || deriv) {
+            int d             = deriv * std::max(1, t.arraylen);
+            llvm::Value* elem = ll.constant(d);
+            ptr               = ll.GEP(ptr, elem);
+        }
+
+        // If it's multi-component (triple or matrix), step to the right field
+        if (!type.is_closure_based() && t.aggregate > 1) {
+            OSL_DEV_ONLY(std::cout << "step to the right field " << component
+                                   << std::endl);
+            ptr = ll.GEP(ptr, 0, component);
+
+            // Need to scale the indices by the stride
+            // of the type
+            int elem_stride = t.aggregate;
+            arrayindex = ll.op_mul(arrayindex, ll.wide_constant(elem_stride));
+            // TODO: possible optimization when elem_stride == 2 && sizeof(type) == 4,
+            // could have optional parameter gather operation to use a scale of 8 (2*4)
+            // vs. the hardcoded 4 and avoid the multiplication above
+        }
+
+
+        // Now grab the value
+        llvm::Value* result;
+        result = ll.op_gather(ptr, arrayindex);
+        // TODO:  possible optimization when we know the array size is small (<= 4)
+        // instead of performing a gather, we could load each value of the the array,
+        // compare the index array against that value's index and select/blend
+        // the results together.  Basically we will loading the entire content of the
+        // array, but can avoid branching or any gather statements.
+
+        if (type.is_closure_based())
+            return result;
+
+        OSL_ASSERT(ll.llvm_typeof(result) != ll.type_wide_bool());
+
+        // Handle int<->float type casting
+        if (type.is_float_based() && cast == TypeDesc::TypeInt)
+            result = ll.op_float_to_int(result);
+        else if (type.is_int() && cast == TypeDesc::TypeFloat)
+            result = ll.op_int_to_float(result);
+        else if (type.is_string() && cast == TypeDesc::LONGLONG)
+            result = ll.ptr_to_cast(result, ll.type_longlong());
+
+
+        return result;
+    }
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_load_constant_value(const Symbol& sym, int arrayindex,
+                                             int component, TypeDesc cast,
+                                             bool op_is_uniform)
+{
+    OSL_ASSERT(sym.is_constant()
+               && "Called llvm_load_constant_value for a non-constant symbol");
+
+    // set array indexing to zero for non-arrays
+    if (!sym.typespec().is_array())
+        arrayindex = 0;
+    OSL_ASSERT(arrayindex >= 0
+               && "Called llvm_load_constant_value with negative array index");
+
+
+    // TODO: might want to take this fix for array types back to the non-wide backend
+    TypeSpec elementType = sym.typespec();
+    // The symbol we are creating a constant for might be an array
+    // and our checks for types use non-array types
+    elementType.make_array(0);
+
+    if (elementType.is_float()) {
+        const float* val = (const float*)sym.data();
+        if (cast == TypeDesc::TypeInt)
+            if (op_is_uniform) {
+                return ll.constant((int)val[arrayindex]);
+            } else {
+                return ll.wide_constant((int)val[arrayindex]);
+            }
+        else if (op_is_uniform) {
+            return ll.constant(val[arrayindex]);
+        } else {
+            return ll.wide_constant(val[arrayindex]);
+        }
+    }
+    if (elementType.is_int()) {
+        const int* val = (const int*)sym.data();
+        if (cast == TypeDesc::TypeFloat)
+            if (op_is_uniform) {
+                return ll.constant((float)val[arrayindex]);
+            } else {
+                return ll.wide_constant((float)val[arrayindex]);
+            }
+        else if (op_is_uniform) {
+            return ll.constant(val[arrayindex]);
+        } else {
+            return ll.wide_constant(val[arrayindex]);
+        }
+    }
+    if (elementType.is_triple() || elementType.is_matrix()) {
+        const float* val = (const float*)sym.data();
+        int ncomps       = (int)sym.typespec().aggregate();
+        if (op_is_uniform) {
+            return ll.constant(val[ncomps * arrayindex + component]);
+        } else {
+            return ll.wide_constant(val[ncomps * arrayindex + component]);
+        }
+    }
+    if (elementType.is_string()) {
+        const ustring* val = (const ustring*)sym.data();
+        if (op_is_uniform) {
+            return ll.constant(val[arrayindex]);
+        } else {
+            return ll.wide_constant(val[arrayindex]);
+        }
+    }
+
+    std::cout << "SYMBOL " << sym.name().c_str() << " type=" << sym.typespec()
+              << std::endl;
+    OSL_ASSERT(0 && "unhandled constant type");
+    return NULL;
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_load_component_value(const Symbol& sym, int deriv,
+                                              llvm::Value* component,
+                                              bool op_is_uniform,
+                                              bool component_is_uniform)
+{
+    bool has_derivs = sym.has_derivs();
+    if (!has_derivs && deriv != 0) {
+        // Regardless of what object this is, if it doesn't have derivs but
+        // we're asking for them, return 0.  Integers don't have derivs
+        // so we don't need to worry about that case.
+        OSL_ASSERT(sym.typespec().is_float_based()
+                   && "can't ask for derivs of an int");
+        if (op_is_uniform) {
+            return ll.constant(0.0f);
+        } else {
+            return ll.wide_constant(0.0f);
+        }
+    }
+
+    // Start with the initial pointer to the value's memory location
+    llvm::Value* pointer = llvm_get_pointer(sym, deriv);
+    if (!pointer)
+        return NULL;  // Error
+
+    TypeDesc t = sym.typespec().simpletype();
+    OSL_ASSERT(t.basetype == TypeDesc::FLOAT);
+    OSL_ASSERT(t.aggregate != TypeDesc::SCALAR);
+    // cast the Vec* to a float*
+
+    if (sym.is_uniform()) {
+        pointer = ll.ptr_cast(pointer, ll.type_float_ptr());
+    } else {
+        pointer = ll.ptr_cast(pointer, ll.type_wide_float_ptr());
+    }
+
+    llvm::Value* result;
+    if (component_is_uniform) {
+        llvm::Value* component_pointer = ll.GEP(pointer, component);
+
+        // Now grab the value
+        result = ll.op_load(component_pointer);
+    } else {
+        OSL_ASSERT(!op_is_uniform);
+        result = ll.op_gather(pointer, component);
+        // TODO:  possible optimization when we know the # of components is small (<= 4)
+        // instead of performing a gather, we could load each value of the components,
+        // compare the component index against that value's index and select/blend
+        // the results together.  Basically we will loading the entire content of the
+        // object, but can avoid branching or any gather statements.
+    }
+
+    if (!op_is_uniform) {
+        if (ll.llvm_typeof(result) == ll.type_float()) {
+            result = ll.widen_value(result);
+        } else {
+            OSL_ASSERT(ll.llvm_typeof(result) == ll.type_wide_float());
+        }
+    }
+    return result;
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_load_arg(const Symbol& sym, bool derivs,
+                                  bool op_is_uniform)
+{
+    OSL_ASSERT(
+        !m_temp_scopes.empty()
+        && "An instance of BatchedBackendLLVM::TempScope must exist higher up in the call stack");
+    bool sym_is_uniform = sym.is_uniform();
+
+    if (sym.typespec().is_string() || sym.typespec().is_int()
+        || (sym.typespec().is_float() && !derivs)) {
+        // Scalar case
+
+        // If we are not uniform, then the argument should
+        // get passed as a pointer instead of by value
+        // So let this case fall through
+        if (op_is_uniform) {
+            return llvm_load_value(sym, 0, 0, TypeDesc::UNKNOWN, op_is_uniform);
+        } else if (sym.symtype() == SymTypeConst) {
+            // As the case to deliver a pointer to a symbol data
+            // doesn't provide an opportunity to promote a uniform constant
+            // to a wide value that the non-uniform function is expecting
+            // we will handle it here.
+            llvm::Value* wide_constant_value
+                = llvm_load_constant_value(sym, 0, 0, TypeDesc::UNKNOWN,
+                                           op_is_uniform);
+
+            // Have to have a place on the stack for the pointer to the wide constant to point to
+            const TypeSpec& t   = sym.typespec();
+            llvm::Value* tmpptr = getOrAllocateTemp(t, false /*derivs*/,
+                                                    false /*is_uniform*/);
+
+            // Store our wide pointer on the stack
+            auto disable_masked_stores = ll.create_masking_scope(false);
+            llvm_store_value(wide_constant_value, tmpptr, t, 0, NULL, 0);
+
+            // return pointer to our stacked wide constant
+            return ll.void_ptr(tmpptr);
+        }
+    }
+
+    if ((sym_is_uniform && !op_is_uniform) || (derivs && !sym.has_derivs())) {
+        // Manufacture-derivs case
+        const TypeSpec& t = sym.typespec();
+
+        // Copy the non-deriv values component by component
+        llvm::Value* tmpptr = getOrAllocateTemp(t, derivs, op_is_uniform);
+
+        auto disable_masked_stores = ll.create_masking_scope(false);
+        int copy_deriv_count       = (derivs && sym.has_derivs()) ? 3 : 1;
+        for (int d = 0; d < copy_deriv_count; ++d) {
+            for (int c = 0; c < t.aggregate(); ++c) {
+                // Will automatically widen value if needed
+                llvm::Value* v = llvm_load_value(sym, d, c, TypeDesc::UNKNOWN,
+                                                 op_is_uniform);
+                llvm_store_value(v, tmpptr, t, d, NULL, c);
+            }
+        }
+        if (derivs && !sym.has_derivs()) {
+            // Zero out the deriv values
+            llvm::Value* zero;
+            if (op_is_uniform)
+                zero = ll.constant(0.0f);
+            else
+                zero = ll.wide_constant(0.0f);
+            for (int c = 0; c < t.aggregate(); ++c)
+                llvm_store_value(zero, tmpptr, t, 1, NULL, c);
+            for (int c = 0; c < t.aggregate(); ++c)
+                llvm_store_value(zero, tmpptr, t, 2, NULL, c);
+        }
+        return ll.void_ptr(tmpptr);
+    }
+
+    // Regular pointer case
+    return llvm_void_ptr(sym);
+}
+
+
+
+bool
+BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, const Symbol& sym,
+                                     int deriv, llvm::Value* arrayindex,
+                                     int component, bool index_is_uniform)
+{
+    bool has_derivs = sym.has_derivs();
+    if (!has_derivs && deriv != 0) {
+        // Attempt to store deriv in symbol that doesn't have it is just a nop
+        return true;
+    }
+
+    return llvm_store_value(new_val, llvm_get_pointer(sym), sym.typespec(),
+                            deriv, arrayindex, component, index_is_uniform);
+}
+
+
+
+bool
+BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
+                                     const TypeSpec& type, int deriv,
+                                     llvm::Value* arrayindex, int component,
+                                     bool index_is_uniform)
+{
+    if (!dst_ptr)
+        return false;  // Error
+
+    if (index_is_uniform) {
+        // If it's an array or we're dealing with derivatives, step to the
+        // right element.
+        TypeDesc t = type.simpletype();
+        if (t.arraylen || deriv) {
+            int d = deriv * std::max(1, t.arraylen);
+            if (arrayindex)
+                arrayindex = ll.op_add(arrayindex, ll.constant(d));
+            else
+                arrayindex = ll.constant(d);
+            dst_ptr = ll.GEP(dst_ptr, arrayindex);
+        }
+
+        // If it's multi-component (triple or matrix), step to the right field
+        if (!type.is_closure_based() && t.aggregate > 1)
+            dst_ptr = ll.GEP(dst_ptr, 0, component);
+
+        if (ll.type_ptr(ll.llvm_typeof(new_val)) != ll.llvm_typeof(dst_ptr)) {
+            std::cerr << " new_val type=";
+            {
+                llvm::raw_os_ostream os_cerr(std::cerr);
+                ll.llvm_typeof(new_val)->print(os_cerr);
+            }
+            std::cerr << " dest_ptr type=";
+            {
+                llvm::raw_os_ostream os_cerr(std::cerr);
+                ll.llvm_typeof(dst_ptr)->print(os_cerr);
+            }
+            std::cerr << std::endl;
+        }
+        OSL_ASSERT(ll.type_ptr(ll.llvm_typeof(new_val))
+                   == ll.llvm_typeof(dst_ptr));
+
+
+        // Finally, store the value.
+        ll.op_store(new_val, dst_ptr);
+        return true;
+    } else {
+        OSL_ASSERT(nullptr != arrayindex);
+
+        // If it's an array or we're dealing with derivatives, step to the
+        // right element.
+        TypeDesc t = type.simpletype();
+        if (t.arraylen || deriv) {
+            int d             = deriv * std::max(1, t.arraylen);
+            llvm::Value* elem = ll.constant(d);
+            dst_ptr           = ll.GEP(dst_ptr, elem);
+        }
+
+        // If it's multi-component (triple or matrix), step to the right field
+        if (!type.is_closure_based() && t.aggregate > 1) {
+            OSL_DEV_ONLY(std::cout << "step to the right field " << component
+                                   << std::endl);
+            dst_ptr = ll.GEP(dst_ptr, 0, component);
+
+            // Need to scale the indices by the stride
+            // of the type
+            int elem_stride = t.aggregate;
+            arrayindex = ll.op_mul(arrayindex, ll.wide_constant(elem_stride));
+            // TODO: possible optimization when elem_stride == 2 && sizeof(type) == 4,
+            // could have optional parameter gather operation to use a scale of 8 (2*4)
+            // vs. the hardcoded 4 and avoid the multiplication above
+        }
+
+        // Finally, store the value.
+        ll.op_scatter(new_val, dst_ptr, arrayindex);
+        // TODO:  possible optimization when we know the array size is small (<= 4)
+        // instead of performing a scatter, we could load each value of the the array,
+        // compare the index array against that value's index and select/blend
+        // the results together, and store the result.  Basically we will loading the entire content of the
+        // array, but can avoid branching or any scatter statements.
+        return true;
+    }
+}
+
+
+bool
+BatchedBackendLLVM::llvm_store_mask(llvm::Value* new_mask, const Symbol& cond)
+{
+    OSL_ASSERT(ll.llvm_typeof(new_mask) == ll.type_wide_bool());
+    OSL_ASSERT(cond.is_varying());
+    OSL_ASSERT(cond.typespec().is_int());
+    if (cond.forced_llvm_bool()) {
+        return llvm_store_value(ll.llvm_mask_to_native(new_mask), cond);
+    } else {
+        return llvm_store_value(ll.op_bool_to_int(new_mask), cond);
+    }
+}
+
+
+bool
+BatchedBackendLLVM::llvm_store_component_value(llvm::Value* new_val,
+                                               const Symbol& sym, int deriv,
+                                               llvm::Value* component,
+                                               bool component_is_uniform)
+{
+    bool has_derivs = sym.has_derivs();
+    if (!has_derivs && deriv != 0) {
+        // Attempt to store deriv in symbol that doesn't have it is just a nop
+        return true;
+    }
+
+    // Let llvm_get_pointer do most of the heavy lifting to get us a
+    // pointer to where our data lives.
+    llvm::Value* pointer = llvm_get_pointer(sym, deriv);
+    if (!pointer)
+        return false;  // Error
+
+    TypeDesc t = sym.typespec().simpletype();
+    OSL_ASSERT(t.basetype == TypeDesc::FLOAT);
+    OSL_ASSERT(t.aggregate != TypeDesc::SCALAR);
+    // cast the Vec* to a float*
+
+    bool symbolsIsUniform = sym.is_uniform();
+    if (symbolsIsUniform) {
+        pointer = ll.ptr_cast(pointer, ll.type_float_ptr());
+    } else {
+        pointer = ll.ptr_cast(pointer, ll.type_wide_float_ptr());
+    }
+
+    if (component_is_uniform) {
+        llvm::Value* component_pointer
+            = ll.GEP(pointer, component);  // get the component
+
+        // Finally, store the value.
+        ll.op_store(new_val, component_pointer);
+    } else {
+        OSL_ASSERT(!symbolsIsUniform);
+        ll.op_scatter(new_val, pointer, component);
+    }
+    return true;
+}
+
+void
+BatchedBackendLLVM::llvm_broadcast_uniform_value_from_mem(
+    llvm::Value* pointerTotempUniform, const Symbol& Destination,
+    bool ignore_derivs)
+{
+    OSL_ASSERT(Destination.is_varying());
+    const TypeDesc& dest_type = Destination.typespec().simpletype();
+    bool derivs               = Destination.has_derivs();
+
+    int derivCount = (!ignore_derivs && derivs) ? 3 : 1;
+
+    int arrayEnd;
+
+    if (dest_type.is_array()) {
+        OSL_ASSERT(dest_type.arraylen != 0);
+        OSL_ASSERT(dest_type.arraylen != -1
+                   && "We don't support an unsized array");
+        arrayEnd = dest_type.arraylen;
+    } else {
+        arrayEnd = 1;
+    }
+
+    int componentCount = dest_type.aggregate;
+
+    for (int derivIndex = 0; derivIndex < derivCount; ++derivIndex) {
+        for (int arrayIndex = 0; arrayIndex < arrayEnd; ++arrayIndex) {
+            llvm::Value* llvm_array_index = ll.constant(arrayIndex);
+            for (int componentIndex = 0; componentIndex < componentCount;
+                 ++componentIndex) {
+                // Load the uniform component from the temporary
+                // base passing false for op_is_uniform, the llvm_load_value will
+                // automatically broadcast the uniform value to a vector type
+                llvm::Value* wide_component_value
+                    = llvm_load_value(pointerTotempUniform, dest_type,
+                                      derivIndex, llvm_array_index,
+                                      componentIndex, TypeDesc::UNKNOWN,
+                                      false /*op_is_uniform*/);
+                bool success = llvm_store_value(wide_component_value,
+                                                Destination, derivIndex,
+                                                llvm_array_index,
+                                                componentIndex);
+                OSL_ASSERT(success);
+            }
+        }
+    }
+}
+
+void
+BatchedBackendLLVM::llvm_broadcast_uniform_value(llvm::Value* tempUniform,
+                                                 const Symbol& Destination,
+                                                 int derivs, int component)
+{
+    const TypeDesc& dest_type = Destination.typespec().simpletype();
+    OSL_ASSERT(false == dest_type.is_array());
+
+    llvm::Value* wide_value = ll.widen_value(tempUniform);
+    llvm_store_value(wide_value, Destination, derivs, nullptr, component);
+}
+
+void
+BatchedBackendLLVM::llvm_conversion_store_masked_status(llvm::Value* val,
+                                                        const Symbol& Status)
+{
+    OSL_ASSERT(ll.type_int() == ll.llvm_typeof(val));
+
+    llvm::Value* mask = ll.int_as_mask(val);
+
+    if (Status.forced_llvm_bool()) {
+        // status is a "native" boolean, so we need to convert it before storing
+        mask = ll.llvm_mask_to_native(mask);
+    } else {
+        llvm::Type* statusType = ll.llvm_typeof(llvm_get_pointer(Status));
+        OSL_ASSERT(statusType
+                   == reinterpret_cast<llvm::Type*>(ll.type_wide_int_ptr()));
+        // status is a integer, so we need to convert it to integer before storing
+        mask = ll.op_bool_to_int(mask);
+    }
+
+    llvm_store_value(mask, Status);
+}
+
+void
+BatchedBackendLLVM::llvm_conversion_store_uniform_status(llvm::Value* val,
+                                                         const Symbol& Status)
+{
+    OSL_ASSERT(ll.type_int() == ll.llvm_typeof(val));
+
+    bool is_uniform = Status.is_uniform();
+    if (Status.forced_llvm_bool()) {
+        // Handle demoting to bool
+        val = ll.op_int_to_bool(val);
+        if (!is_uniform) {
+            // expanding out to wide bool
+            val = ll.widen_value(val);
+            // Always store native mask type
+            val = ll.llvm_mask_to_native(val);
+        }
+    } else {
+        if (!is_uniform) {
+            // Expanding out to wide int
+            val = ll.widen_value(val);
+        }
+    }
+
+    llvm_store_value(val, Status);
+}
+
+llvm::Value*
+BatchedBackendLLVM::groupdata_field_ref(int fieldnum)
+{
+    return ll.GEP(groupdata_ptr(), 0, fieldnum);
+}
+
+
+llvm::Value*
+BatchedBackendLLVM::groupdata_field_ptr(int fieldnum, TypeDesc type,
+                                        bool is_uniform)
+{
+    llvm::Value* result = ll.void_ptr(groupdata_field_ref(fieldnum));
+    if (type != TypeDesc::UNKNOWN) {
+        if (is_uniform) {
+            result = ll.ptr_to_cast(result, llvm_type(type));
+        } else {
+            result = ll.ptr_to_cast(result, llvm_wide_type(type));
+        }
+    }
+    return result;
+}
+
+llvm::Value*
+BatchedBackendLLVM::temp_wide_matrix_ptr()
+{
+    if (m_llvm_temp_wide_matrix_ptr == nullptr) {
+        // Don't worry about what basic block we are currently inside of because
+        // we insert all alloca's to the top function, not the current insertion point
+        m_llvm_temp_wide_matrix_ptr = ll.op_alloca(ll.type_wide_matrix(), 1,
+                                                   std::string(), 64);
+    }
+    return m_llvm_temp_wide_matrix_ptr;
+}
+
+
+llvm::Value*
+BatchedBackendLLVM::temp_batched_texture_options_ptr()
+{
+    if (m_llvm_temp_batched_texture_options_ptr == nullptr) {
+        // Don't worry about what basic block we are currently inside of because
+        // we insert all alloca's to the top function, not the current insertion point
+        m_llvm_temp_batched_texture_options_ptr
+            = ll.op_alloca(llvm_type_batched_texture_options(), 1,
+                           std::string(), 64);
+    }
+    return m_llvm_temp_batched_texture_options_ptr;
+}
+
+llvm::Value*
+BatchedBackendLLVM::temp_batched_trace_options_ptr()
+{
+    if (m_llvm_temp_batched_trace_options_ptr == nullptr) {
+        // Don't worry about what basic block we are currently inside of because
+        // we insert all alloca's to the top function, not the current insertion point
+        m_llvm_temp_batched_trace_options_ptr
+            = ll.op_alloca(llvm_type_batched_trace_options(), 1, std::string(),
+                           64);
+    }
+    return m_llvm_temp_batched_trace_options_ptr;
+}
+
+
+llvm::Value*
+BatchedBackendLLVM::layer_run_ref(int layer)
+{
+    int fieldnum           = 0;  // field 0 is the layer_run array
+    llvm::Value* layer_run = groupdata_field_ref(fieldnum);
+    return ll.GEP(layer_run, 0, layer);
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::userdata_initialized_ref(int userdata_index)
+{
+    int fieldnum = 1;  // field 1 is the userdata_initialized array
+    llvm::Value* userdata_initiazlied = groupdata_field_ref(fieldnum);
+    return ll.GEP(userdata_initiazlied, 0, userdata_index);
+}
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_call_function(const FuncSpec& name,
+                                       const Symbol** symargs, int nargs,
+                                       bool deriv_ptrs,
+                                       bool function_is_uniform,
+                                       bool functionIsLlvmInlined,
+                                       bool ptrToReturnStructIs1stArg)
+{
+    bool requiresMasking = ptrToReturnStructIs1stArg && !function_is_uniform
+                           && ll.is_masking_required();
+
+    llvm::Value* uniformResultTemp = nullptr;
+
+    TempScope scoped_temps(*this);
+
+    bool needToBroadcastUniformResultToWide = false;
+    std::vector<llvm::Value*> valargs;
+    valargs.resize((size_t)nargs + (requiresMasking ? 1 : 0));
+    for (int i = 0; i < nargs; ++i) {
+        const Symbol& s   = *(symargs[i]);
+        const TypeSpec& t = s.typespec();
+
+        if (t.is_closure())
+            valargs[i] = llvm_load_value(s);
+        else if (t.simpletype().aggregate > 1 || (deriv_ptrs && s.has_derivs())
+                 || (!function_is_uniform && !functionIsLlvmInlined)) {
+            // Need to pass a pointer to the function
+            if (function_is_uniform || (s.symtype() != SymTypeConst)) {
+                //OSL_ASSERT(function_is_uniform || s.is_varying());
+                if (function_is_uniform) {
+                    OSL_DASSERT(function_is_uniform);
+                    if (s.is_uniform()) {
+                        valargs[i] = llvm_void_ptr(s);
+                    } else {
+                        // if the function is uniform, all parameters need to be uniform
+                        // however we could doing a masked assignment to a wide result
+                        // which would have to be the 1st parameter!
+                        OSL_ASSERT(i == 0);
+                        OSL_ASSERT(ptrToReturnStructIs1stArg);
+                        // in that case we will allocate a uniform result parameter on the
+                        // stack to hold the result and then do a masked store after
+                        // calling the uniform version of the function
+                        OSL_ASSERT(!t.is_array() && "incomplete");
+                        needToBroadcastUniformResultToWide = true;
+                        uniformResultTemp
+                            = getOrAllocateTemp(t, s.has_derivs(),
+                                                /*is_uniform=*/true);
+
+                        valargs[i] = ll.void_ptr(uniformResultTemp);
+                    }
+                } else if (s.is_varying()) {
+                    OSL_DASSERT(false == function_is_uniform);
+                    valargs[i] = llvm_void_ptr(s);
+                } else {
+                    OSL_DASSERT(false == function_is_uniform);
+                    OSL_DASSERT(s.is_uniform());
+                    // TODO: Consider dynamically generating function name based on varying/uniform parameters
+                    // and their types.  Could even detect what function names exist and only promote necessary
+                    // parameters to be wide.  This would allow library implementer to add mixed varying uniform
+                    // parameter versions of their functions as deemed necessary for highly used combinations
+                    // versus supplying all combinations possible
+                    OSL_DEV_ONLY(std::cout << "....widening value "
+                                           << s.name().c_str() << std::endl);
+
+                    OSL_ASSERT(false == function_is_uniform);
+                    // As the case to deliver a pointer to a symbol data
+                    // doesn't provide an opportunity to promote a uniform value
+                    // to a wide value that the non-uniform function is expecting
+                    // we will handle it here.
+
+                    OSL_ASSERT(!t.is_array() && "incomplete");
+
+                    // Have to have a place on the stack for the pointer to the wide to point to
+                    llvm::Value* tmpptr
+                        = getOrAllocateTemp(t, s.has_derivs(),
+                                            /*is_uniform=*/false);
+                    auto disable_masked_stores = ll.create_masking_scope(false);
+                    int numDeriv               = s.has_derivs() ? 3 : 1;
+                    for (int d = 0; d < numDeriv; ++d) {
+                        for (int c = 0; c < t.simpletype().aggregate; ++c) {
+                            llvm::Value* wide_value = llvm_load_value(
+                                s, /*deriv=*/d, /*component*/ c,
+                                TypeDesc::UNKNOWN, function_is_uniform);
+                            // Store our wide pointer on the stack
+                            llvm_store_value(wide_value, tmpptr, t, d, NULL, c);
+                        }
+                    }
+
+                    // return pointer to our stacked wide variable
+                    valargs[i] = ll.void_ptr(tmpptr);
+                }
+            } else {
+                OSL_DEV_ONLY(std::cout << "....widening constant value "
+                                       << s.name().c_str() << std::endl);
+
+                OSL_ASSERT(s.symtype() == SymTypeConst);
+                OSL_ASSERT(false == function_is_uniform);
+                // As the case to deliver a pointer to a symbol data
+                // doesn't provide an opportunity to promote a uniform constant
+                // to a wide value that the non-uniform function is expecting.
+                // So we will handle it here.
+
+                OSL_ASSERT(!t.is_array() && "incomplete");
+
+                OSL_ASSERT(s.has_derivs() == false
+                           && "how could we have a constant with derivatives");
+                // Have to have a place on the stack for the pointer to the wide constant to point to
+                llvm::Value* tmpptr
+                    = getOrAllocateTemp(t, false /*derivs*/,
+                                        false /*function_is_uniform*/);
+
+                auto disable_masked_stores = ll.create_masking_scope(false);
+                for (int a = 0; a < t.simpletype().aggregate; ++a) {
+                    llvm::Value* wide_constant_value
+                        = llvm_load_constant_value(s, 0, a, TypeDesc::UNKNOWN,
+                                                   function_is_uniform);
+                    // Store our wide pointer on the stack
+                    llvm_store_value(wide_constant_value, tmpptr, t, 0, NULL,
+                                     a);
+                }
+
+                // return pointer to our stacked wide constant
+                valargs[i] = ll.void_ptr(tmpptr);
+            }
+
+
+            OSL_DEV_ONLY(std::cout << "....pushing " << s.name().c_str()
+                                   << " as void_ptr" << std::endl);
+        } else {
+            OSL_DEV_ONLY(std::cout << "....pushing " << s.name().c_str()
+                                   << " as value" << std::endl);
+            valargs[i] = llvm_load_value(s, /*deriv*/ 0, /*component*/ 0,
+                                         TypeDesc::UNKNOWN,
+                                         function_is_uniform);
+        }
+    }
+
+    if (requiresMasking) {
+        if (functionIsLlvmInlined) {
+            // For inlined functions, keep the native mask type
+            valargs[nargs] = ll.current_mask();
+        } else {
+            // For non-inlined functions, cast the mask to an int32
+            valargs[nargs] = ll.mask_as_int(ll.current_mask());
+        }
+        // NOTE: although we accept a const FuncSpec &, we want to modify
+        // its masked attribute.  As FuncSpec's are not meant to be stored
+        // and should only exist on the stack to be passed into this exact
+        // function (and is most likely a temporary), we don't feel bad
+        // about the following const_cast, consider it by design
+        const_cast<FuncSpec&>(name).mask();
+    }
+
+    OSL_DEV_ONLY(std::cout << "call_function " << build_name(name)
+                           << std::endl);
+    llvm::Value* func_call = ll.call_function(build_name(name), valargs);
+    if (ptrToReturnStructIs1stArg) {
+        if (needToBroadcastUniformResultToWide) {
+            auto& wide_result_sym = *(symargs[0]);
+            llvm_broadcast_uniform_value_from_mem(uniformResultTemp,
+                                                  wide_result_sym);
+        }
+    } else {
+        OSL_ASSERT(false == needToBroadcastUniformResultToWide);
+    }
+    return func_call;
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_call_function(const FuncSpec& name, const Symbol& A,
+                                       bool deriv_ptrs)
+{
+    const Symbol* args[1];
+    args[0] = &A;
+    return llvm_call_function(name, args, 1, deriv_ptrs);
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_call_function(const FuncSpec& name, const Symbol& A,
+                                       const Symbol& B, bool deriv_ptrs)
+{
+    const Symbol* args[2];
+    args[0] = &A;
+    args[1] = &B;
+    return llvm_call_function(name, args, 2, deriv_ptrs);
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_call_function(const FuncSpec& name, const Symbol& A,
+                                       const Symbol& B, const Symbol& C,
+                                       bool deriv_ptrs,
+                                       bool function_is_uniform,
+                                       bool functionIsLlvmInlined,
+                                       bool ptrToReturnStructIs1stArg)
+{
+    const Symbol* args[3];
+    args[0] = &A;
+    args[1] = &B;
+    args[2] = &C;
+    return llvm_call_function(name, args, 3, deriv_ptrs, function_is_uniform,
+                              functionIsLlvmInlined, ptrToReturnStructIs1stArg);
+}
+
+
+
+llvm::Value*
+BatchedBackendLLVM::llvm_test_nonzero(const Symbol& val, bool test_derivs)
+{
+    const TypeSpec& ts(val.typespec());
+    OSL_ASSERT(!ts.is_array() && !ts.is_closure() && !ts.is_string());
+    TypeDesc t = ts.simpletype();
+
+    // Handle int case -- guaranteed no derivs, no multi-component
+    if (t == TypeDesc::TypeInt) {
+        // Because we allow temporaries and local results of comparison operations
+        // to use the native bool type of i1, we will need to build an matching constant 0
+        // for comparisons.  We can just interrogate the underlying llvm symbol to see if
+        // it is a bool
+        llvm::Value* llvmValue = llvm_get_pointer(val);
+        //OSL_DEV_ONLY(std::cout << "llvmValue type=" << ll.llvm_typenameof(llvmValue) << std::endl);
+
+        if (ll.llvm_typeof(llvmValue) == ll.type_ptr(ll.type_bool())) {
+            return ll.op_ne(llvm_load_value(val), ll.constant_bool(0));
+        } else {
+            return ll.op_ne(llvm_load_value(val), ll.constant(0));
+        }
+    }
+
+    // float-based
+    int ncomps             = t.aggregate;
+    int nderivs            = (test_derivs && val.has_derivs()) ? 3 : 1;
+    llvm::Value* isnonzero = NULL;
+    for (int d = 0; d < nderivs; ++d) {
+        for (int c = 0; c < ncomps; ++c) {
+            llvm::Value* v  = llvm_load_value(val, d, c);
+            llvm::Value* nz = ll.op_ne(v, ll.constant(0.0f), true);
+            if (isnonzero)  // multi-component/deriv: OR with running result
+                isnonzero = ll.op_or(nz, isnonzero);
+            else
+                isnonzero = nz;
+        }
+    }
+    return isnonzero;
+}
+
+
+
+bool
+BatchedBackendLLVM::llvm_assign_impl(const Symbol& Result, const Symbol& Src,
+                                     int arrayindex, int srccomp, int dstcomp)
+{
+    OSL_DEV_ONLY(std::cout << "llvm_assign_impl arrayindex=" << arrayindex
+                           << " Result(" << Result.name() << ") is_uniform="
+                           << Result.is_uniform() << std::endl);
+    OSL_DEV_ONLY(std::cout << "                              Src(" << Src.name()
+                           << ") is_uniform=" << Src.is_uniform() << std::endl);
+    OSL_ASSERT(!Result.typespec().is_structure());
+    OSL_ASSERT(!Src.typespec().is_structure());
+
+    bool op_is_uniform = Result.is_uniform();
+
+    const TypeSpec& result_t(Result.typespec());
+    const TypeSpec& src_t(Src.typespec());
+
+    llvm::Value* arrind = arrayindex >= 0 ? ll.constant(arrayindex) : NULL;
+
+    if (Result.typespec().is_closure() || Src.typespec().is_closure()) {
+        OSL_ASSERT(0 && "unhandled case");  // TODO: implement
+
+        if (Src.typespec().is_closure()) {
+            llvm::Value* srcval = llvm_load_value(Src, 0, arrind, 0);
+            llvm_store_value(srcval, Result, 0, arrind, 0);
+        } else {
+            llvm::Value* null = ll.constant_ptr(NULL, ll.type_void_ptr());
+            llvm_store_value(null, Result, 0, arrind, 0);
+        }
+        return true;
+    }
+
+    if (Result.typespec().is_matrix() && Src.typespec().is_int_or_float()) {
+        // Handle m=f, m=i separately
+        llvm::Value* src = llvm_load_value(Src, 0, arrind, 0,
+                                           TypeDesc::FLOAT /*cast*/,
+                                           op_is_uniform);
+        // m=f sets the diagonal components to f, the others to zero
+        llvm::Value* zero;
+        if (op_is_uniform)
+            zero = ll.constant(0.0f);
+        else
+            zero = ll.wide_constant(0.0f);
+
+        for (int i = 0; i < 4; ++i)
+            for (int j = 0; j < 4; ++j)
+                llvm_store_value(i == j ? src : zero, Result, 0, arrind,
+                                 i * 4 + j);
+        llvm_zero_derivs(Result);  // matrices don't have derivs currently
+        return true;
+    }
+
+    // memcpy complicated by promotion of uniform to wide during assignment, dissallow
+
+    // The following code handles f=f, f=i, v=v, v=f, v=i, m=m, s=s.
+    // Remember that llvm_load_value will automatically convert scalar->triple.
+    TypeDesc rt              = Result.typespec().simpletype();
+    TypeDesc basetype        = TypeDesc::BASETYPE(rt.basetype);
+    const int num_components = rt.aggregate;
+    const bool singlechan    = (srccomp != -1) || (dstcomp != -1);
+
+    // Because we are not mem-copying arrays wholesale,
+    // We will add an outer array index loop to copy 1 element or entire array
+    int start_array_index = arrayindex;
+    int end_array_index   = start_array_index + 1;
+    if (start_array_index == -1) {
+        if (result_t.is_array() && src_t.is_array()) {
+            start_array_index = 0;
+            end_array_index   = std::min(result_t.arraylength(),
+                                       src_t.arraylength());
+        }
+    }
+    for (arrayindex = start_array_index; arrayindex < end_array_index;
+         ++arrayindex) {
+        arrind = arrayindex >= 0 ? ll.constant(arrayindex) : NULL;
+
+        if (!singlechan) {
+            for (int i = 0; i < num_components; ++i) {
+                // Automatically handle widening the source value to match the destination's
+                llvm::Value* src_val
+                    = Src.is_constant()
+                          ? llvm_load_constant_value(Src, arrayindex, i,
+                                                     basetype, op_is_uniform)
+                          : llvm_load_value(Src, 0, arrind, i, basetype,
+                                            op_is_uniform);
+                if (!src_val)
+                    return false;
+
+                // The llvm_load_value above should have handled bool to int conversions
+                // when the basetype == Typedesc::INT
+                llvm_store_value(src_val, Result, 0, arrind, i);
+            }
+        } else {
+            // connect individual component of an aggregate type
+            // set srccomp to 0 for case when src is actually a float
+            if (srccomp == -1)
+                srccomp = 0;
+            // Automatically handle widening the source value to match the destination's
+            llvm::Value* src_val
+                = Src.is_constant()
+                      ? llvm_load_constant_value(Src, arrayindex, srccomp,
+                                                 basetype, op_is_uniform)
+                      : llvm_load_value(Src, 0, arrind, srccomp, basetype,
+                                        op_is_uniform);
+            if (!src_val)
+                return false;
+
+            // The llvm_load_value above should have handled bool to int conversions
+            // when the basetype == Typedesc::INT
+
+            // write source float into all compnents when dstcomp == -1, otherwise
+            // the single element requested.
+            if (dstcomp == -1) {
+                for (int i = 0; i < num_components; ++i)
+                    llvm_store_value(src_val, Result, 0, arrind, i);
+            } else
+                llvm_store_value(src_val, Result, 0, arrind, dstcomp);
+        }
+
+        // Handle derivatives
+        if (Result.has_derivs()) {
+            llvm::Value* zero = nullptr;
+            if (!Src.has_derivs()) {
+                // Result wants derivs but src didn't have them -- zero them
+                zero = op_is_uniform ? ll.constant(0.0f)
+                                     : ll.wide_constant(0.0f);
+            }
+
+            for (int d = 1; d <= 2; ++d) {
+                if (!singlechan) {
+                    for (int i = 0; i < num_components; ++i) {
+                        llvm::Value* val = zero;
+                        if (Src.has_derivs()) {
+                            // src and result both have derivs -- copy them
+                            // allow a uniform Src to store to a varying Result,
+                            val = llvm_load_value(Src, d, arrind, i,
+                                                  TypeDesc::UNKNOWN,
+                                                  op_is_uniform);
+                        }
+                        llvm_store_value(val, Result, d, arrind, i);
+                    }
+                } else {
+                    llvm::Value* val = zero;
+                    if (Src.has_derivs()) {
+                        // src and result both have derivs -- copy them
+                        // allow a uniform Src to store to a varying Result,
+                        val = llvm_load_value(Src, d, arrind, srccomp,
+                                              TypeDesc::UNKNOWN, op_is_uniform);
+                    }
+
+                    if (dstcomp == -1) {
+                        for (int i = 0; i < num_components; ++i)
+                            llvm_store_value(val, Result, d, arrind, i);
+                    } else
+                        llvm_store_value(val, Result, d, arrind, dstcomp);
+                }
+            }
+        }
+    }
+    return true;
+}
+
+int
+BatchedBackendLLVM::find_userdata_index(const Symbol& sym)
+{
+    int userdata_index = -1;
+    for (int i = 0, e = (int)group().m_userdata_names.size(); i < e; ++i) {
+        if (sym.name() == group().m_userdata_names[i]
+            && equivalent(sym.typespec().simpletype(),
+                          group().m_userdata_types[i])) {
+            userdata_index = i;
+            break;
+        }
+    }
+    return userdata_index;
+}
+
+
+void
+BatchedBackendLLVM::append_arg_to(llvm::raw_svector_ostream& OS,
+                                  const FuncSpec::Arg& arg)
+{
+    if (arg.is_varying()) {
+        OS << m_wide_arg_prefix;
+    }
+
+    const TypeDesc& td = arg.type();
+    const char* name   = nullptr;
+    if (td == TypeDesc::TypeInt)
+        name = "i";
+    else if (td == TypeDesc::TypeMatrix)
+        name = "m";
+    else if (td == TypeDesc::TypeString)
+        name = "s";
+    else if (td == TypeDesc::TypeFloat)
+        name = arg.has_derivs() ? "df" : "f";
+    else if (td.aggregate == 3 && td.basetype == TypeDesc::FLOAT
+             && td.arraylen == 0)
+        name = arg.has_derivs() ? "dv" : "v";
+    else if (td == TypeDesc(TypeDesc::PTR))
+        name = "X";
+    else
+        OSL_ASSERT(0);
+    OS << name;
+}
+
+const char*
+BatchedBackendLLVM::build_name(const FuncSpec& fs)
+{
+    m_built_op_name.clear();
+
+    if (fs.is_batched()) {
+        OSL_ASSERT(m_library_selector != nullptr);
+        if (fs.is_masked()) {
+            auto op_name = llvm::Twine("osl_") + m_library_selector + fs.name();
+            op_name.toVector(m_built_op_name);
+
+            llvm::raw_svector_ostream OS(m_built_op_name);
+            if (!fs.empty()) {
+                OS << "_";
+                for (const FuncSpec::Arg& arg : fs) {
+                    append_arg_to(OS, arg);
+                }
+            }
+            OS << "_masked";
+        } else {
+            auto op_name = llvm::Twine("osl_") + m_library_selector + fs.name();
+            op_name.toVector(m_built_op_name);
+
+            llvm::raw_svector_ostream OS(m_built_op_name);
+            if (!fs.empty()) {
+                OS << "_";
+                for (const FuncSpec::Arg& arg : fs) {
+                    append_arg_to(OS, arg);
+                }
+            }
+        }
+    } else {
+        auto op_name = llvm::Twine("osl_") + fs.name();
+        op_name.toVector(m_built_op_name);
+        llvm::raw_svector_ostream OS(m_built_op_name);
+        if (!fs.empty()) {
+            OS << "_";
+            for (const FuncSpec::Arg& arg : fs) {
+                append_arg_to(OS, arg);
+            }
+        }
+    }
+
+    // add null terminator
+    m_built_op_name.push_back(0);
+
+    //std::cout << "Built Func Name:"  << m_built_op_name.data() << std::endl;
+    return m_built_op_name.data();
+}
+
+
+void
+BatchedBackendLLVM::llvm_print_mask(const char* title, llvm::Value* mask)
+{
+    llvm::Value* mask_value = ll.mask_as_int(
+        (mask == nullptr) ? ll.current_mask() : mask);
+
+    llvm::Value* call_args[] = { sg_void_ptr(),
+                                 ll.constant(true_mask_value()),
+                                 ll.constant("current_mask[%s]=%X (%d)\n"),
+                                 ll.constant(title),
+                                 mask_value,
+                                 mask_value };
+
+    ll.call_function(build_name("printf"), call_args);
+}
 
 };  // namespace pvt
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -268,9 +268,9 @@ BatchedBackendLLVM::llvm_assign_zero(const Symbol& sym)
     int num_elements = t.numelements();
     for (int a = 0; a < num_elements; ++a) {
         int numDeriv = sym.has_derivs() ? 3 : 1;
+        llvm::Value* arrind = t.simpletype().arraylen ? ll.constant(a)
+                                                      : NULL;
         for (int d = 0; d < numDeriv; ++d) {
-            llvm::Value* arrind = t.simpletype().arraylen ? ll.constant(a)
-                                                          : NULL;
             for (int c = 0; c < t.aggregate(); ++c) {
                 llvm_store_value(zero, sym, d, arrind, c);
             }

--- a/src/liboslexec/batched_backendllvm.h
+++ b/src/liboslexec/batched_backendllvm.h
@@ -732,7 +732,7 @@ private:
     int m_true_mask_value;
 
     // Interface and Factory method to construct a Concrete TargetLibraryHelper
-    // that provides a prefex string that all function calls will start with
+    // that provides a prefix string that all function calls will start with
     // and correctly initialize a function map for the shading system with
     // the functions from the target ISA library.
     class TargetLibraryHelper {
@@ -744,6 +744,9 @@ private:
         static std::unique_ptr<TargetLibraryHelper> build(int vector_width,
                                                           TargetISA target_isa);
     };
+    // TargetLibraryHelper is private, so need to be friend with Concrete
+    template <int WidthT, TargetISA IsaT>
+    friend class ConcreteTargetLibraryHelper;
 
     std::unique_ptr<TargetLibraryHelper> m_target_lib_helper;
     const char* m_library_selector;

--- a/src/liboslexec/batched_backendllvm.h
+++ b/src/liboslexec/batched_backendllvm.h
@@ -1,0 +1,790 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+
+#pragma once
+
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "oslexec_pvt.h"
+
+using namespace OSL;
+using namespace OSL::pvt;
+
+#include "OSL/llvm_util.h"
+#include "runtimeoptimize.h"
+
+#include <llvm/ADT/SmallString.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/Twine.h>
+
+namespace llvm {
+class raw_svector_ostream;
+}
+
+
+OSL_NAMESPACE_ENTER
+
+namespace pvt {  // OSL::pvt
+
+
+
+/// OSOProcessor that generates LLVM IR and JITs it to give machine
+/// code to implement a shader group.
+class BatchedBackendLLVM : public OSOProcessorBase {
+public:
+    BatchedBackendLLVM(ShadingSystemImpl& shadingsys, ShaderGroup& group,
+                       ShadingContext* context, int width);
+
+    // Ensure destructor is in the cpp
+    // to allow smart pointers of incomplete types
+    virtual ~BatchedBackendLLVM();
+
+    virtual void set_inst(int layer);
+
+    /// Create an llvm function for the whole shader group, JIT it,
+    /// and store the llvm::Function* handle to it with the ShaderGroup.
+    virtual void run();
+
+
+    /// What LLVM debug level are we at?
+    int llvm_debug() const;
+
+    /// Set up a bunch of static things we'll need for the whole group.
+    ///
+    void initialize_llvm_group();
+
+    int layer_remap(int origlayer) const { return m_layer_remap[origlayer]; }
+
+    /// Create an llvm function for the current shader instance.
+    /// This will end up being the group entry if 'groupentry' is true.
+    llvm::Function* build_llvm_instance(bool groupentry);
+
+    /// Create an llvm function for group initialization code.
+    llvm::Function* build_llvm_init();
+
+    /// Build up LLVM IR code for the given range [begin,end) or
+    /// opcodes, putting them (initially) into basic block bb (or the
+    /// current basic block if bb==NULL).
+    bool build_llvm_code(int beginop, int endop, llvm::BasicBlock* bb = NULL);
+
+    typedef std::map<std::string, llvm::Value*> AllocationMap;
+
+    void llvm_assign_initial_value(const Symbol& sym,
+                                   llvm::Value* llvm_initial_shader_mask_value,
+                                   bool force = false);
+    llvm::LLVMContext& llvm_context() const { return ll.context(); }
+    AllocationMap& named_values() { return m_named_values; }
+
+    /// Return an llvm::Value* corresponding to the address of the given
+    /// symbol element, with derivative (0=value, 1=dx, 2=dy) and array
+    /// index (NULL if it's not an array).
+    llvm::Value* llvm_get_pointer(const Symbol& sym, int deriv = 0,
+                                  llvm::Value* arrayindex = NULL);
+
+    /// Allocate a new memory location to store a wide copy of the value
+    /// in sym. Optionally pass in the deriv to create wide copy of the deriv.
+    llvm::Value* llvm_widen_value_into_temp(const Symbol& sym, int deriv = 0);
+
+    /// Return the llvm::Value* corresponding to the given element
+    /// value, with derivative (0=value, 1=dx, 2=dy), array index (NULL
+    /// if it's not an array), and component (x=0 or scalar, y=1, z=2).
+    /// If deriv >0 and the symbol doesn't have derivatives, return 0
+    /// for the derivative.  If the component >0 and it's a scalar,
+    /// return the scalar -- this allows automatic casting to triples.
+    /// Finally, auto-cast int<->float if requested (no conversion is
+    /// performed if cast is the default of UNKNOWN).
+    llvm::Value* llvm_load_value(const Symbol& sym, int deriv,
+                                 llvm::Value* arrayindex, int component,
+                                 TypeDesc cast         = TypeDesc::UNKNOWN,
+                                 bool op_is_uniform    = true,
+                                 bool index_is_uniform = true);
+
+
+    /// Given an llvm::Value* of a pointer (and the type of the data
+    /// that it points to), Return the llvm::Value* corresponding to the
+    /// given element value, with derivative (0=value, 1=dx, 2=dy),
+    /// array index (NULL if it's not an array), and component (x=0 or
+    /// scalar, y=1, z=2).  If deriv >0 and the symbol doesn't have
+    /// derivatives, return 0 for the derivative.  If the component >0
+    /// and it's a scalar, return the scalar -- this allows automatic
+    /// casting to triples.  Finally, auto-cast int<->float if requested
+    /// (no conversion is performed if cast is the default of UNKNOWN).
+    llvm::Value* llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
+                                 int deriv, llvm::Value* arrayindex,
+                                 int component,
+                                 TypeDesc cast              = TypeDesc::UNKNOWN,
+                                 bool op_is_uniform         = true,
+                                 bool index_is_uniform      = true,
+                                 bool symbol_forced_boolean = false);
+
+    /// Just like llvm_load_value, but when both the symbol and the
+    /// array index are known to be constants.  This can even handle
+    /// pulling constant-indexed elements out of constant arrays.  Use
+    /// arrayindex==-1 to indicate that it's not an array dereference.
+    llvm::Value* llvm_load_constant_value(const Symbol& sym, int arrayindex,
+                                          int component,
+                                          TypeDesc cast = TypeDesc::UNKNOWN,
+                                          bool op_is_uniform = true);
+
+    /// llvm_load_value with non-constant component designation.  Does
+    /// not work with arrays or do type casts!
+    llvm::Value* llvm_load_component_value(const Symbol& sym, int deriv,
+                                           llvm::Value* component,
+                                           bool op_is_uniform        = true,
+                                           bool component_is_uniform = true);
+
+    /// Non-array version of llvm_load_value, with default deriv &
+    /// component.
+    llvm::Value* llvm_load_value(const Symbol& sym, int deriv = 0,
+                                 int component      = 0,
+                                 TypeDesc cast      = TypeDesc::UNKNOWN,
+                                 bool op_is_uniform = true)
+    {
+        return llvm_load_value(sym, deriv, NULL, component, cast,
+                               op_is_uniform);
+    }
+
+    /// Legacy version
+    ///
+    llvm::Value* loadLLVMValue(const Symbol& sym, int component = 0,
+                               int deriv = 0, TypeDesc cast = TypeDesc::UNKNOWN,
+                               bool op_is_uniform = true)
+    {
+        return llvm_load_value(sym, deriv, NULL, component, cast,
+                               op_is_uniform);
+    }
+
+    /// Version to handle converting from native mask representation
+    /// to LLVM's required vector of bits
+    llvm::Value* llvm_load_mask(const Symbol& cond);
+
+    /// Return an llvm::Value* that is either a scalar and derivs is
+    /// false, or a pointer to sym's values (if sym is an aggreate or
+    /// derivs == true).  Furthermore, if deriv == true and sym doesn't
+    /// have derivs, coerce it into a variable with zero derivs.
+    llvm::Value* llvm_load_arg(const Symbol& sym, bool derivs,
+                               bool is_uniform = true);
+
+    /// Just like llvm_load_arg(sym,deriv), except use use sym's derivs
+    /// as-is, no coercion.
+    llvm::Value* llvm_load_arg(const Symbol& sym)
+    {
+        return llvm_load_arg(sym, sym.has_derivs());
+    }
+
+    /// Store new_val into the given symbol, given the derivative
+    /// (0=value, 1=dx, 2=dy), array index (NULL if it's not an array),
+    /// and component (x=0 or scalar, y=1, z=2).  If deriv>0 and the
+    /// symbol doesn't have a deriv, it's a nop.  If the component >0
+    /// and it's a scalar, set the scalar.  Returns true if ok, false
+    /// upon failure.
+    bool llvm_store_value(llvm::Value* new_val, const Symbol& sym, int deriv,
+                          llvm::Value* arrayindex, int component,
+                          bool index_is_uniform = true);
+
+    /// Store new_val into the memory pointed to by dst_ptr, given the
+    /// derivative (0=value, 1=dx, 2=dy), array index (NULL if it's not
+    /// an array), and component (x=0 or scalar, y=1, z=2).  If deriv>0
+    /// and the symbol doesn't have a deriv, it's a nop.  If the
+    /// component >0 and it's a scalar, set the scalar.  Returns true if
+    /// ok, false upon failure.
+    bool llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
+                          const TypeSpec& type, int deriv,
+                          llvm::Value* arrayindex, int component,
+                          bool index_is_uniform = true);
+
+    /// Non-array version of llvm_store_value, with default deriv &
+    /// component.
+    bool llvm_store_value(llvm::Value* new_val, const Symbol& sym,
+                          int deriv = 0, int component = 0)
+    {
+        return llvm_store_value(new_val, sym, deriv, NULL, component);
+    }
+
+    /// Version to handle converting to native mask representation
+    /// from LLVM's required vector of bits
+    bool llvm_store_mask(llvm::Value* new_mask, const Symbol& cond);
+
+    /// llvm_store_value with non-constant component designation.  Does
+    /// not work with arrays or do type casts!
+    bool llvm_store_component_value(llvm::Value* new_val, const Symbol& sym,
+                                    int deriv, llvm::Value* component,
+                                    bool component_is_uniform = true);
+
+    /// Legacy version
+    ///
+    bool storeLLVMValue(llvm::Value* new_val, const Symbol& sym,
+                        int component = 0, int deriv = 0)
+    {
+        return llvm_store_value(new_val, sym, deriv, component);
+    }
+
+    void llvm_conversion_store_masked_status(llvm::Value* val,
+                                             const Symbol& Status);
+    void llvm_conversion_store_uniform_status(llvm::Value* val,
+                                              const Symbol& Status);
+
+    void llvm_broadcast_uniform_value(llvm::Value* tempUniform,
+                                      const Symbol& Destination, int derivs = 0,
+                                      int component = 0);
+    void llvm_broadcast_uniform_value_from_mem(llvm::Value* pointerTotempUniform,
+                                               const Symbol& Destination,
+                                               bool ignore_derivs = false);
+
+    /// Generate an alloca instruction to allocate space for the given
+    /// type, with derivs if derivs==true, and return the its pointer.
+    llvm::Value* llvm_alloca(const TypeSpec& type, bool derivs, bool is_uniform,
+                             bool forceBool          = false,
+                             const std::string& name = "");
+
+private:
+    // We have need to allocate temporaries for function calls that
+    // take varying arguments when the symbol's passed ar uniform.
+    // We need to broadcast the uniform value to a temporary wide block
+    // to pass into the function.
+    // We also might need a temporary to hold a uniform result from a function
+    // that will then need to be broadcast to a varying symbol afterwards.
+    // Rather than having a ton of allocs out there, we will keep track of
+    // allocs and reuse them once the go out of scope (usually right after
+    // a function call finishes).
+    // As llvm is type safe, we track the attributes that affect the underlying
+    // type for reuse vs. trying to reuse/cast bytes for different types
+    struct TempAlloc {
+        bool in_use;
+        bool derivs;
+        bool is_uniform;
+        bool forceBool;
+        TypeSpec type;
+        llvm::Value* llvm_value;
+    };
+    std::vector<TempAlloc> m_temp_allocs;
+
+public:
+    // Any calls to getOrAllocateTemp during the lifetime of a TempScope
+    // will be associated with the latest TempScope on the stack and
+    // when that TempScope's lifetime ends, any temp allocations will
+    // be marked unused and will be available for reuse by the next
+    // call to getOrAllocateTemp
+    class TempScope {
+        friend class BatchedBackendLLVM;
+        BatchedBackendLLVM& m_backend;
+        // Avoid dynamic allocations if 14 temps or less
+        llvm::SmallVector<int, 14> m_in_use_indices;
+
+    public:
+        TempScope(BatchedBackendLLVM& backend);
+        TempScope(const TempScope& other)  = delete;
+        TempScope(const TempScope&& other) = delete;
+        TempScope& operator=(const TempScope& other) = delete;
+        TempScope& operator=(const TempScope&& other) = delete;
+        ~TempScope();
+    };
+
+private:
+    friend class TempScope;
+    std::vector<TempScope*> m_temp_scopes;
+
+public:
+    /// Generate an alloca instruction to allocate space for the given
+    /// type, with derivs if derivs==true, and return the its pointer.
+    llvm::Value* getOrAllocateTemp(const TypeSpec& type, bool derivs,
+                                   bool is_uniform, bool forceBool = false,
+                                   const std::string& name = "");
+
+    inline llvm::Value* getTempMask(const std::string& name = "")
+    {
+        ASSERT(
+            !m_temp_scopes.empty()
+            && "An instance of BatchedBackendLLVM::TempScope must exist higher up in the call stack");
+        return getOrAllocateTemp(TypeSpec(TypeDesc::INT), false /*derivs*/,
+                                 false /*is_uniform*/, true /*forceBool*/,
+                                 name);
+    }
+
+
+    /// Given the OSL symbol, return the llvm::Value* corresponding to the
+    /// address of the start of that symbol (first element, first component,
+    /// and just the plain value if it has derivatives).  This is retrieved
+    /// from the allocation map if already there; and if not yet in the
+    /// map, the symbol is alloca'd and placed in the map.
+    llvm::Value* getOrAllocateLLVMSymbol(const Symbol& sym);
+
+    /// Retrieve an llvm::Value that is a pointer holding the start address
+    /// of the specified symbol. This always works for globals and params;
+    /// for stack variables (locals/temps) is succeeds only if the symbol is
+    /// already in the allocation table (will fail otherwise). This method
+    /// is not designed to retrieve constants.
+    llvm::Value* getLLVMSymbolBase(const Symbol& sym);
+
+    /// Retrieve the named global ("P", "N", etc.).
+    /// is_uniform is output parameter
+    llvm::Value* llvm_global_symbol_ptr(ustring name, bool& is_uniform);
+
+    /// Test whether val is nonzero, return the llvm::Value* that's the
+    /// result of a CreateICmpNE or CreateFCmpUNE (depending on the
+    /// type).  If test_derivs is true, it it also tests whether the
+    /// derivs are zero.
+    llvm::Value* llvm_test_nonzero(const Symbol& val, bool test_derivs = false);
+
+    /// Implementaiton of Simple assignment.  If arrayindex >= 0, in
+    /// designates a particular array index to assign.
+    bool llvm_assign_impl(const Symbol& Result, const Symbol& Src,
+                          int arrayindex = -1, int srccomp = -1,
+                          int dstcomp = -1);
+
+
+    /// Convert the name of a global (and its derivative index) into the
+    /// field number of the ShaderGlobals struct.
+    int ShaderGlobalNameToIndex(ustring name, bool& is_uniform);
+
+    /// Return the LLVM type handle for the BatchedShaderGlobals struct.
+    ///
+    llvm::Type* llvm_type_sg();
+
+    /// Return the LLVM type handle for a pointer to a
+    /// BatchedShaderGlobals struct.
+    llvm::Type* llvm_type_sg_ptr();
+
+    /// Return the LLVM type handle for the BatchedTextureOptions struct.
+    ///
+    llvm::Type* llvm_type_batched_texture_options();
+
+    /// Return the LLVM type handle for the BatchedTraceOptions struct.
+    ///
+    llvm::Type* llvm_type_batched_trace_options();
+
+    /// Return the ShaderGlobals pointer.
+    ///
+    llvm::Value* sg_ptr() const { return m_llvm_shaderglobals_ptr; }
+
+    llvm::Type* llvm_type_closure_component();
+    llvm::Type* llvm_type_closure_component_ptr();
+
+    /// Return the ShaderGlobals pointer cast as a void*.
+    ///
+    llvm::Value* sg_void_ptr() { return ll.void_ptr(m_llvm_shaderglobals_ptr); }
+
+    llvm::Value* llvm_ptr_cast(llvm::Value* val, const TypeSpec& type)
+    {
+        return ll.ptr_cast(val, type.simpletype());
+    }
+
+    llvm::Value* llvm_wide_ptr_cast(llvm::Value* val, const TypeSpec& type)
+    {
+        return ll.wide_ptr_cast(val, type.simpletype());
+    }
+
+
+    llvm::Value* llvm_void_ptr(const Symbol& sym, int deriv = 0)
+    {
+        return ll.void_ptr(llvm_get_pointer(sym, deriv));
+    }
+
+    /// Return the LLVM type handle for a structure of the common group
+    /// data that holds all the shader params.
+    llvm::Type* llvm_type_groupdata();
+
+    /// Return the LLVM type handle for a pointer to the common group
+    /// data that holds all the shader params.
+    llvm::Type* llvm_type_groupdata_ptr();
+
+    /// Return the group data pointer.
+    ///
+    llvm::Value* groupdata_ptr() const { return m_llvm_groupdata_ptr; }
+
+    /// Return the group data pointer cast as a void*.
+    ///
+    llvm::Value* groupdata_void_ptr()
+    {
+        return ll.void_ptr(m_llvm_groupdata_ptr);
+    }
+
+    /// Return a reference to the specified field within the group data.
+    llvm::Value* groupdata_field_ref(int fieldnum);
+
+    /// Return a pointer to the specified field within the group data,
+    /// optionally cast to pointer to a particular data type.
+    llvm::Value* groupdata_field_ptr(int fieldnum,
+                                     TypeDesc type   = TypeDesc::UNKNOWN,
+                                     bool is_uniform = true);
+
+
+    /// Return a pointer to an WideMatrix that was previously alloca
+    /// on the stack, meant for generator to reuse as a temporary
+    llvm::Value* temp_wide_matrix_ptr();
+
+    /// Return a pointer to an BatchedTextureOptions that was previously alloca
+    /// on the stack, meant for generator to reuse as a temporary
+    llvm::Value* temp_batched_texture_options_ptr();
+
+    /// Return a pointer to an BatchedTraceOptions that was previously alloca
+    /// on the stack, meant for generator to reuse as a temporary
+    llvm::Value* temp_batched_trace_options_ptr();
+
+
+    /// Return a ref to the bool where the "layer_run" flag is stored for
+    /// the specified layer.
+    llvm::Value* layer_run_ref(int layer);
+
+    /// Return a ref to the int where the "userdata_initialized" Mask is
+    /// stored for the specified userdata index.
+    llvm::Value* userdata_initialized_ref(int userdata_index = 0);
+
+    /// Generate LLVM code to zero out the variable (including derivs)
+    ///
+    void llvm_assign_zero(const Symbol& sym);
+
+    /// Generate LLVM code to zero out the derivatives of sym.
+    ///
+    void llvm_zero_derivs(const Symbol& sym);
+
+    /// Generate LLVM code to zero out the derivatives of an array
+    /// only for the first count elements of it.
+    ///
+    void llvm_zero_derivs(const Symbol& sym, llvm::Value* count);
+
+    /// Generate a debugging printf at shader execution time.
+    void llvm_gen_debug_printf(string_view message);
+
+    /// Generate a warning message at shader execution time.
+    void llvm_gen_warning(string_view message);
+
+    /// Generate an error message at shader execution time.
+    void llvm_gen_error(string_view message);
+
+    /// Generate code to call the given layer.  If 'unconditional' is
+    /// true, call it without even testing if the layer has already been
+    /// called.
+    void llvm_call_layer(int layer, bool unconditional = false);
+
+    /// Execute the upstream connection (if any, and if not yet run) that
+    /// establishes the value of symbol sym, which has index 'symindex'
+    /// within the current layer rop.inst().  If already_run is not NULL,
+    /// it points to a vector of layer indices that are known to have been
+    /// run -- those can be skipped without dynamically checking their
+    /// execution status.
+    void llvm_run_connected_layers(const Symbol& sym, int symindex,
+                                   int opnum                  = -1,
+                                   std::set<int>* already_run = NULL);
+
+
+
+    // Encapsulate creation of function names that encode parameter types,
+    // including if each is varying or uniform, and if a mask is required.
+    // Utilize llvm::Twine to efficently combine multiple strings
+    // Usage is to start with the function name then append arguments,
+    // and at any point masking can be turned on/off as well as batching.
+    // The effect of disabling batching would be the function name is
+    // not mangled to a target ISA specific library.  IE:
+    //        FuncSpec func_spec("foo");
+    //        func_spec.arg(resultSym, resultSym.has_derivs(), op_is_uniform);
+    //        func_spec.arg(op1Sym, op1Sym.has_derivs(), op_is_uniform);
+    //        func_spec.arg(op2Sym, op2Sym.has_derivs(), op_is_uniform);
+    //        if (is_masking_required) func_spec.mask();
+    //        if (op_is_uniform) func_spec.unbatch();
+    //        rop.ll.call_function (rop.build_name(func_spec), ...);
+    //
+    // NOTE:  build_name will add the "osl_" prefix or "osl_TARGETISA_" prefix
+    // not need to include it in the FuncSpec.
+    // NOTE: FuncSpec is never meant to be stored, only exist on the stack
+    class FuncSpec {
+    public:
+        class Arg {
+            const TypeDesc m_type;
+            bool m_derivs;
+            bool m_is_uniform;
+
+        public:
+            Arg(const TypeDesc& type, bool derivs, bool is_uniform)
+                : m_type(type), m_derivs(derivs), m_is_uniform(is_uniform)
+            {
+            }
+
+            const TypeDesc& type() const { return m_type; }
+            bool has_derivs() const { return m_derivs; }
+            bool is_uniform() const { return m_is_uniform; }
+            bool is_varying() const { return !m_is_uniform; }
+        };
+
+    private:
+        const llvm::Twine m_name;
+        bool m_batched;
+        bool m_masked;
+
+        typedef llvm::SmallVector<Arg, 16> ArgVector;
+        ArgVector m_args;
+
+    public:
+        FuncSpec(const FuncSpec&) = delete;
+        FuncSpec& operator=(const FuncSpec&) = delete;
+
+        FuncSpec(const llvm::Twine& name)
+            : m_name(name), m_batched(true), m_masked(false)
+        {
+        }
+
+        FuncSpec(const char* name)
+            : m_name(name), m_batched(true), m_masked(false)
+        {
+        }
+
+        FuncSpec& mask()
+        {
+            m_masked = true;
+            return *this;
+        }
+        FuncSpec& unmask()
+        {
+            m_masked = false;
+            return *this;
+        }
+
+        FuncSpec& batch()
+        {
+            m_batched = true;
+            return *this;
+        }
+
+        FuncSpec& unbatch()
+        {
+            m_batched = false;
+            unmask();
+            return *this;
+        }
+        bool is_masked() const { return m_masked; }
+        bool is_batched() const { return m_batched; }
+
+        const llvm::Twine& name() const { return m_name; }
+
+        FuncSpec& arg(const TypeDesc& type_desc, bool derivs, bool is_uniform)
+        {
+            m_args.emplace_back(type_desc, derivs, is_uniform);
+            return *this;
+        }
+        FuncSpec& arg(const Symbol& sym, bool derivs, bool is_uniform)
+        {
+            OSL_DASSERT(sym.typespec().is_closure() == false);
+            OSL_DASSERT(sym.typespec().is_structure() == false);
+            return arg(sym.typespec().simpletype(), derivs, is_uniform);
+        }
+        FuncSpec& arg(const Symbol& sym, bool is_uniform)
+        {
+            return arg(sym, false /*derivs*/, is_uniform);
+        }
+        FuncSpec& arg(const TypeDesc& type_desc, bool is_uniform)
+        {
+            return arg(type_desc, false /*derivs*/, is_uniform);
+        }
+
+        FuncSpec& arg_uniform(const TypeDesc& type_desc)
+        {
+            return arg(type_desc, false /*derivs*/, true /*is_uniform*/);
+        }
+        FuncSpec& arg_varying(const TypeDesc& type_desc)
+        {
+            return arg(type_desc, false /*derivs*/, false /*is_uniform*/);
+        }
+        FuncSpec& arg_varying(const Symbol& sym)
+        {
+            OSL_DASSERT(sym.typespec().is_closure() == false);
+            OSL_DASSERT(sym.typespec().is_structure() == false);
+            return arg_varying(sym.typespec().simpletype());
+        }
+
+        typedef typename ArgVector::const_iterator const_iterator;
+        const_iterator begin() const { return m_args.begin(); }
+        const_iterator end() const { return m_args.end(); }
+        bool empty() const { return begin() == end(); }
+    };
+
+    /// Generate code for a call to the named function with the given
+    /// arg list as symbols -- float & ints will be passed by value,
+    /// triples and matrices will be passed by address.  If deriv_ptrs
+    /// is true, pass pointers even for floats if they have derivs.
+    /// Return an llvm::Value* corresponding to the return value of the
+    /// function, if any.
+    llvm::Value* llvm_call_function(const FuncSpec& name, const Symbol** args,
+                                    int nargs, bool deriv_ptrs = false,
+                                    bool function_is_uniform       = true,
+                                    bool functionIsLlvmInlined     = false,
+                                    bool ptrToReturnStructIs1stArg = false);
+    llvm::Value* llvm_call_function(const FuncSpec& name, const Symbol& A,
+                                    bool deriv_ptrs = false);
+    llvm::Value* llvm_call_function(const FuncSpec& name, const Symbol& A,
+                                    const Symbol& B, bool deriv_ptrs = false);
+    llvm::Value* llvm_call_function(const FuncSpec& name, const Symbol& A,
+                                    const Symbol& B, const Symbol& C,
+                                    bool deriv_ptrs                = false,
+                                    bool function_is_uniform       = true,
+                                    bool functionIsLlvmInlined     = false,
+                                    bool ptrToReturnStructIs1stArg = false);
+
+    TypeDesc llvm_typedesc(const TypeSpec& typespec)
+    {
+        return typespec.is_closure_based()
+                   ? TypeDesc(TypeDesc::PTR, typespec.arraylength())
+                   : typespec.simpletype();
+    }
+
+    /// Generate the appropriate llvm type definition for a TypeSpec
+    /// (this is the actual type, for example when we allocate it).
+    /// Allocates ptrs for closures.
+    llvm::Type* llvm_type(const TypeSpec& typespec)
+    {
+        return ll.llvm_type(llvm_typedesc(typespec));
+    }
+
+    llvm::Type* llvm_wide_type(const TypeSpec& typespec)
+    {
+        // We are the "wide" backend, so all types will be vector types
+        return ll.llvm_vector_type(llvm_typedesc(typespec));
+    }
+
+    /// Generate the parameter-passing llvm type definition for an OSL
+    /// TypeSpec.
+    llvm::Type* llvm_pass_type(const TypeSpec& typespec);
+    llvm::Type* llvm_pass_wide_type(const TypeSpec& typespec);
+
+    llvm::PointerType* llvm_type_prepare_closure_func()
+    {
+        return m_llvm_type_prepare_closure_func;
+    }
+    llvm::PointerType* llvm_type_setup_closure_func()
+    {
+        return m_llvm_type_setup_closure_func;
+    }
+
+    /// Return the basic block of the exit for the whole instance.
+    ///
+    bool llvm_has_exit_instance_block() const { return m_exit_instance_block; }
+
+    /// Return the basic block of the exit for the whole instance.
+    ///
+    llvm::BasicBlock* llvm_exit_instance_block()
+    {
+        if (!m_exit_instance_block) {
+            std::string name      = Strutil::sprintf("%s_%d_exit_",
+                                                inst()->layername(),
+                                                inst()->id());
+            m_exit_instance_block = ll.new_basic_block(name);
+        }
+        return m_exit_instance_block;
+    }
+
+    /// Check for inf/nan in all written-to arguments of the op
+    void llvm_generate_debugnan(const Opcode& op);
+    /// Check for uninitialized values in all read-from arguments to the op
+    void llvm_generate_debug_uninit(const Opcode& op);
+    /// Print debugging line for the op
+    void llvm_generate_debug_op_printf(const Opcode& op);
+
+    llvm::Function* layer_func() const { return ll.current_function(); }
+
+    /// Call this when JITing a texture-like call, to track how many.
+    void generated_texture_call(bool handle)
+    {
+        shadingsys().m_stat_tex_calls_codegened += 1;
+        if (handle)
+            shadingsys().m_stat_tex_calls_as_handles += 1;
+    }
+
+    void llvm_print_mask(const char* title, llvm::Value* mask = nullptr);
+
+    /// Return the userdata index for the given Symbol.  Return -1 if the Symbol
+    /// is not an input parameter or is constant and therefore doesn't have an
+    /// entry in the groupdata struct.
+    int find_userdata_index(const Symbol& sym);
+
+    LLVM_Util ll;
+
+
+    int vector_width() const { return m_width; }
+    int true_mask_value() const { return m_true_mask_value; }
+
+private:
+    void append_arg_to(llvm::raw_svector_ostream& OS, const FuncSpec::Arg& arg);
+
+public:
+    // Uses internal buffer to store concatenated result,
+    // Assuming the backend is only used single threaded,
+    // the returned string pointer is only valid until the
+    // next call to build_name.
+    // The "osl_" prefix or library selector prefix
+    // is prepended to the function name during build_name
+    const char* build_name(const FuncSpec& func_spec);
+
+private:
+    // Helpers to export the actual data member offsets from LLVM's point of view
+    // of data structures that exist in C++ so we can validate the offsets match
+    template<int WidthT>
+    void build_offsets_of_BatchedShaderGlobals(
+        std::vector<unsigned int>& offset_by_index);
+    template<int WidthT>
+    void build_offsets_of_BatchedTextureOptions(
+        std::vector<unsigned int>& offset_by_index);
+
+    int m_width;
+    int m_true_mask_value;
+
+    // Interface and Factory method to construct a Concrete TargetLibraryHelper
+    // that provides a prefex string that all function calls will start with
+    // and correctly initialize a function map for the shading system with
+    // the functions from the target ISA library.
+    class TargetLibraryHelper {
+    public:
+        virtual ~TargetLibraryHelper() {}
+        virtual const char* library_selector() const                        = 0;
+        virtual void init_function_map(ShadingSystemImpl& shadingsys) const = 0;
+
+        static std::unique_ptr<TargetLibraryHelper> build(int vector_width,
+                                                          TargetISA target_isa);
+    };
+
+    std::unique_ptr<TargetLibraryHelper> m_target_lib_helper;
+    const char* m_library_selector;
+    const char* m_wide_arg_prefix;
+    llvm::SmallString<512> m_built_op_name;
+
+
+    std::vector<int> m_layer_remap;      ///< Remapping of layer ordering
+    std::set<int> m_layers_already_run;  ///< List of layers run
+    int m_num_used_layers;               ///< Number of layers actually used
+
+    double m_stat_total_llvm_time;  ///<   total time spent on LLVM
+    double m_stat_llvm_setup_time;  ///<     llvm setup time
+    double m_stat_llvm_irgen_time;  ///<     llvm IR generation time
+    double m_stat_llvm_opt_time;    ///<     llvm IR optimization time
+    double m_stat_llvm_jit_time;    ///<     llvm JIT time
+
+    // LLVM stuff
+    AllocationMap m_named_values;
+    std::map<const Symbol*, int> m_param_order_map;
+    llvm::Value* m_llvm_shaderglobals_ptr;
+    llvm::Value* m_llvm_groupdata_ptr;
+
+    // Reused allocas for temps used to pass options or intermediates
+    llvm::Value* m_llvm_temp_wide_matrix_ptr;  // for gen_tranform
+    llvm::Value* m_llvm_temp_batched_texture_options_ptr;
+    llvm::Value* m_llvm_temp_batched_trace_options_ptr;
+
+    llvm::BasicBlock* m_exit_instance_block;  // exit point for the instance
+    llvm::Type* m_llvm_type_sg;         // LLVM type of ShaderGlobals struct
+    llvm::Type* m_llvm_type_groupdata;  // LLVM type of group data
+    llvm::Type* m_llvm_type_closure_component;
+    llvm::Type* m_llvm_type_batched_texture_options;
+    llvm::Type* m_llvm_type_batched_trace_options;
+    llvm::PointerType* m_llvm_type_prepare_closure_func;
+    llvm::PointerType* m_llvm_type_setup_closure_func;
+    int m_llvm_local_mem;  // Amount of memory we use for locals
+
+    friend class ShadingSystemImpl;
+};
+
+
+};  // namespace pvt
+OSL_NAMESPACE_EXIT

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -1,0 +1,186 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+#include <set>
+
+#include <llvm/IR/Constant.h>
+
+#include "batched_backendllvm.h"
+
+
+
+using namespace OSL;
+using namespace OSL::pvt;
+
+OSL_NAMESPACE_ENTER
+
+namespace pvt {
+
+
+/// Macro that defines the arguments to LLVM IR generating routines
+///
+#define LLVMGEN_ARGS BatchedBackendLLVM &rop, int opnum
+
+/// Macro that defines the full declaration of an LLVM generator.
+///
+#define LLVMGEN(name) bool name(LLVMGEN_ARGS)
+
+
+
+typedef typename BatchedBackendLLVM::FuncSpec FuncSpec;
+
+
+
+void
+BatchedBackendLLVM::llvm_gen_debug_printf(string_view message)
+{
+    ustring s = ustring::format("(%s %s) %s", inst()->shadername(),
+                                inst()->layername(), message);
+    ll.call_function(build_name("printf"), sg_void_ptr(), ll.constant("%s\n"),
+                     ll.constant(s));
+}
+
+
+
+void
+BatchedBackendLLVM::llvm_call_layer(int layer, bool unconditional)
+{
+    OSL_DEV_ONLY(std::cout << "llvm_call_layer layer=" << layer
+                           << " unconditional=" << unconditional << std::endl);
+    // Make code that looks like:
+    //     if (! groupdata->run[parentlayer])
+    //         parent_layer (sg, groupdata);
+    // if it's a conditional call, or
+    //     parent_layer (sg, groupdata);
+    // if it's run unconditionally.
+    // The code in the parent layer itself will set its 'executed' flag.
+
+    llvm::Value* args[3];
+    args[0] = sg_ptr();
+    args[1] = groupdata_ptr();
+
+    ShaderInstance* parent       = group()[layer];
+    llvm::Value* layerfield      = layer_run_ref(layer_remap(layer));
+    llvm::BasicBlock *then_block = NULL, *after_block = NULL;
+    llvm::Value* lanes_requiring_execution_value = nullptr;
+    if (!unconditional) {
+        llvm::Value* previously_executed = ll.int_as_mask(
+            ll.op_load(layerfield));
+        llvm::Value* lanes_requiring_execution
+            = ll.op_select(previously_executed, ll.wide_constant_bool(false),
+                           ll.current_mask());
+        lanes_requiring_execution_value = ll.mask_as_int(
+            lanes_requiring_execution);
+        llvm::Value* execution_required
+            = ll.op_ne(lanes_requiring_execution_value, ll.constant(0));
+        then_block = ll.new_basic_block(
+            llvm_debug()
+                ? std::string("then layer ").append(std::to_string(layer))
+                : std::string());
+        after_block = ll.new_basic_block(
+            llvm_debug()
+                ? std::string("after layer ").append(std::to_string(layer))
+                : std::string());
+        ll.op_branch(execution_required, then_block, after_block);
+        // insert point is now then_block
+    } else {
+        lanes_requiring_execution_value = ll.mask_as_int(ll.shader_mask());
+    }
+
+    args[2] = lanes_requiring_execution_value;
+
+    // Before the merge, keeping in case we broke it
+    //std::string name = Strutil::format ("%s_%s_%d", m_library_selector,  parent->layername().c_str(),
+    //                                  parent->id());
+    std::string name
+        = Strutil::format("%s_%s", m_library_selector,
+                          layer_function_name(group(), *parent).c_str());
+
+    // Mark the call as a fast call
+    llvm::Value* funccall = ll.call_function(name.c_str(), args);
+    if (!parent->entry_layer())
+        ll.mark_fast_func_call(funccall);
+
+    if (!unconditional)
+        ll.op_branch(after_block);  // also moves insert point
+}
+
+
+
+void
+BatchedBackendLLVM::llvm_run_connected_layers(const Symbol& sym, int symindex,
+                                              int opnum,
+                                              std::set<int>* already_run)
+{
+    if (sym.valuesource() != Symbol::ConnectedVal)
+        return;  // Nothing to do
+
+    OSL_DEV_ONLY(std::cout << "BatchedBackendLLVM::llvm_run_connected_layers "
+                           << sym.name().c_str() << " opnum " << opnum
+                           << std::endl);
+    bool inmain = (opnum >= inst()->maincodebegin()
+                   && opnum < inst()->maincodeend());
+
+    for (int c = 0; c < inst()->nconnections(); ++c) {
+        const Connection& con(inst()->connection(c));
+        // If the connection gives a value to this param
+        if (con.dst.param == symindex) {
+            // already_run is a set of layers run for this particular op.
+            // Just so we don't stupidly do several consecutive checks on
+            // whether we ran this same layer. It's JUST for this op.
+            if (already_run) {
+                if (already_run->count(con.srclayer))
+                    continue;  // already ran that one on this op
+                else
+                    already_run->insert(con.srclayer);  // mark it
+            }
+
+            if (inmain) {
+                // There is an instance-wide m_layers_already_run that tries
+                // to remember which earlier layers have unconditionally
+                // been run at any point in the execution of this layer. But
+                // only honor (and modify) that when in the main code
+                // section, not when in init ops, which are inherently
+                // conditional.
+                if (m_layers_already_run.count(con.srclayer)) {
+                    continue;  // already unconditionally ran the layer
+                }
+                if (!m_in_conditional[opnum]) {
+                    // Unconditionally running -- mark so we don't do it
+                    // again. If we're inside a conditional, don't mark
+                    // because it may not execute the conditional body.
+                    m_layers_already_run.insert(con.srclayer);
+                }
+            }
+
+            // If the earlier layer it comes from has not yet been
+            // executed, do so now.
+            llvm_call_layer(con.srclayer);
+        }
+    }
+}
+
+
+
+// Comparison ops
+LLVMGEN(llvm_gen_compare_op)
+{
+    OSL_ASSERT(0 && "To Be Implemented");
+    return false;
+}
+
+
+
+LLVMGEN(llvm_gen_getattribute)
+{
+    OSL_ASSERT(0 && "To Be Implemented");
+    return false;
+}
+
+
+
+// TODO: rest of gen functions to be added in separate PR
+
+};  // namespace pvt
+OSL_NAMESPACE_EXIT

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -1,0 +1,2517 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/imageworks/OpenShadingLanguage
+
+#include <bitset>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/functional/hash.hpp>
+
+#include <OpenImageIO/filesystem.h>
+#include <OpenImageIO/fmath.h>
+#include <OpenImageIO/plugin.h>
+#include <OpenImageIO/strutil.h>
+#include <OpenImageIO/sysutil.h>
+#include <OpenImageIO/timer.h>
+
+#include <OSL/batched_shaderglobals.h>
+#include <OSL/batched_texture.h>
+
+#include <llvm/IR/Constant.h>
+
+#include "../liboslcomp/oslcomp_pvt.h"
+#include "batched_backendllvm.h"
+#include "oslexec_pvt.h"
+
+// Create extrenal declarations for all built-in funcs we may call from LLVM
+#define DECL(name, signature) extern "C" void name();
+#include "builtindecl.h"
+#undef DECL
+
+
+/*
+This whole file is concerned with taking our post-optimized OSO
+intermediate code and translating it into LLVM IR code so we can JIT it
+and run it directly, for an expected huge speed gain over running our
+interpreter.
+
+Schematically, we want to create code that resembles the following:
+
+    // Assume 2 layers. 
+    struct GroupData_1 {
+        // Array telling if we have already run each layer
+        char layer_run[nlayers];
+        // Array telling if we have already initialized each
+        // needed user data (0 = haven't checked, 1 = checked and there
+        // was no userdata, 2 = checked and there was userdata)
+        char userdata_initialized[num_userdata];
+        // All the user data slots, in order
+        float userdata_s;
+        float userdata_t;
+        // For each layer in the group, we declare all shader params
+        // whose values are not known -- they have init ops, or are
+        // interpolated from the geom, or are connected to other layers.
+        float param_0_foo;   // number is layer ID
+        float param_1_bar;
+    };
+
+    // Name of layer entry is $layer_ID
+    void $layer_0 (ShaderGlobals *sg, GroupData_1 *group)
+    {
+        // Declare locals, temps, constants, params with known values.
+        // Make them all look like stack memory locations:
+        float *x = alloca (sizeof(float));
+        // ...and so on for all the other locals & temps...
+
+        // then run the shader body:
+        *x = sg->u * group->param_0_bar;
+        group->param_1_foo = *x;
+    }
+
+    void $layer_1 (ShaderGlobals *sg, GroupData_1 *group)
+    {
+        // Because we need the outputs of layer 0 now, we call it if it
+        // hasn't already run:
+        if (! group->layer_run[0]) {
+            group->layer_run[0] = 1;
+            $layer_0 (sg, group);    // because we need its outputs
+        }
+        *y = sg->u * group->$param_1_bar;
+    }
+
+    void $group_1 (ShaderGlobals *sg, GroupData_1 *group)
+    {
+        group->layer_run[...] = 0;
+        // Run just the unconditional layers
+
+        if (! group->layer_run[1]) {
+            group->layer_run[1] = 1;
+            $layer_1 (sg, group);
+        }
+    }
+
+*/
+
+extern int osl_llvm_compiled_ops_size;
+extern unsigned char osl_llvm_compiled_ops_block[];
+
+using namespace OSL::pvt;
+
+OSL_NAMESPACE_ENTER
+
+namespace pvt {
+
+static spin_mutex llvm_mutex;
+
+static ustring op_end("end");
+static ustring op_nop("nop");
+static ustring op_aassign("aassign");
+static ustring op_compassign("compassign");
+static ustring op_mxcompassign("mxcompassign");
+static ustring op_aref("aref");
+static ustring op_compref("compref");
+static ustring op_mxcompref("mxcompref");
+static ustring op_useparam("useparam");
+static ustring unknown_shader_group_name("<Unknown Shader Group Name>");
+
+
+static TypeSpec
+possibly_wide_type_from_code(const char* code, int* advance, bool& is_uniform)
+{
+    // Codes leading with a W stand for "wide" and have varying non-uniform values
+    int i = 0;
+    if (code[0] == 'W') {
+        is_uniform = false;
+        ++i;
+    } else {
+        is_uniform = true;
+    }
+
+    TypeSpec t = OSLCompilerImpl::type_from_code(code + i, advance);
+
+    if (advance)
+        *advance += i;
+    return t;
+}
+
+struct HelperFuncRecord {
+    const char* argtypes;
+    void (*function)();
+    int vector_width;
+    TargetISA target_isa;
+
+    OSL_FORCEINLINE HelperFuncRecord(const char* argtypes_ = NULL,
+                                     void (*function_)()   = NULL,
+                                     int vector_width_     = 0,
+                                     TargetISA target_isa_ = TargetISA::UNKNOWN)
+        : argtypes(argtypes_)
+        , function(function_)
+        , vector_width(vector_width_)
+        , target_isa(target_isa_)
+    {
+    }
+
+    OSL_FORCEINLINE HelperFuncRecord(const HelperFuncRecord& other)
+        : argtypes(other.argtypes)
+        , function(other.function)
+        , vector_width(other.vector_width)
+        , target_isa(other.target_isa)
+    {
+    }
+};
+
+// As we will be using compile time const char * to populate the HelperFuncMap
+// We avoid std::string (which would create a copy), and instead just store
+// the const char *, however we must supply our own hashing and equality
+// functors to the map to avoid default behavior of using the pointer vs.
+// the string it points to, in C++20 std::string_view could be used
+struct CStrHash {
+    OSL_FORCEINLINE size_t operator()(const char* str) const
+    {
+        OSL_DASSERT(str != nullptr);
+        size_t seed = 0;
+        for (;;) {
+            char c = *str;
+            if (c == 0)
+                break;
+            boost::hash_combine<char>(seed, c);
+            ++str;
+        }
+        return seed;
+    }
+};
+struct CStrEquality {
+    OSL_FORCEINLINE bool operator()(const char* lhs, const char* rhs) const
+    {
+        bool is_equal = (strcmp(lhs, rhs) == 0);
+        return is_equal;
+    }
+};
+typedef std::unordered_map<const char*, HelperFuncRecord, CStrHash, CStrEquality>
+    HelperFuncMap;
+static HelperFuncMap llvm_helper_function_map;
+static atomic_int llvm_helper_function_map_initialized(0);
+static spin_mutex llvm_helper_function_map_mutex;
+
+static void
+initialize_llvm_helper_function_map()
+{
+    if (llvm_helper_function_map_initialized)
+        return;  // already done
+    spin_lock lock(llvm_helper_function_map_mutex);
+    if (llvm_helper_function_map_initialized)
+        return;
+#define DECL(name, signature) \
+    llvm_helper_function_map[#name] = HelperFuncRecord(signature, name);
+#include "builtindecl.h"
+#undef DECL
+
+    llvm_helper_function_map_initialized = 1;
+}
+
+struct NameAndSignature {
+    const char* name;
+    const char* signature;
+};
+
+// As we don't now the sizeof ConcreteT::library_functions until specialization,
+// we need a helper template function to defer its resolution
+template<typename ConcreteT>
+static void
+init_wide_function_map(const ConcreteT&, ShadingSystemImpl& shadingsys)
+{
+    static atomic_int is_initialized(0);
+
+    if (is_initialized)
+        return;  // already done
+    spin_lock lock(llvm_helper_function_map_mutex);
+    if (is_initialized)
+        return;
+
+    const char* shared_lib_ext  = OIIO::Plugin::plugin_extension();
+    std::string shared_lib_name = std::string("lib_")
+                                  + ConcreteT::library_selector_string
+                                  + "oslexec." + shared_lib_ext;
+    //std::cout << ">>>Attempting to open shared lib:  " << shared_lib_name.c_str() << std::endl;
+
+    std::string filename = OIIO::Filesystem::searchpath_find(
+        shared_lib_name, shadingsys.library_searchpath_dirs());
+
+    // TODO: consider trying to open it even if searchpath_find failed, so that LD_LIBRARY_PATH has a chance
+    if (filename.empty()) {
+        shadingsys.errorf(
+            "%s could not be found along the attribute \"searchpath:library\" of \"%s\"",
+            shared_lib_name.c_str(), shadingsys.library_searchpath().c_str());
+        // Something later will ASSERT/Fail now, we can't really continue successfully
+        return;
+    }
+
+
+    auto shared_lib = OIIO::Plugin::open(filename, /*global=*/false);
+    if (shared_lib == 0) {
+        shadingsys.errorf("%s could not be loaded with error \"%s\"",
+                          filename.c_str(), OIIO::Plugin::geterror().c_str());
+        // Something later will ASSERT/Fail, now we can't really continue successfully
+        return;
+    }
+
+    typedef void (*FunctionPtr)();
+
+    for (const auto& name_and_sig : ConcreteT::library_functions) {
+        //std::cout << ">>>Attempting to getsym " << name_and_sig.name << std::endl;
+        FunctionPtr function_pointer = reinterpret_cast<FunctionPtr>(
+            OIIO::Plugin::getsym(shared_lib, name_and_sig.name,
+                                 /*report_error*/ true));
+        if (function_pointer == nullptr) {
+            std::cout << ">>>Failed attempting to getsym " << name_and_sig.name
+                      << std::endl
+                      << "OIIO::Plugin::geterror()="
+                      << OIIO::Plugin::geterror().c_str();
+            ASSERT(
+                0
+                && "Unable to find precompiled OSL library function in shared library.  This indicates a build/configuration problem.  We can't continue");
+        }
+        llvm_helper_function_map[name_and_sig.name]
+            = HelperFuncRecord(name_and_sig.signature, function_pointer,
+                               ConcreteT::width, ConcreteT::isa);
+    }
+
+    is_initialized = 1;
+}
+
+template<int WidthT, TargetISA IsaT>
+class ConcreteTargetLibraryHelper final
+    : public BatchedBackendLLVM::TargetLibraryHelper {
+public:
+    ConcreteTargetLibraryHelper() {}
+    ~ConcreteTargetLibraryHelper() final {}
+
+    static constexpr int width     = WidthT;
+    static constexpr TargetISA isa = IsaT;
+
+    // Specialize instances for each supported Width and IsaT combo
+    static const NameAndSignature library_functions[];
+    static const char* library_selector_string;
+
+    void init_function_map(ShadingSystemImpl& shadingsys) const final
+    {
+        init_wide_function_map(*this, shadingsys);
+    }
+
+    const char* library_selector() const final
+    {
+        return library_selector_string;
+    }
+};
+
+// Specialize ConcreteTargetLibraryHelper<>::library_functions and
+// ConcreteTargetLibraryHelper<>::library_selector_string for each
+// WidthT and TargetISA that we are building a shared library for.
+// To identify these shared libraries, the build system should define:
+// __OSL_SUPPORTS_B##WidthT##_##TargetISA
+// You will see conditional compilation around specilization below...
+
+// NOTE:  Because builtindecl_wide_xmacro.h passes macros through the name
+// parameter of DECL(name,signature), we must have a layer of indirection
+// to allow those macros to expand.  Thus the use of DECL_INDIRECT.
+#ifdef __OSL_SUPPORTS_B16_AVX512
+template<>
+const NameAndSignature
+    ConcreteTargetLibraryHelper<16, TargetISA::AVX512>::library_functions[]
+    = {
+#    define DECL_INDIRECT(name, signature) \
+        NameAndSignature { #name, signature },
+#    define DECL(name, signature) DECL_INDIRECT(name, signature)
+#    define __OSL_WIDTH           16
+#    define __OSL_TARGET_ISA      AVX512
+#    include "builtindecl_wide_xmacro.h"
+#    include "wide/define_opname_macros.h"
+#    include "wide/undef_opname_macros.h"
+#    undef __OSL_TARGET_ISA
+#    undef __OSL_WIDTH
+#    undef DECL
+#    undef DECL_INDIRECT
+      };
+template<>
+const char*
+    ConcreteTargetLibraryHelper<16, TargetISA::AVX512>::library_selector_string
+    = "b16_AVX512_";
+#endif
+
+#ifdef __OSL_SUPPORTS_B16_AVX512_NOFMA
+template<>
+const NameAndSignature
+    ConcreteTargetLibraryHelper<16, TargetISA::AVX512_noFMA>::library_functions[]
+    = {
+#    define DECL_INDIRECT(name, signature) \
+        NameAndSignature { #name, signature },
+#    define DECL(name, signature) DECL_INDIRECT(name, signature)
+#    define __OSL_WIDTH           16
+#    define __OSL_TARGET_ISA      AVX512_noFMA
+#    include "builtindecl_wide_xmacro.h"
+#    include "wide/define_opname_macros.h"
+#    include "wide/undef_opname_macros.h"
+#    undef __OSL_TARGET_ISA
+#    undef __OSL_WIDTH
+#    undef DECL
+#    undef DECL_INDIRECT
+      };
+template<>
+const char* ConcreteTargetLibraryHelper<
+    16, TargetISA::AVX512_noFMA>::library_selector_string
+    = "b16_AVX512_noFMA_";
+#endif
+
+#ifdef __OSL_SUPPORTS_B8_AVX512
+template<>
+const NameAndSignature
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX512>::library_functions[]
+    = {
+#    define DECL_INDIRECT(name, signature) \
+        NameAndSignature { #name, signature },
+#    define DECL(name, signature) DECL_INDIRECT(name, signature)
+#    define __OSL_WIDTH           8
+#    define __OSL_TARGET_ISA      AVX512
+#    include "builtindecl_wide_xmacro.h"
+#    include "wide/define_opname_macros.h"
+#    include "wide/undef_opname_macros.h"
+#    undef __OSL_TARGET_ISA
+#    undef __OSL_WIDTH
+#    undef DECL
+#    undef DECL_INDIRECT
+      };
+template<>
+const char*
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX512>::library_selector_string
+    = "b8_AVX512_";
+#endif
+
+#ifdef __OSL_SUPPORTS_B8_AVX512_NOFMA
+template<>
+const NameAndSignature
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX512_noFMA>::library_functions[]
+    = {
+#    define DECL_INDIRECT(name, signature) \
+        NameAndSignature { #name, signature },
+#    define DECL(name, signature) DECL_INDIRECT(name, signature)
+#    define __OSL_WIDTH           8
+#    define __OSL_TARGET_ISA      AVX512_noFMA
+#    include "builtindecl_wide_xmacro.h"
+#    include "wide/define_opname_macros.h"
+#    include "wide/undef_opname_macros.h"
+#    undef __OSL_TARGET_ISA
+#    undef __OSL_WIDTH
+#    undef DECL
+#    undef DECL_INDIRECT
+      };
+template<>
+const char* ConcreteTargetLibraryHelper<
+    8, TargetISA::AVX512_noFMA>::library_selector_string
+    = "b8_AVX512_noFMA_";
+#endif
+
+#ifdef __OSL_SUPPORTS_B8_AVX2
+template<>
+const NameAndSignature
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX2>::library_functions[]
+    = {
+#    define DECL_INDIRECT(name, signature) \
+        NameAndSignature { #name, signature },
+#    define DECL(name, signature) DECL_INDIRECT(name, signature)
+#    define __OSL_WIDTH           8
+#    define __OSL_TARGET_ISA      AVX2
+#    include "builtindecl_wide_xmacro.h"
+#    include "wide/define_opname_macros.h"
+#    include "wide/undef_opname_macros.h"
+#    undef __OSL_TARGET_ISA
+#    undef __OSL_WIDTH
+#    undef DECL
+#    undef DECL_INDIRECT
+      };
+template<>
+const char*
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX2>::library_selector_string
+    = "b8_AVX2_";
+#endif
+
+#ifdef __OSL_SUPPORTS_B8_AVX2_NOFMA
+template<>
+const NameAndSignature
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX2_noFMA>::library_functions[]
+    = {
+#    define DECL_INDIRECT(name, signature) \
+        NameAndSignature { #name, signature },
+#    define DECL(name, signature) DECL_INDIRECT(name, signature)
+#    define __OSL_WIDTH           8
+#    define __OSL_TARGET_ISA      AVX2_noFMA
+#    include "builtindecl_wide_xmacro.h"
+#    include "wide/define_opname_macros.h"
+#    include "wide/undef_opname_macros.h"
+#    undef __OSL_TARGET_ISA
+#    undef __OSL_WIDTH
+#    undef DECL
+#    undef DECL_INDIRECT
+      };
+template<>
+const char*
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX2_noFMA>::library_selector_string
+    = "b8_AVX2_noFMA_";
+#endif
+
+#ifdef __OSL_SUPPORTS_B8_AVX
+template<>
+const NameAndSignature
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX>::library_functions[]
+    = {
+#    define DECL_INDIRECT(name, signature) \
+        NameAndSignature { #name, signature },
+#    define DECL(name, signature) DECL_INDIRECT(name, signature)
+#    define __OSL_WIDTH           8
+#    define __OSL_TARGET_ISA      AVX
+#    include "builtindecl_wide_xmacro.h"
+#    include "wide/define_opname_macros.h"
+#    include "wide/undef_opname_macros.h"
+#    undef __OSL_TARGET_ISA
+#    undef __OSL_WIDTH
+#    undef DECL
+#    undef DECL_INDIRECT
+      };
+template<>
+const char*
+    ConcreteTargetLibraryHelper<8, TargetISA::AVX>::library_selector_string
+    = "b8_AVX_";
+#endif
+
+std::unique_ptr<BatchedBackendLLVM::TargetLibraryHelper>
+BatchedBackendLLVM::TargetLibraryHelper::build(int vector_width,
+                                               TargetISA target_isa)
+{
+    typedef std::unique_ptr<BatchedBackendLLVM::TargetLibraryHelper> RetType;
+    switch (vector_width) {
+    case 16:
+        switch (target_isa) {
+#ifdef __OSL_SUPPORTS_B16_AVX512
+        case TargetISA::AVX512:
+            return RetType(
+                new ConcreteTargetLibraryHelper<16, TargetISA::AVX512>());
+#endif
+#ifdef __OSL_SUPPORTS_B16_AVX512_NOFMA
+        case TargetISA::AVX512_noFMA:
+            return RetType(
+                new ConcreteTargetLibraryHelper<16, TargetISA::AVX512_noFMA>());
+#endif
+        default:
+            OSL_ASSERT(0 && "unsupported target ISA for vector width of 16");
+        }
+    case 8:
+        switch (target_isa) {
+#ifdef __OSL_SUPPORTS_B8_AVX512
+        case TargetISA::AVX512:
+            return RetType(
+                new ConcreteTargetLibraryHelper<8, TargetISA::AVX512>());
+#endif
+#ifdef __OSL_SUPPORTS_B8_AVX512_NOFMA
+        case TargetISA::AVX512_noFMA:
+            return RetType(
+                new ConcreteTargetLibraryHelper<8, TargetISA::AVX512_noFMA>());
+#endif
+#ifdef __OSL_SUPPORTS_B8_AVX2
+        case TargetISA::AVX2:
+            return RetType(
+                new ConcreteTargetLibraryHelper<8, TargetISA::AVX2>());
+#endif
+#ifdef __OSL_SUPPORTS_B8_AVX2_NOFMA
+        case TargetISA::AVX2_noFMA:
+            return RetType(
+                new ConcreteTargetLibraryHelper<8, TargetISA::AVX2_noFMA>());
+#endif
+#ifdef __OSL_SUPPORTS_B8_AVX
+        case TargetISA::AVX:
+            return RetType(
+                new ConcreteTargetLibraryHelper<8, TargetISA::AVX>());
+#endif
+        default:
+            OSL_ASSERT(0 && "unsupported target ISA for vector width of 8");
+        }
+    default: OSL_ASSERT(0 && "unsupported vector width");
+    }
+    return nullptr;
+}
+
+
+static void*
+helper_function_lookup(const std::string& name)
+{
+    OSL_DEV_ONLY(std::cout << "helper_function_lookup (" << name << ")"
+                           << std::endl);
+    HelperFuncMap::const_iterator i = llvm_helper_function_map.find(
+        name.c_str());
+    if (i == llvm_helper_function_map.end()) {
+        // built-in functions like memset wouldn't be in this lookup
+        //std::cout << "DIDN'T FIND helper_function_lookup (" << name << ")" << std::endl;
+        //for(auto v:llvm_helper_function_map) {
+        //    std::cout << "llvm_helper_function_map [" << v.first << "]" << std::endl;
+        //}
+        return NULL;
+    }
+    return (void*)i->second.function;
+}
+
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_type_sg()
+{
+    // Create a type that defines the ShaderGlobals for LLVM IR.  This
+    // absolutely MUST exactly match the ShaderGlobals struct in oslexec.h.
+    if (m_llvm_type_sg)
+        return m_llvm_type_sg;
+
+    // Derivs look like arrays of 3 values
+    llvm::Type* wide_float_deriv = llvm_wide_type(
+        TypeDesc(TypeDesc::FLOAT, TypeDesc::SCALAR, 3));
+    llvm::Type* wide_triple_deriv = llvm_wide_type(
+        TypeDesc(TypeDesc::FLOAT, TypeDesc::VEC3, 3));
+
+    llvm::Type* vp      = (llvm::Type*)ll.type_void_ptr();
+    llvm::Type* wide_vp = (llvm::Type*)ll.type_wide_void_ptr();
+
+    std::vector<llvm::Type*> sg_types;
+
+    // Uniform values of the batch
+    sg_types.push_back(vp);             // opaque renderstate*
+    sg_types.push_back(vp);             // opaque tracedata*
+    sg_types.push_back(vp);             // opaque objdata*
+    sg_types.push_back(vp);             // ShadingContext*
+    sg_types.push_back(vp);             // RendererServices*
+    sg_types.push_back(vp);             // Ci
+    sg_types.push_back(ll.type_int());  // raytype
+    sg_types.push_back(ll.type_int());  // pad0
+    sg_types.push_back(ll.type_int());  // pad1
+    sg_types.push_back(ll.type_int());  // pad2
+
+
+    // VaryingShaderGlobals of the batch
+    sg_types.push_back(wide_triple_deriv);      // P, dPdx, dPdy
+    sg_types.push_back(ll.type_wide_triple());  // dPdz
+    sg_types.push_back(wide_triple_deriv);      // I, dIdx, dIdy
+    sg_types.push_back(ll.type_wide_triple());  // N
+    sg_types.push_back(ll.type_wide_triple());  // Ng
+    sg_types.push_back(wide_float_deriv);       // u, dudx, dudy
+    sg_types.push_back(wide_float_deriv);       // v, dvdx, dvdy
+    sg_types.push_back(ll.type_wide_triple());  // dPdu
+    sg_types.push_back(ll.type_wide_triple());  // dPdv
+    sg_types.push_back(ll.type_wide_float());   // time
+    sg_types.push_back(ll.type_wide_float());   // dtime
+    sg_types.push_back(ll.type_wide_triple());  // dPdtime
+    sg_types.push_back(wide_triple_deriv);      // Ps, dPsdx, dPsdy;
+
+    sg_types.push_back(wide_vp);  // object2common
+    sg_types.push_back(wide_vp);  // shader2common
+
+    sg_types.push_back(ll.type_wide_float());  // surfacearea
+    sg_types.push_back(ll.type_wide_int());    // flipHandedness
+    sg_types.push_back(ll.type_wide_int());    // backfacing
+
+    return m_llvm_type_sg = ll.type_struct(sg_types, "BatchedShaderGlobals",
+                                           true /*is_packed*/);
+}
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_type_batched_texture_options()
+{
+    // Create a type that defines the BatchedTextureOptions for LLVM IR.  This
+    // absolutely MUST exactly match the BatchedTextureOptions struct in batched_texture.h.
+    if (m_llvm_type_batched_texture_options)
+        return m_llvm_type_batched_texture_options;
+
+    llvm::Type* vp = (llvm::Type*)ll.type_void_ptr();
+
+    std::vector<llvm::Type*> sg_types;
+
+    // Varying values of the batch
+    sg_types.push_back(ll.type_wide_float());  // sblur
+    sg_types.push_back(ll.type_wide_float());  // tblur
+    sg_types.push_back(ll.type_wide_float());  // rblur
+    sg_types.push_back(ll.type_wide_float());  // swidth
+    sg_types.push_back(ll.type_wide_float());  // twidth
+    sg_types.push_back(ll.type_wide_float());  // rwidth
+
+    // Uniform values of the batch
+    sg_types.push_back(ll.type_int());                 // firstchannel
+    sg_types.push_back(ll.type_int());                 // subimage
+    sg_types.push_back(vp);                            // subimagename
+    sg_types.push_back(ll.type_int());                 // swrap
+    sg_types.push_back(ll.type_int());                 // twrap
+    sg_types.push_back(ll.type_int());                 // rwrap
+    sg_types.push_back(ll.type_int());                 // mipmode
+    sg_types.push_back(ll.type_int());                 // interpmode
+    sg_types.push_back(ll.type_int());                 // anisotropic
+    sg_types.push_back(ll.type_int());                 // conservative_filter
+    sg_types.push_back(ll.type_float());               // fill
+    sg_types.push_back(ll.type_ptr(ll.type_float()));  // missingcolor
+
+    // Private internal data
+    sg_types.push_back(ll.type_int());  // envlayout
+
+    m_llvm_type_batched_texture_options
+        = ll.type_struct(sg_types, "BatchedTextureOptions",
+                         false /*is_packed*/);
+
+
+#if 0 && defined(OSL_DEV)
+    std::cout << std::endl << std::endl << "llvm's data layout of BatchedTextureOptions" << std::endl;
+    ll.dump_struct_data_layout(llvm_type_batched_texture_options());
+#endif
+
+    {
+        std::vector<unsigned int> offset_by_index;
+        switch (m_width) {
+        case 8:
+            build_offsets_of_BatchedTextureOptions<8>(offset_by_index);
+            break;
+        case 16:
+            build_offsets_of_BatchedTextureOptions<16>(offset_by_index);
+            break;
+        default:
+            OSL_ASSERT(
+                0
+                && "Unsupported width of batch.  Only widths 4, 8, and 16 are allowed");
+            break;
+        };
+
+        ll.validate_struct_data_layout(m_llvm_type_batched_texture_options,
+                                       offset_by_index);
+        // std::cout<<"After texture validation"<<std::endl;
+    }
+
+    return m_llvm_type_batched_texture_options;
+}
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_type_batched_trace_options()
+{
+    // Create a type that defines the BatchedTraceOptions for LLVM IR.  This
+    // absolutely MUST exactly match the BatchedTraceOptions struct in batched_texture.h.
+    if (m_llvm_type_batched_trace_options)
+        return m_llvm_type_batched_trace_options;
+
+    std::vector<llvm::Type*> sg_types;
+
+    // Uniform values of the batch
+    sg_types.push_back(ll.type_float());  // mindist
+    sg_types.push_back(ll.type_float());  // maxdist
+    sg_types.push_back(ll.type_int());    // shade
+    sg_types.push_back(
+        reinterpret_cast<llvm::Type*>(ll.type_string()));  // traceset
+
+    m_llvm_type_batched_trace_options = ll.type_struct(sg_types, "TraceOptions",
+                                                       false /*is_packed*/);
+
+    {
+        std::vector<unsigned int> offset_by_index;
+
+        offset_by_index.push_back(
+            offsetof(RendererServices::TraceOpt, mindist));
+        offset_by_index.push_back(
+            offsetof(RendererServices::TraceOpt, maxdist));
+        offset_by_index.push_back(offsetof(RendererServices::TraceOpt, shade));
+        offset_by_index.push_back(
+            offsetof(RendererServices::TraceOpt, traceset));
+        //        std::cout<<"Offset vec size is "<<offset_by_index.size()<<std::endl;
+        //        std::cout<<"Offset by index size is "<<offset_by_index.size()<<std::endl;
+        //        std::cout<<"Offset_by_index[0] "<<offset_by_index[0]<<std::endl;
+        //        std::cout<<"Offset_by_index[1] "<<offset_by_index[1]<<std::endl;
+        //        std::cout<<"Offset_by_index[2] "<<offset_by_index[2]<<std::endl;
+        //        std::cout<<"Offset_by_index[3] "<<offset_by_index[3]<<std::endl;
+
+        ll.validate_struct_data_layout(m_llvm_type_batched_trace_options,
+                                       offset_by_index);
+    }
+
+    return m_llvm_type_batched_trace_options;
+}
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_type_sg_ptr()
+{
+    return ll.type_ptr(llvm_type_sg());
+}
+
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_type_groupdata()
+{
+    // If already computed, return it
+    if (m_llvm_type_groupdata)
+        return m_llvm_type_groupdata;
+
+    std::vector<llvm::Type*> fields;
+    int offset = 0;
+    int order  = 0;
+
+    if (llvm_debug() >= 2)
+        std::cout << "Group param struct:\n";
+
+    // First, add the array that tells if each layer has run.  But only make
+    // slots for the layers that may be called/used.
+    if (llvm_debug() >= 2)
+        std::cout << "  layers run flags: " << m_num_used_layers
+                  << " at offset " << offset << "\n";
+    // The next item in the data structure has 64 byte alignment, so we need to move our offset to a 64 byte alignment
+    // Round up to a 64 bit boundary
+    int sz = 16 * ((m_num_used_layers + 15) / 16);
+    OSL_ASSERT(sz * sizeof(int) % 16 == 0);
+    fields.push_back(ll.type_array(ll.type_int(), sz));
+    offset += sz * sizeof(int);
+    ++order;
+
+    // Now add the array that tells which userdata have been initialized,
+    // and the space for the userdata values.
+    int nuserdata = (int)group().m_userdata_names.size();
+    if (nuserdata) {
+        if (llvm_debug() >= 2)
+            std::cout << "  userdata initialized flags: " << nuserdata
+                      << " at offset " << offset << ", field " << order << "\n";
+        ustring* names = &group().m_userdata_names[0];
+        OSL_DEV_ONLY(std::cout << "USERDATA " << *names << std::endl);
+        TypeDesc* types = &group().m_userdata_types[0];
+        int* offsets    = &group().m_userdata_offsets[0];
+        int sz          = nuserdata;
+        fields.push_back(ll.type_array(ll.type_int(), sz));
+        offset += nuserdata * sizeof(int);
+        ++order;
+        for (int i = 0; i < nuserdata; ++i) {
+            TypeDesc type = types[i];
+            // TODO: why do we always make deriv room? Do we not know
+            int n         = type.numelements() * 3;  // always make deriv room
+            type.arraylen = n;
+            fields.push_back(llvm_wide_type(type));
+            // Alignment
+            int align = type.basesize() * m_width;
+            offset    = OIIO::round_to_multiple_of_pow2(offset, align);
+            if (llvm_debug() >= 2) {
+                std::cout << "  userdata ";
+                if (names[i] != nullptr) {
+                    std::cout << names[i];
+                } else {
+                    std::cout << i;
+                }
+                std::cout << ' ' << type << ", field " << order << ", offset "
+                          << offset << std::endl;
+            }
+            offsets[i] = offset;
+            offset += int(type.size()) * m_width;
+            ++order;
+        }
+    }
+
+    // For each layer in the group, add entries for all params that are
+    // connected or interpolated, and output params.  Also mark those
+    // symbols with their offset within the group struct.
+    m_param_order_map.clear();
+    for (int layer = 0; layer < group().nlayers(); ++layer) {
+        ShaderInstance* inst = group()[layer];
+        // TODO:  Does anything bad happen from not skipping unused layers?
+        // We wanted space for default parameters to still be
+        // part of group data so we have a place to create a wide version
+        // So we choose to always have a run function for a layer
+        // just to broadcast out the scalar default value.
+        // TODO: Optimize to only run unused layers once, shouldn't
+        // need to be run again as nothing should overwrite the values.
+        FOREACH_PARAM(Symbol & sym, inst)
+        {
+            TypeSpec ts = sym.typespec();
+            if (ts.is_structure())  // skip the struct symbol itself
+                continue;
+            const int arraylen  = std::max(1, sym.typespec().arraylength());
+            const int derivSize = (sym.has_derivs() ? 3 : 1);
+            ts.make_array(arraylen * derivSize);
+            fields.push_back(llvm_wide_type(ts));
+
+            // Alignment
+            // TODO:  this isn't quite right, cant rely on batch size to == ISA SIMD requirements
+            size_t align = sym.typespec().is_closure_based()
+                               ? sizeof(void*)
+                               : sym.typespec().simpletype().basesize()
+                                     * m_width;
+            if (offset & (align - 1))
+                offset += align - (offset & (align - 1));
+            if (llvm_debug() >= 2)
+                std::cout << "  " << inst->layername() << " (" << inst->id()
+                          << ") " << sym.mangled() << " " << ts.c_str()
+                          << ", field " << order << ", size "
+                          << derivSize * int(sym.size()) << ", offset "
+                          << offset << std::endl;
+            sym.wide_dataoffset((int)offset);
+            offset += derivSize * int(sym.size()) * m_width;
+
+            m_param_order_map[&sym] = order;
+            ++order;
+        }
+    }
+    group().llvm_groupdata_wide_size(offset);
+    if (llvm_debug() >= 2)
+        std::cout << " Group struct had " << order << " fields, total size "
+                  << offset << "\n\n";
+
+    std::string groupdataname
+        = Strutil::sprintf("Groupdata_%llu",
+                           (long long unsigned int)group().name().hash());
+    m_llvm_type_groupdata = ll.type_struct(fields, groupdataname,
+                                           false /*is_packed*/);
+
+    return m_llvm_type_groupdata;
+}
+
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_type_groupdata_ptr()
+{
+    return ll.type_ptr(llvm_type_groupdata());
+}
+
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_type_closure_component()
+{
+    if (m_llvm_type_closure_component)
+        return m_llvm_type_closure_component;
+
+    std::vector<llvm::Type*> comp_types;
+    comp_types.push_back(ll.type_int());     // id
+    comp_types.push_back(ll.type_triple());  // w
+    comp_types.push_back(ll.type_int());     // fake field for char mem[4]
+
+    return m_llvm_type_closure_component = ll.type_struct(comp_types,
+                                                          "ClosureComponent");
+}
+
+
+
+llvm::Type*
+BatchedBackendLLVM::llvm_type_closure_component_ptr()
+{
+    return ll.type_ptr(llvm_type_closure_component());
+}
+
+
+
+void
+BatchedBackendLLVM::llvm_assign_initial_value(
+    const Symbol& sym, llvm::Value* llvm_initial_shader_mask_value, bool force)
+{
+    // Don't write over connections!  Connection values are written into
+    // our layer when the earlier layer is run, as part of its code.  So
+    // we just don't need to initialize it here at all.
+    if (!force && sym.valuesource() == Symbol::ConnectedVal
+        && !sym.typespec().is_closure_based())
+        return;
+    if (sym.typespec().is_closure_based() && sym.symtype() == SymTypeGlobal)
+        return;
+
+    int arraylen = std::max(1, sym.typespec().arraylength());
+
+    // Closures need to get their storage before anything can be
+    // assigned to them.  Unless they are params, in which case we took
+    // care of it in the group entry point.
+    if (sym.typespec().is_closure_based() && sym.symtype() != SymTypeParam
+        && sym.symtype() != SymTypeOutputParam) {
+        llvm_assign_zero(sym);
+        return;
+    }
+
+    if ((sym.symtype() == SymTypeLocal || sym.symtype() == SymTypeTemp)
+        && shadingsys().debug_uninit()) {
+        // Handle the "debug uninitialized values" case
+        bool isarray   = sym.typespec().is_array();
+        int alen       = isarray ? sym.typespec().arraylength() : 1;
+        llvm::Value* u = NULL;
+        if (sym.typespec().is_closure_based()) {
+            // skip closures
+        } else if (sym.typespec().is_float_based()) {
+            u = sym.is_uniform()
+                    ? ll.constant(std::numeric_limits<float>::quiet_NaN())
+                    : ll.wide_constant(std::numeric_limits<float>::quiet_NaN());
+        } else if (sym.typespec().is_int_based()) {
+            // Because we allow temporaries and local results of comparison operations
+            // to use the native bool type of i1, we can just skip initializing these
+            // as they should always be assigned a value.
+            // We can just interrogate the underlying llvm symbol to see if
+            // it is a bool
+            llvm::Value* llvmValue = llvm_get_pointer(sym);
+            if (ll.llvm_typeof(llvmValue) != ll.type_ptr(ll.type_bool())
+                && ll.llvm_typeof(llvmValue)
+                       != ll.type_ptr(ll.type_wide_bool())) {
+                u = sym.is_uniform()
+                        ? ll.constant(std::numeric_limits<int>::min())
+                        : ll.wide_constant(std::numeric_limits<int>::min());
+            }
+        } else if (sym.typespec().is_string_based()) {
+            u = sym.is_uniform()
+                    ? ll.constant(Strings::uninitialized_string)
+                    : ll.wide_constant(Strings::uninitialized_string);
+        }
+        if (u) {
+            //std::cout << "Assigning uninit value to symbol=" << sym.name().c_str() << std::endl;
+            for (int a = 0; a < alen; ++a) {
+                llvm::Value* aval = isarray ? ll.constant(a) : NULL;
+                for (int c = 0; c < (int)sym.typespec().aggregate(); ++c)
+                    llvm_store_value(u, sym, 0, aval, c);
+            }
+        }
+        return;
+    }
+
+    if ((sym.symtype() == SymTypeLocal || sym.symtype() == SymTypeTemp)
+        && sym.typespec().is_string_based()) {
+        // Strings are pointers.  Can't take any chance on leaving
+        // local/tmp syms uninitialized.
+        llvm_assign_zero(sym);
+        return;  // we're done, the parts below are just for params
+    }
+    ASSERT_MSG(sym.symtype() == SymTypeParam
+                   || sym.symtype() == SymTypeOutputParam,
+               "symtype was %d, data type was %s", (int)sym.symtype(),
+               sym.typespec().c_str());
+
+    // Handle interpolated params by calling osl_bind_interpolated_param,
+    // which will check if userdata is already retrieved, if not it will
+    // call RendererServices::get_userdata to retrieve it. In either case,
+    // it will return 1 if it put the userdata in the right spot (either
+    // retrieved de novo or copied from a previous retrieval), or 0 if no
+    // such userdata was available.
+    llvm::BasicBlock* after_userdata_block = NULL;
+    bool partial_userdata_mask_was_pushed  = false;
+    LLVM_Util::ScopedMasking partial_data_masking_scope;
+    if (!sym.lockgeom() && !sym.typespec().is_closure()
+        && !(sym.symtype() == SymTypeOutputParam)) {
+        ustring symname = sym.name();
+        TypeDesc type   = sym.typespec().simpletype();
+
+        int userdata_index = find_userdata_index(sym);
+        OSL_ASSERT(userdata_index >= 0);
+
+        // User connectable params must be varying
+        OSL_ASSERT(sym.is_varying());
+        std::vector<llvm::Value*> args;
+        args.push_back(sg_void_ptr());
+        args.push_back(ll.constant(symname));
+#ifdef OSL_EXPERIMENTAL_BIND_USER_DATA_WITH_LAYERNAME
+        args.push_back(ll.constant(inst()->layername()));
+#endif
+        args.push_back(ll.constant(type));
+        args.push_back(
+            ll.constant((int)group().m_userdata_derivs[userdata_index]));
+        args.push_back(
+            groupdata_field_ptr(2 + userdata_index));  // userdata data ptr
+        args.push_back(ll.constant((int)sym.has_derivs()));
+        args.push_back(llvm_void_ptr(sym));
+        args.push_back(ll.constant(sym.derivsize() * m_width));
+        args.push_back(ll.void_ptr(userdata_initialized_ref(userdata_index)));
+        args.push_back(ll.constant(userdata_index));
+        args.push_back(llvm_initial_shader_mask_value);
+        llvm::Value* got_userdata
+            = ll.call_function(build_name("bind_interpolated_param"), args);
+        llvm::Value* got_userdata_mask = ll.int_as_mask(got_userdata);
+
+        if (shadingsys().debug_nan() && type.basetype == TypeDesc::FLOAT) {
+            // check for NaN/Inf for float-based types
+            int ncomps          = type.numelements() * type.aggregate;
+            llvm::Value* args[] = { ll.mask_as_int(ll.current_mask()),
+                                    ll.constant(ncomps),
+                                    llvm_void_ptr(sym),
+                                    ll.constant((int)sym.has_derivs()),
+                                    sg_void_ptr(),
+                                    ll.constant(ustring(inst()->shadername())),
+                                    ll.constant(0),
+                                    ll.constant(sym.name()),
+                                    ll.constant(0),
+                                    ll.constant(ncomps),
+                                    ll.constant("<get_userdata>") };
+            ll.call_function(build_name(FuncSpec("naninf_check_offset")
+                                            .arg_uniform(TypeDesc::TypeInt)
+                                            .mask()),
+                             args);
+        }
+        // We will enclose the subsequent initialization of default values
+        // or init ops in an "if" so that the extra copies or code don't
+        // happen if the userdata was retrieved.
+        llvm::BasicBlock* partial_userdata_block = ll.new_basic_block(
+            "partial_userdata");
+        after_userdata_block  = ll.new_basic_block();
+        llvm::Value* cond_val = ll.op_ne(got_userdata,
+                                         ll.constant(true_mask_value()));
+        ll.op_branch(cond_val, partial_userdata_block, after_userdata_block);
+
+        // If we got no or partial user data, we need to mask out the lanes
+        // that successfully got user data from the initops or default value
+        // assignment
+        ll.push_mask(
+            got_userdata_mask, /* negate */
+            true /*, absolute = false (not sure how it wouldn't be an absolute mask) */);
+        partial_data_masking_scope = ll.create_masking_scope(/*enabled=*/true);
+        partial_userdata_mask_was_pushed = true;
+    }
+
+    if (sym.has_init_ops() && sym.valuesource() == Symbol::DefaultVal) {
+        // Forcing masking shouldn't be required here,
+        // believe our discovery handled this correctly
+        // as these are initialization op's that are being processed,
+        // they should have corresponding require's masking entries,
+        // unlike the rest of the copies/initialization going on here
+
+        // Handle init ops.
+        build_llvm_code(sym.initbegin(), sym.initend());
+    } else {
+        // We think the non-memcpy route is preferable as it give the compiler
+        // a chance to optimize constant values Also memcpy would ignoring the
+        // mask stack, which is problematic
+        LLVM_Util::ScopedMasking render_output_masking_scope;
+        if (sym.renderer_output()) {
+            render_output_masking_scope = ll.create_masking_scope(
+                /*enabled=*/true);
+        }
+
+        // Use default value
+        int num_components = sym.typespec().simpletype().aggregate;
+        TypeSpec elemtype  = sym.typespec().elementtype();
+        for (int a = 0, c = 0; a < arraylen; ++a) {
+            llvm::Value* arrind = sym.typespec().is_array() ? ll.constant(a)
+                                                            : NULL;
+            if (sym.typespec().is_closure_based())
+                continue;
+            for (int i = 0; i < num_components; ++i, ++c) {
+                // Fill in the constant val
+                llvm::Value* init_val = 0;
+                if (elemtype.is_float_based())
+                    init_val = ll.constant(((float*)sym.data())[c]);
+                else if (elemtype.is_string())
+                    init_val = ll.constant(((ustring*)sym.data())[c]);
+                else if (elemtype.is_int())
+                    init_val = ll.constant(((int*)sym.data())[c]);
+                OSL_ASSERT(init_val);
+
+                if (sym.is_uniform()) {
+                    OSL_ASSERT(!sym.renderer_output()
+                               && "All render outputs should be varying");
+                    llvm_store_value(init_val, sym, 0, arrind, i);
+                } else {
+                    llvm::Value* wide_init_val = ll.wide_constant(
+                        static_cast<llvm::Constant*>(init_val));
+                    llvm_store_value(wide_init_val, sym, 0, arrind, i);
+                }
+            }
+        }
+        if (sym.has_derivs()) {
+            llvm_zero_derivs(sym);
+        }
+    }
+
+    if (partial_userdata_mask_was_pushed) {
+        partial_data_masking_scope.release();
+        ll.pop_mask();
+    }
+
+    if (after_userdata_block) {
+        // If we enclosed the default initialization in an "if", jump to the
+        // next basic block now.
+        ll.op_branch(after_userdata_block);
+    }
+}
+
+
+
+void
+BatchedBackendLLVM::llvm_generate_debugnan(const Opcode& op)
+{
+    for (int i = 0; i < op.nargs(); ++i) {
+        Symbol& sym(*opargsym(op, i));
+        if (!op.argwrite(i))
+            continue;
+        TypeDesc t = sym.typespec().simpletype();
+        if (t.basetype != TypeDesc::FLOAT)
+            continue;  // just check float-based types
+        llvm::Value* ncomps = ll.constant(int(t.numelements() * t.aggregate));
+        llvm::Value* offset = ll.constant(0);
+        llvm::Value* ncheck = ncomps;
+        BatchedBackendLLVM::TempScope temp_scope(*this);
+        llvm::Value* loc_varying_offsets = nullptr;
+        if (op.opname() == op_aassign) {
+            // Special case -- array assignment -- only check one element
+            OSL_ASSERT(i == 0 && "only arg 0 is written for aassign");
+            Symbol& index_sym = *opargsym(op, 1);
+            llvm::Value* ind  = llvm_load_value(index_sym);
+            llvm::Value* agg  = index_sym.is_uniform()
+                                   ? ll.constant(t.aggregate)
+                                   : ll.wide_constant(t.aggregate);
+            llvm::Value* scaled_offset = t.aggregate == 1 ? ind
+                                                          : ll.op_mul(ind, agg);
+            if (index_sym.is_uniform()) {
+                offset = scaled_offset;
+            } else {
+                loc_varying_offsets
+                    = getOrAllocateTemp(TypeSpec(TypeDesc::INT),
+                                        false /*derivs*/, false /*is_uniform*/,
+                                        false /*forceBool*/,
+                                        std::string("nan check scaled indices:")
+                                            + index_sym.name().c_str());
+                ll.op_store(scaled_offset, loc_varying_offsets);
+            }
+            ncheck = ll.constant(t.aggregate);
+        } else if (op.opname() == op_compassign) {
+            // Special case -- component assignment -- only check one channel
+            OSL_ASSERT(i == 0 && "only arg 0 is written for compassign");
+            Symbol& index_sym = *opargsym(op, 1);
+            if (index_sym.is_uniform()) {
+                offset = llvm_load_value(index_sym);
+            } else {
+                loc_varying_offsets = llvm_get_pointer(index_sym);
+            }
+            ncheck = ll.constant(1);
+        } else if (op.opname() == op_mxcompassign) {
+            // Special case -- matrix component assignment -- only check one channel
+            OSL_ASSERT(i == 0 && "only arg 0 is written for compassign");
+            Symbol& row_sym             = *opargsym(op, 1);
+            Symbol& col_sym             = *opargsym(op, 2);
+            bool components_are_uniform = row_sym.is_uniform()
+                                          && col_sym.is_uniform();
+
+            llvm::Value* row_ind = llvm_load_value(row_sym, 0, 0,
+                                                   TypeDesc::UNKNOWN,
+                                                   components_are_uniform);
+            llvm::Value* col_ind = llvm_load_value(col_sym, 0, 0,
+                                                   TypeDesc::UNKNOWN,
+                                                   components_are_uniform);
+
+            llvm::Value* comp = ll.op_mul(row_ind, components_are_uniform
+                                                       ? ll.constant(4)
+                                                       : ll.wide_constant(4));
+            comp              = ll.op_add(comp, col_ind);
+
+            if (components_are_uniform) {
+                offset = comp;
+            } else {
+                loc_varying_offsets
+                    = getOrAllocateTemp(TypeSpec(TypeDesc::INT),
+                                        false /*derivs*/, false /*is_uniform*/,
+                                        false /*forceBool*/,
+                                        std::string("nan check comp from row(")
+                                            + row_sym.name().c_str() + ") col("
+                                            + col_sym.name().c_str() + ")");
+                ll.op_store(comp, loc_varying_offsets);
+            }
+            ncheck = ll.constant(1);
+        }
+
+        if (loc_varying_offsets != nullptr) {
+            OSL_ASSERT(sym.is_varying());
+            llvm::Value* args[] = { ll.mask_as_int(ll.current_mask()),
+                                    ncomps,
+                                    llvm_void_ptr(sym),
+                                    ll.constant((int)sym.has_derivs()),
+                                    sg_void_ptr(),
+                                    ll.constant(op.sourcefile()),
+                                    ll.constant(op.sourceline()),
+                                    ll.constant(sym.name()),
+                                    ll.void_ptr(loc_varying_offsets),
+                                    ncheck,
+                                    ll.constant(op.opname()) };
+            ll.call_function(build_name(FuncSpec("naninf_check_offset")
+                                            .arg_varying(TypeDesc::TypeInt)
+                                            .mask()),
+                             args);
+
+        } else {
+            if (sym.is_uniform()) {
+                llvm::Value* args[] = { ncomps,
+                                        llvm_void_ptr(sym),
+                                        ll.constant((int)sym.has_derivs()),
+                                        sg_void_ptr(),
+                                        ll.constant(op.sourcefile()),
+                                        ll.constant(op.sourceline()),
+                                        ll.constant(sym.name()),
+                                        offset,
+                                        ncheck,
+                                        ll.constant(op.opname()) };
+                ll.call_function(build_name("naninf_check"), args);
+            } else {
+                llvm::Value* args[] = { ll.mask_as_int(ll.current_mask()),
+                                        ncomps,
+                                        llvm_void_ptr(sym),
+                                        ll.constant((int)sym.has_derivs()),
+                                        sg_void_ptr(),
+                                        ll.constant(op.sourcefile()),
+                                        ll.constant(op.sourceline()),
+                                        ll.constant(sym.name()),
+                                        offset,
+                                        ncheck,
+                                        ll.constant(op.opname()) };
+                ll.call_function(build_name(FuncSpec("naninf_check_offset")
+                                                .arg_uniform(TypeDesc::TypeInt)
+                                                .mask()),
+                                 args);
+            }
+        }
+    }
+}
+
+
+
+void
+BatchedBackendLLVM::llvm_generate_debug_uninit(const Opcode& op)
+{
+    if (op.opname() == op_useparam) {
+        // Don't check the args of a useparam before the op; they are by
+        // definition potentially net yet set before the useparam action
+        // itself puts values into them. Checking them for uninitialized
+        // values will result in false positives.
+        return;
+    }
+    for (int i = 0; i < op.nargs(); ++i) {
+        Symbol& sym(*opargsym(op, i));
+        if (!op.argread(i))
+            continue;
+        if (sym.typespec().is_closure_based())
+            continue;
+        TypeDesc t = sym.typespec().simpletype();
+        if (t.basetype != TypeDesc::FLOAT && t.basetype != TypeDesc::INT
+            && t.basetype != TypeDesc::STRING)
+            continue;  // just check float, int, string based types
+
+        // Because we allow temporaries and local results of comparison operations
+        // to use the native bool type of i1, we can just skip checking these
+        // as they should always be assigned a value.
+        // We can just interrogate the underlying llvm symbol to see if
+        // it is a bool
+        llvm::Value* llvmValue = llvm_get_pointer(sym);
+        if (ll.llvm_typeof(llvmValue) == ll.type_ptr(ll.type_bool())
+            || ll.llvm_typeof(llvmValue) == ll.type_ptr(ll.type_wide_bool())) {
+            continue;
+        }
+
+        llvm::Value* ncheck = ll.constant(int(t.numelements() * t.aggregate));
+        llvm::Value* offset = ll.constant(0);
+        BatchedBackendLLVM::TempScope temp_scope(*this);
+        llvm::Value* loc_varying_offsets = nullptr;
+
+        // Some special cases...
+        if (op.opname() == Strings::op_for && i == 0) {
+            // The first argument of 'for' is the condition temp, but
+            // note that it may not have had its initializer run yet, so
+            // don't generate uninit test code for it.
+            continue;
+        }
+        if (op.opname() == Strings::op_dowhile && i == 0) {
+            // The first argument of 'dowhile' is the condition temp, but
+            // it most likely its initializer run yet.
+            // Unless there is no "condition" code block, in that
+            // case we should still
+            if (op.jump(0) != op.jump(1))
+                continue;
+        }
+        if (op.opname() == op_aref && i == 1) {
+            // Special case -- array reference -- only check one element
+            Symbol& index_sym = *opargsym(op, 2);
+            llvm::Value* ind  = llvm_load_value(index_sym);
+
+            llvm::Value* agg = index_sym.is_uniform()
+                                   ? ll.constant(t.aggregate)
+                                   : ll.wide_constant(t.aggregate);
+            llvm::Value* scaled_offset = t.aggregate == 1 ? ind
+                                                          : ll.op_mul(ind, agg);
+            if (index_sym.is_uniform()) {
+                offset = scaled_offset;
+            } else {
+                loc_varying_offsets = getOrAllocateTemp(
+                    TypeSpec(TypeDesc::INT), false /*derivs*/,
+                    false /*is_uniform*/, false /*forceBool*/,
+                    std::string("uninit check scaled indices:")
+                        + index_sym.name().c_str());
+                ll.op_store(scaled_offset, loc_varying_offsets);
+            }
+            ncheck = ll.constant(t.aggregate);
+
+        } else if (op.opname() == op_compref && i == 1) {
+            // Special case -- component reference -- only check one channel
+            Symbol& index_sym = *opargsym(op, 2);
+            if (index_sym.is_uniform()) {
+                offset = llvm_load_value(index_sym);
+            } else {
+                loc_varying_offsets = llvm_get_pointer(index_sym);
+            }
+            ncheck = ll.constant(1);
+        } else if (op.opname() == op_mxcompref && i == 1) {
+            // Special case -- matrix component reference -- only check one channel
+            Symbol& row_sym             = *opargsym(op, 2);
+            Symbol& col_sym             = *opargsym(op, 3);
+            bool components_are_uniform = row_sym.is_uniform()
+                                          && col_sym.is_uniform();
+
+            llvm::Value* row_ind = llvm_load_value(row_sym, 0, 0,
+                                                   TypeDesc::UNKNOWN,
+                                                   components_are_uniform);
+            llvm::Value* col_ind = llvm_load_value(col_sym, 0, 0,
+                                                   TypeDesc::UNKNOWN,
+                                                   components_are_uniform);
+
+            llvm::Value* comp = ll.op_mul(row_ind, components_are_uniform
+                                                       ? ll.constant(4)
+                                                       : ll.wide_constant(4));
+            comp              = ll.op_add(comp, col_ind);
+
+            if (components_are_uniform) {
+                offset = comp;
+            } else {
+                loc_varying_offsets = getOrAllocateTemp(
+                    TypeSpec(TypeDesc::INT), false /*derivs*/,
+                    false /*is_uniform*/, false /*forceBool*/,
+                    std::string("uninit check comp from row(")
+                        + row_sym.name().c_str() + ") col("
+                        + col_sym.name().c_str() + ")");
+                ll.op_store(comp, loc_varying_offsets);
+            }
+            ncheck = ll.constant(1);
+        }
+
+        if (loc_varying_offsets != nullptr) {
+            llvm::Value* args[] = { ll.mask_as_int(ll.current_mask()),
+                                    ll.constant(t),
+                                    llvm_void_ptr(sym),
+                                    sg_void_ptr(),
+                                    ll.constant(op.sourcefile()),
+                                    ll.constant(op.sourceline()),
+                                    ll.constant(group().name()),
+                                    ll.constant(layer()),
+                                    ll.constant(inst()->layername()),
+                                    ll.constant(inst()->shadername().c_str()),
+                                    ll.constant(int(&op - &inst()->ops()[0])),
+                                    ll.constant(op.opname()),
+                                    ll.constant(i),
+                                    ll.constant(sym.name()),
+                                    ll.void_ptr(loc_varying_offsets),
+                                    ncheck };
+
+            if (sym.is_uniform()) {
+                ll.call_function(build_name(
+                                     FuncSpec("uninit_check_values_offset")
+                                         .arg_uniform(TypeDesc::PTR)
+                                         .arg_varying(TypeDesc::TypeInt)
+                                         .mask()),
+                                 args);
+            } else {
+                ll.call_function(build_name(
+                                     FuncSpec("uninit_check_values_offset")
+                                         .arg_varying(TypeDesc::PTR)
+                                         .arg_varying(TypeDesc::TypeInt)
+                                         .mask()),
+                                 args);
+            }
+        } else {
+            if (sym.is_uniform()) {
+                llvm::Value* args[]
+                    = { ll.constant(t),
+                        llvm_void_ptr(sym),
+                        sg_void_ptr(),
+                        ll.constant(op.sourcefile()),
+                        ll.constant(op.sourceline()),
+                        ll.constant(group().name()),
+                        ll.constant(layer()),
+                        ll.constant(inst()->layername()),
+                        ll.constant(inst()->shadername().c_str()),
+                        ll.constant(int(&op - &inst()->ops()[0])),
+                        ll.constant(op.opname()),
+                        ll.constant(i),
+                        ll.constant(sym.name()),
+                        offset,
+                        ncheck };
+                ll.call_function(build_name(
+                                     FuncSpec("uninit_check_values_offset")
+                                         .arg_uniform(TypeDesc::PTR)
+                                         .arg_uniform(TypeDesc::TypeInt)),
+                                 args);
+            } else {
+                llvm::Value* args[]
+                    = { ll.mask_as_int(ll.current_mask()),
+                        ll.constant(t),
+                        llvm_void_ptr(sym),
+                        sg_void_ptr(),
+                        ll.constant(op.sourcefile()),
+                        ll.constant(op.sourceline()),
+                        ll.constant(group().name()),
+                        ll.constant(layer()),
+                        ll.constant(inst()->layername()),
+                        ll.constant(inst()->shadername().c_str()),
+                        ll.constant(int(&op - &inst()->ops()[0])),
+                        ll.constant(op.opname()),
+                        ll.constant(i),
+                        ll.constant(sym.name()),
+                        offset,
+                        ncheck };
+                ll.call_function(build_name(
+                                     FuncSpec("uninit_check_values_offset")
+                                         .arg_varying(TypeDesc::PTR)
+                                         .arg_uniform(TypeDesc::TypeInt)
+                                         .mask()),
+                                 args);
+            }
+        }
+    }
+}
+
+
+void
+BatchedBackendLLVM::llvm_generate_debug_op_printf(const Opcode& op)
+{
+    std::ostringstream msg;
+    msg << op.sourcefile() << ':' << op.sourceline() << ' ' << op.opname();
+    for (int i = 0; i < op.nargs(); ++i)
+        msg << ' ' << opargsym(op, i)->mangled();
+    llvm_gen_debug_printf(msg.str());
+}
+
+
+bool
+BatchedBackendLLVM::build_llvm_code(int beginop, int endop,
+                                    llvm::BasicBlock* bb)
+{
+    OSL_DEV_ONLY(std::cout << "build_llvm_code : beginop=" << beginop
+                           << " endop=" << endop << " bb=" << bb << std::endl);
+    if (bb)
+        ll.set_insert_point(bb);
+
+    for (int opnum = beginop; opnum < endop; ++opnum) {
+        const Opcode& op        = inst()->ops()[opnum];
+        const OpDescriptor* opd = shadingsys().op_descriptor(op.opname());
+        if (opd && opd->llvmgenwide) {
+            if (shadingsys().debug_uninit() /* debug uninitialized vals */)
+                llvm_generate_debug_uninit(op);
+            if (shadingsys().llvm_debug_ops())
+                llvm_generate_debug_op_printf(op);
+                // TODO: optionally enable
+#ifdef OSL_DEV
+            std::cout << "Generating :" << op.opname() << std::endl;
+            if (requiresMasking(opnum))
+                std::cout << " with MASKING";
+            std::cout << std::endl;
+#endif
+            if (ll.debug_is_enabled()) {
+                ll.debug_set_location(op.sourcefile(), op.sourceline() <= 0
+                                                           ? 1
+                                                           : op.sourceline());
+            }
+            {
+                auto op_masking_scope = ll.create_masking_scope(
+                    /*enabled=*/op.requires_masking());
+                bool ok = (*opd->llvmgenwide)(*this, opnum);
+                if (!ok)
+                    return false;
+            }
+            if (shadingsys().debug_nan() /* debug NaN/Inf */
+                && op.farthest_jump() < 0 /* Jumping ops don't need it */) {
+                llvm_generate_debugnan(op);
+            }
+        } else if (op.opname() == op_nop || op.opname() == op_end) {
+            // Skip this op, it does nothing...
+        } else {
+            shadingcontext()->errorf("LLVMOSL: Unsupported op %s in layer %s\n",
+                                     op.opname(), inst()->layername());
+            return false;
+        }
+
+        // If the op we coded jumps around, skip past its recursive block
+        // executions.
+        int next = op.farthest_jump();
+        OSL_DEV_ONLY(std::cout << "farthest_jump=" << next << std::endl);
+        if (next >= 0)
+            opnum = next - 1;
+    }
+    return true;
+}
+
+
+
+llvm::Function*
+BatchedBackendLLVM::build_llvm_init()
+{
+    // Make a group init function: void group_init(ShaderGlobals*, GroupData*)
+    // Note that the GroupData* is passed as a void*.
+    OSL_ASSERT(m_library_selector);
+    std::string unique_name = Strutil::sprintf("%s_group_%d_init",
+                                               m_library_selector,
+                                               group().id());
+    ll.current_function(ll.make_function(unique_name, false,
+                                         ll.type_void(),  // return type
+                                         llvm_type_sg_ptr(),
+                                         llvm_type_groupdata_ptr(),
+                                         ll.type_int()));
+
+    if (ll.debug_is_enabled()) {
+        ustring file_name
+            = group()[0]->op(group()[0]->maincodebegin()).sourcefile();
+        unsigned int method_line = 0;
+        ll.debug_push_function(unique_name, file_name, method_line);
+    }
+
+    // Get shader globals and groupdata pointers
+    m_llvm_shaderglobals_ptr = ll.current_function_arg(0);  //arg_it++;
+    m_llvm_groupdata_ptr     = ll.current_function_arg(1);  //arg_it++;
+    // TODO: do we need to utilize the shader mask in the init function?
+    //llvm::Value * llvm_initial_shader_mask_value = ll.current_function_arg(2); //arg_it++;
+
+    // New function, reset temp matrix pointer
+    m_llvm_temp_wide_matrix_ptr             = nullptr;
+    m_llvm_temp_batched_texture_options_ptr = nullptr;
+    m_llvm_temp_batched_trace_options_ptr   = nullptr;
+
+    // Set up a new IR builder
+    llvm::BasicBlock* entry_bb = ll.new_basic_block(unique_name);
+    ll.new_builder(entry_bb);
+
+    ll.assume_ptr_is_aligned(m_llvm_shaderglobals_ptr, 64);
+    ll.assume_ptr_is_aligned(m_llvm_groupdata_ptr, 64);
+
+#if 0 /* helpful for debugging */
+    if (llvm_debug()) {
+        llvm_gen_debug_printf (Strutil::sprintf("\n\n\n\nGROUP! %s",group().name()));
+        llvm_gen_debug_printf ("enter group initlayer %d %s %s");                               this->layer(), inst()->layername(), inst()->shadername()));
+    }
+#endif
+
+    // Group init clears all the "layer_run" and "userdata_initialized" flags.
+    if (m_num_used_layers > 1) {
+        // Round up to a 64 bit boundary
+        int sz = 16 * ((m_num_used_layers + 15) / 16) * sizeof(int);
+
+        ll.op_memset(ll.void_ptr(layer_run_ref(0)), 0, sz, 4 /*align*/);
+    }
+    int num_userdata = (int)group().m_userdata_names.size();
+    if (num_userdata) {
+        int sz = num_userdata * sizeof(int);
+        ll.op_memset(ll.void_ptr(userdata_initialized_ref(0)), 0, sz,
+                     4 /*align*/);
+    }
+
+    // Group init also needs to allot space for ALL layers' params
+    // that are closures (to avoid weird order of layer eval problems).
+    for (int i = 0; i < group().nlayers(); ++i) {
+        ShaderInstance* gi = group()[i];
+        if (gi->unused() || gi->empty_instance())
+            continue;
+        FOREACH_PARAM(Symbol & sym, gi)
+        {
+            if (sym.typespec().is_closure_based()) {
+                int arraylen     = std::max(1, sym.typespec().arraylength());
+                llvm::Value* val = ll.constant_ptr(NULL, ll.type_void_ptr());
+                for (int a = 0; a < arraylen; ++a) {
+                    llvm::Value* arrind = sym.typespec().is_array()
+                                              ? ll.constant(a)
+                                              : NULL;
+                    llvm_store_value(val, sym, 0, arrind, 0);
+                }
+            }
+        }
+    }
+
+
+    // All done
+#if 0 /* helpful for debugging */
+    if (llvm_debug())
+        llvm_gen_debug_printf (Strutil::sprintf("exit group init %s",
+                                               group().name());
+#endif
+    ll.op_return();
+
+    if (llvm_debug())
+        std::cout << "group init func (" << unique_name << ") "
+                  << " after llvm  = "
+                  << ll.bitcode_string(ll.current_function()) << "\n";
+
+    if (ll.debug_is_enabled()) {
+        ll.debug_pop_function();
+    }
+
+    ll.end_builder();  // clear the builder
+
+    OSL_ASSERT(
+        m_temp_scopes.empty()
+        && "LOGIC BUG, all BatchedBackendLLVM::TempScope's should be destroyed by now");
+    // Any temp allocations we've been tracking in the function's scope
+    // will no longer be valid
+    m_temp_allocs.clear();
+
+    return ll.current_function();
+}
+
+
+llvm::Function*
+BatchedBackendLLVM::build_llvm_instance(bool groupentry)
+{
+    // Make a layer function: void layer_func(ShaderGlobals*, GroupData*)
+    // Note that the GroupData* is passed as a void*.
+    OSL_ASSERT(m_library_selector);
+    std::string unique_layer_name
+        = Strutil::sprintf("%s_%s", m_library_selector,
+                           layer_function_name().c_str());
+
+    bool is_entry_layer = group().is_entry_layer(layer());
+    ll.current_function(ll.make_function(
+        unique_layer_name,
+        !is_entry_layer,  // fastcall for non-entry layer functions
+        ll.type_void(),   // return type
+        llvm_type_sg_ptr(), llvm_type_groupdata_ptr(), ll.type_int()));
+
+    if (ll.debug_is_enabled()) {
+        ustring file_name = inst()->op(inst()->maincodebegin()).sourcefile();
+
+        unsigned int method_line
+            = inst()->op(inst()->maincodebegin()).sourceline();
+        ll.debug_push_function(unique_layer_name, file_name, method_line);
+    }
+
+
+    // Get shader globals and groupdata pointers
+    m_llvm_shaderglobals_ptr = ll.current_function_arg(0);  //arg_it++;
+    m_llvm_groupdata_ptr     = ll.current_function_arg(1);  //arg_it++;
+    llvm::Value* llvm_initial_shader_mask_value = ll.current_function_arg(
+        2);  //arg_it++;
+
+    // New function, reset temp matrix pointer
+    m_llvm_temp_wide_matrix_ptr             = nullptr;
+    m_llvm_temp_batched_texture_options_ptr = nullptr;
+    m_llvm_temp_batched_trace_options_ptr   = nullptr;
+
+    llvm::BasicBlock* entry_bb = ll.new_basic_block(unique_layer_name);
+    m_exit_instance_block      = NULL;
+
+    // Set up a new IR builder
+    ll.new_builder(entry_bb);
+
+    ll.assume_ptr_is_aligned(m_llvm_shaderglobals_ptr, 64);
+    ll.assume_ptr_is_aligned(m_llvm_groupdata_ptr, 64);
+
+    // Start with fewer data lanes active based on how full batch is.
+    llvm::Value* initial_shader_mask = ll.int_as_mask(
+        llvm_initial_shader_mask_value);
+    ll.push_shader_instance(initial_shader_mask);
+//#define __OSL_TRACE_MASKS 1
+#ifdef __OSL_TRACE_MASKS
+    llvm_print_mask("initial_shader_mask", initial_shader_mask);
+#endif
+
+    OSL_DEV_ONLY(std::cout << "Master Shadername = "
+                           << inst()->master()->shadername() << std::endl);
+    OSL_DEV_ONLY(std::cout << "Master osofilename = "
+                           << inst()->master()->osofilename() << std::endl);
+    OSL_DEV_ONLY(std::cout << "source of maincodebegin operation = "
+                           << inst()->op(inst()->maincodebegin()).sourcefile()
+                           << std::endl);
+
+
+    llvm::Value* layerfield = layer_run_ref(layer_remap(layer()));
+
+    llvm::Value* previously_executed_value = nullptr;
+    if (!group().is_last_layer(layer())) {
+        previously_executed_value = ll.op_load(layerfield);
+    }
+
+    if (is_entry_layer && !group().is_last_layer(layer())) {
+        // For entry layers, we need an extra check to see if it already
+        // ran. If it has, do an early return. Otherwise, set the 'ran' flag
+        // and then run the layer.
+        if (shadingsys().llvm_debug_layers())
+            llvm_gen_debug_printf(
+                Strutil::sprintf("checking for already-run layer %d %s %s",
+                                 this->layer(), inst()->layername(),
+                                 inst()->shadername()));
+        llvm::Value* previously_executed = ll.int_as_mask(
+            previously_executed_value);
+        llvm::Value* required_lanes_executed
+            = ll.op_select(initial_shader_mask, previously_executed,
+                           ll.wide_constant_bool(false));
+        llvm::Value* all_required_lanes_already_executed
+            = ll.op_eq(initial_shader_mask, required_lanes_executed);
+
+        llvm::BasicBlock* then_block  = ll.new_basic_block();
+        llvm::BasicBlock* after_block = ll.new_basic_block();
+        ll.op_branch(all_required_lanes_already_executed, then_block,
+                     after_block);
+        // insert point is now then_block
+        // we've already executed, so return early
+        if (shadingsys().llvm_debug_layers())
+            llvm_gen_debug_printf(Strutil::sprintf(
+                "  taking early exit, already executed layer %d %s %s",
+                this->layer(), inst()->layername(), inst()->shadername()));
+        ll.op_return();
+        ll.set_insert_point(after_block);
+    }
+
+    if (shadingsys().llvm_debug_layers())
+        llvm_gen_debug_printf(
+            Strutil::sprintf("enter layer %d %s %s", this->layer(),
+                             inst()->layername(), inst()->shadername()));
+    // Mark this layer as executed
+    if (!group().is_last_layer(layer())) {
+        // Caller may only be asking for a subset of the lanes to be executed
+        // We don't want to loose track of lanes we have already executed, so
+        // we will OR together previously & requested executed
+        llvm::Value* combined_executed
+            = ll.op_or(previously_executed_value,
+                       llvm_initial_shader_mask_value);
+        ll.op_store(combined_executed, layerfield);
+        if (shadingsys().countlayerexecs())
+            ll.call_function("osl_incr_layers_executed", sg_void_ptr());
+    }
+
+    // Setup the symbols
+    m_named_values.clear();
+    m_layers_already_run.clear();
+
+    for (auto&& s : inst()->symbols()) {
+        // Skip constants -- we always inline scalar constants, and for
+        // array constants we will just use the pointers to the copy of
+        // the constant that belongs to the instance.
+        if (s.symtype() == SymTypeConst)
+            continue;
+        // Skip structure placeholders
+        if (s.typespec().is_structure())
+            continue;
+        // Allocate space for locals, temps, aggregate constants
+        if (s.symtype() == SymTypeLocal || s.symtype() == SymTypeTemp
+            || s.symtype() == SymTypeConst) {
+            getOrAllocateLLVMSymbol(s);
+        }
+        // Set initial value for constants, closures, and strings that are
+        // not parameters.
+        if (s.symtype() != SymTypeParam && s.symtype() != SymTypeOutputParam
+            && s.symtype() != SymTypeGlobal
+            && (s.is_constant() || s.typespec().is_closure_based()
+                || s.typespec().is_string_based()
+                || ((s.symtype() == SymTypeLocal || s.symtype() == SymTypeTemp)
+                    && shadingsys().debug_uninit())))
+            llvm_assign_initial_value(s, llvm_initial_shader_mask_value);
+        // If debugnan is turned on, globals check that their values are ok
+        if (s.symtype() == SymTypeGlobal && shadingsys().debug_nan()) {
+            TypeDesc t = s.typespec().simpletype();
+            if (t.basetype
+                == TypeDesc::FLOAT) {  // just check float-based types
+                int ncomps = t.numelements() * t.aggregate;
+                if (s.is_uniform()) {
+                    llvm::Value* args[]
+                        = { ll.constant(ncomps),
+                            llvm_void_ptr(s),
+                            ll.constant((int)s.has_derivs()),
+                            sg_void_ptr(),
+                            ll.constant(ustring(inst()->shadername())),
+                            ll.constant(0),
+                            ll.constant(s.name()),
+                            ll.constant(0),
+                            ll.constant(ncomps),
+                            ll.constant("<none>") };
+                    ll.call_function(build_name("naninf_check"), args);
+                } else {
+                    llvm::Value* args[]
+                        = { llvm_initial_shader_mask_value,
+                            ll.constant(ncomps),
+                            llvm_void_ptr(s),
+                            ll.constant((int)s.has_derivs()),
+                            sg_void_ptr(),
+                            ll.constant(ustring(inst()->shadername())),
+                            ll.constant(0),
+                            ll.constant(s.name()),
+                            ll.constant(0),
+                            ll.constant(ncomps),
+                            ll.constant("<none>") };
+                    ll.call_function(build_name(
+                                         FuncSpec("naninf_check_offset")
+                                             .arg_uniform(TypeDesc::TypeInt)
+                                             .mask()),
+                                     args);
+                }
+            }
+        }
+    }
+
+    // make a second pass for the parameters (which may make use of
+    // locals and constants from the first pass)
+    FOREACH_PARAM(Symbol & s, inst())
+    {
+        // Skip structure placeholders
+        if (s.typespec().is_structure())
+            continue;
+        // Skip if it's never read and isn't connected
+        if (!s.everread() && !s.connected_down() && !s.connected()
+            && !s.renderer_output())
+            continue;
+        // Skip if it's an interpolated (userdata) parameter and we're
+        // initializing them lazily.
+        if (s.symtype() == SymTypeParam && !s.lockgeom()
+            && !s.typespec().is_closure() && !s.connected()
+            && !s.connected_down() && shadingsys().lazy_userdata())
+            continue;
+        // Set initial value for params (may contain init ops)
+        llvm_assign_initial_value(s, llvm_initial_shader_mask_value);
+    }
+
+    // All the symbols are stack allocated now.
+
+    if (groupentry) {
+        // Group entries also need to run any earlier layers that must be
+        // run unconditionally. It's important that we do this AFTER all the
+        // parameter initialization for this layer.
+        for (int i = 0; i < group().nlayers() - 1; ++i) {
+            ShaderInstance* gi = group()[i];
+            if (!gi->unused() && !gi->empty_instance() && !gi->run_lazily())
+                llvm_call_layer(i, true /* unconditionally run */);
+        }
+    }
+
+    // Mark all the basic blocks, including allocating llvm::BasicBlock
+    // records for each.
+    find_basic_blocks();
+    find_conditionals();
+
+    build_llvm_code(inst()->maincodebegin(), inst()->maincodeend());
+
+    if (llvm_has_exit_instance_block()) {
+        ll.op_branch(m_exit_instance_block);  // also sets insert point
+    }
+
+    // Track all symbols who needed 'partial' initialization
+    std::unordered_set<Symbol*> initedsyms;
+
+    {
+        // The current mask could be altered by early returns or exit
+        // But for copying output parameters to connected shaders,
+        // we want to use the shader mask
+        ll.push_mask(initial_shader_mask, /*negate=*/false,
+                     /*absolute = */ true);
+        // Need to make sure we only copy the lanes that this layer populated
+        // and avoid overwriting lanes that may have previously been populated
+        auto mask_copying_of_connected_symbols = ll.create_masking_scope(true);
+
+        // Transfer all of this layer's outputs into the downstream shader's
+        // inputs.
+        for (int layer = this->layer() + 1; layer < group().nlayers();
+             ++layer) {
+            // If connection is to a node not used in the next layer
+            // then it may not have been analyzed properly
+            // and more importantly can be skipped
+            if (m_layer_remap[layer] != -1) {
+                ShaderInstance* child = group()[layer];
+
+                for (int c = 0, Nc = child->nconnections(); c < Nc; ++c) {
+                    const Connection& con(child->connection(c));
+                    if (con.srclayer == this->layer()) {
+                        OSL_ASSERT(
+                            con.src.arrayindex == -1 && con.dst.arrayindex == -1
+                            && "no support for individual array element connections");
+                        // Validate unsupported connection vecSrc -> vecDst[j]
+                        OSL_ASSERT(
+                            (con.dst.channel == -1
+                             || con.src.type.aggregate() == TypeDesc::SCALAR
+                             || con.src.channel != -1)
+                            && "no support for vector -> vector[i] connections");
+
+                        Symbol* srcsym(inst()->symbol(con.src.param));
+                        Symbol* dstsym(child->symbol(con.dst.param));
+
+                        // Check remaining connections to see if any channels of this
+                        // aggregate need to be initialize.
+                        if (con.dst.channel != -1
+                            && initedsyms.count(dstsym) == 0) {
+                            initedsyms.insert(dstsym);
+                            std::bitset<32> inited(
+                                0);  // Only need to be 16 (matrix4)
+                            assert(dstsym->typespec().aggregate()
+                                   <= inited.size());
+                            unsigned ninit = dstsym->typespec().aggregate() - 1;
+                            for (int rc = c + 1; rc < Nc && ninit; ++rc) {
+                                const Connection& next(child->connection(rc));
+                                if (next.srclayer == this->layer()) {
+                                    // Allow redundant/overwriting connections, i.e:
+                                    // 1.  connect layer.value[i] connect layer.value[j]
+                                    // 2.  connect layer.value connect layer.value
+                                    if (child->symbol(next.dst.param)
+                                        == dstsym) {
+                                        if (next.dst.channel != -1) {
+                                            assert(next.dst.channel
+                                                   < (int)inited.size());
+                                            if (!inited[next.dst.channel]) {
+                                                inited[next.dst.channel] = true;
+                                                --ninit;
+                                            }
+                                        } else
+                                            ninit = 0;
+                                    }
+                                }
+                            }
+                            if (ninit) {
+                                // FIXME: Init only components that are not connected
+                                llvm_assign_initial_value(*dstsym,
+                                                          initial_shader_mask,
+                                                          true);
+                            }
+                        }
+
+                        // llvm_run_connected_layers tracks layers that have been run,
+                        // so no need to do it here as well
+                        llvm_run_connected_layers(*srcsym, con.src.param);
+
+                        // FIXME -- I'm not sure I understand this.  Isn't this
+                        // unnecessary if we wrote to the parameter ourself?
+                        llvm_assign_impl(*dstsym, *srcsym, -1, con.src.channel,
+                                         con.dst.channel);
+                    }
+                }
+            }
+        }
+        ll.pop_mask();
+        // llvm_gen_debug_printf ("done copying connections");
+    }
+
+    // All done
+    if (shadingsys().llvm_debug_layers())
+        llvm_gen_debug_printf(
+            Strutil::sprintf("exit layer %d %s %s", this->layer(),
+                             inst()->layername(), inst()->shadername()));
+    ll.op_return();
+
+    if (llvm_debug())
+        std::cout << "layer_func (" << unique_layer_name << ") "
+                  << this->layer() << "/" << group().nlayers()
+                  << " after llvm  = "
+                  << ll.bitcode_string(ll.current_function()) << "\n";
+
+    if (ll.debug_is_enabled()) {
+        ll.debug_pop_function();
+    }
+    ll.pop_shader_instance();
+    ll.end_builder();  // clear the builder
+
+    OSL_ASSERT(
+        m_temp_scopes.empty()
+        && "LOGIC BUG, all BatchedBackendLLVM::TempScope's should be destroyed by now");
+    // Any temp allocations we've been tracking in the function's scope
+    // will no longer be valid
+    m_temp_allocs.clear();
+
+    return ll.current_function();
+}
+
+
+
+void
+BatchedBackendLLVM::initialize_llvm_group()
+{
+    if (ll.debug_is_enabled()) {
+        const char* compile_unit_name = m_group.m_name.empty()
+                                            ? unknown_shader_group_name.c_str()
+                                            : m_group.m_name.c_str();
+
+        ll.debug_setup_compilation_unit(compile_unit_name);
+    }
+
+    ll.setup_optimization_passes(shadingsys().llvm_optimize(),
+                                 true /*targetHost*/);
+
+    // Clear the shaderglobals and groupdata types -- they will be
+    // created on demand.
+    m_llvm_type_sg                      = NULL;
+    m_llvm_type_groupdata               = NULL;
+    m_llvm_type_closure_component       = NULL;
+    m_llvm_type_batched_texture_options = NULL;
+    m_llvm_type_batched_trace_options   = NULL;
+
+    initialize_llvm_helper_function_map();
+
+    m_target_lib_helper->init_function_map(shadingsys());
+
+    ll.InstallLazyFunctionCreator(helper_function_lookup);
+
+    for (HelperFuncMap::iterator i = llvm_helper_function_map.begin(),
+                                 e = llvm_helper_function_map.end();
+         i != e; ++i) {
+        // In case we have loaded multiple target libraries, we need to filter out
+        // library functions for different isa's or vector widths
+        if ((i->second.vector_width != 0 && i->second.vector_width != m_width)
+            || (i->second.target_isa != TargetISA::UNKNOWN
+                && i->second.target_isa != ll.target_isa())) {
+            continue;  // Skip declaring functions for different vector widths and ISA targets
+        }
+        const std::string& funcname(i->first);
+        //std::cout << "OSL Library Function Fwd:" << funcname << std::endl;
+        bool varargs      = false;
+        const char* types = i->second.argtypes;
+        int advance;
+        bool ret_is_uniform;
+        TypeSpec rettype = possibly_wide_type_from_code(types, &advance,
+                                                        ret_is_uniform);
+        types += advance;
+        std::vector<llvm::Type*> params;
+        if (ret_is_uniform == false) {
+            // For varying return types, we pass a pointer to the wide type as the 1st
+            // parameter
+            params.push_back(llvm_pass_wide_type(rettype));
+        }
+
+        while (*types) {
+            bool pass_is_uniform;
+            TypeSpec t = possibly_wide_type_from_code(types, &advance,
+                                                      pass_is_uniform);
+            if (t.simpletype().basetype == TypeDesc::UNKNOWN) {
+                if (*types == '*')
+                    varargs = true;
+                else
+                    OSL_ASSERT(0);
+            } else {
+                if (pass_is_uniform) {
+                    params.push_back(llvm_pass_type(t));
+                } else {
+                    params.push_back(llvm_pass_wide_type(t));
+                }
+            }
+            types += advance;
+        }
+        llvm::Function* f = nullptr;
+        if (ret_is_uniform) {
+            f = ll.make_function(funcname, false, llvm_type(rettype), params,
+                                 varargs);
+        } else {
+            f = ll.make_function(funcname, false, ll.type_void(), params,
+                                 varargs);
+        }
+        ll.add_function_mapping(f, (void*)i->second.function);
+    }
+
+    // Needed for closure setup
+    std::vector<llvm::Type*> params(3);
+    params[0]                        = (llvm::Type*)ll.type_char_ptr();
+    params[1]                        = ll.type_int();
+    params[2]                        = (llvm::Type*)ll.type_char_ptr();
+    m_llvm_type_prepare_closure_func = ll.type_function_ptr(ll.type_void(),
+                                                            params);
+    m_llvm_type_setup_closure_func   = m_llvm_type_prepare_closure_func;
+}
+
+template<int WidthT>
+void
+BatchedBackendLLVM::build_offsets_of_BatchedShaderGlobals(
+    std::vector<unsigned int>& offset_by_index)
+{
+    typedef OSL::BatchedShaderGlobals<WidthT> sgBatch;
+    auto uniform_offset = offsetof(sgBatch, uniform);
+    auto varying_offset = offsetof(sgBatch, varying);
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, renderstate));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, tracedata));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, objdata));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, context));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, renderer));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, Ci));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, raytype));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, pad0));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, pad1));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformShaderGlobals, pad2));
+
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, P));
+    // Triple type in LLVM, so next 2 are included in it
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dPdx));
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dPdy));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, dPdz));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, I));
+    // Triple type in LLVM, so next 2 are included in it
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dIdx));
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dIdy));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, N));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, Ng));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, u));
+    // Triple type in LLVM, so next 2 are included in it
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dudx));
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dudy));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, v));
+    // Triple type in LLVM, so next 2 are included in it
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dvdx));
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dvdy));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, dPdu));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, dPdv));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, time));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, dtime));
+    offset_by_index.push_back(
+        varying_offset + offsetof(VaryingShaderGlobals<WidthT>, dPdtime));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingShaderGlobals<WidthT>, Ps));
+    // Triple type in LLVM, so next 2 are included in it
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dPsdx));
+    //    offset_by_index.push_back(varying_offset + offsetof(VaryingShaderGlobals<WidthT>,dPsdy));
+    offset_by_index.push_back(
+        varying_offset + offsetof(VaryingShaderGlobals<WidthT>, object2common));
+    offset_by_index.push_back(
+        varying_offset + offsetof(VaryingShaderGlobals<WidthT>, shader2common));
+    offset_by_index.push_back(
+        varying_offset + offsetof(VaryingShaderGlobals<WidthT>, surfacearea));
+    offset_by_index.push_back(
+        varying_offset
+        + offsetof(VaryingShaderGlobals<WidthT>, flipHandedness));
+    offset_by_index.push_back(
+        varying_offset + offsetof(VaryingShaderGlobals<WidthT>, backfacing));
+}
+
+
+template<int WidthT>
+void
+BatchedBackendLLVM::build_offsets_of_BatchedTextureOptions(
+    std::vector<unsigned int>& offset_by_index)
+{
+    auto uniform_offset = offsetof(BatchedTextureOptions<WidthT>, uniform);
+    auto varying_offset = offsetof(BatchedTextureOptions<WidthT>, varying);
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingTextureOptions<WidthT>, sblur));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingTextureOptions<WidthT>, tblur));
+    offset_by_index.push_back(varying_offset
+                              + offsetof(VaryingTextureOptions<WidthT>, rblur));
+    offset_by_index.push_back(
+        varying_offset + offsetof(VaryingTextureOptions<WidthT>, swidth));
+    offset_by_index.push_back(
+        varying_offset + offsetof(VaryingTextureOptions<WidthT>, twidth));
+    offset_by_index.push_back(
+        varying_offset + offsetof(VaryingTextureOptions<WidthT>, rwidth));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, firstchannel));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, subimage));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, subimagename));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, swrap));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, twrap));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, rwrap));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, mipmode));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, interpmode));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, anisotropic));
+    offset_by_index.push_back(
+        uniform_offset + offsetof(UniformTextureOptions, conservative_filter));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, fill));
+    offset_by_index.push_back(uniform_offset
+                              + offsetof(UniformTextureOptions, missingcolor));
+    offset_by_index.push_back(
+        offsetof(BatchedTextureOptions<WidthT>, private_envlayout));
+}
+
+void
+BatchedBackendLLVM::run()
+{
+    // We choose to always run a JIT function to allow scalar default values to be
+    // broadcast out to GroupData, so do not skip running if a group().does_nothing()
+    // TODO: Technically we could run just 1 time, then not bother afterwards
+
+    // At this point, we already hold the lock for this group, by virtue
+    // of ShadingSystemImpl::batch_jit_group.
+    OIIO::Timer timer;
+    std::string err;
+
+    {
+#ifdef OSL_LLVM_NO_BITCODE
+        // I don't know which exact part has thread safety issues, but it
+        // crashes on windows when we don't lock.
+        // FIXME -- try subsequent LLVM releases on Windows to see if this
+        // is a problem that is eventually fixed on the LLVM side.
+        static spin_mutex mutex;
+        OIIO::spin_lock lock(mutex);
+#endif
+
+#ifdef OSL_LLVM_NO_BITCODE
+        ll.module(ll.new_module("llvm_ops"));
+#else
+        ll.module(ll.module_from_bitcode((char*)osl_llvm_compiled_ops_block,
+                                         osl_llvm_compiled_ops_size, "llvm_ops",
+                                         &err));
+        if (err.length())
+            shadingcontext()->errorf("ParseBitcodeFile returned '%s'\n",
+                                     err.c_str());
+        OSL_ASSERT(ll.module());
+#endif
+        // Create the ExecutionEngine
+        if (!ll.make_jit_execengine(
+                &err, ll.lookup_isa_by_name(shadingsys().m_llvm_jit_target),
+                shadingsys().llvm_debugging_symbols(),
+                shadingsys().llvm_profiling_events())) {
+            shadingcontext()->errorf("Failed to create engine: %s\n",
+                                     err.c_str());
+            OSL_ASSERT(0);
+            return;
+        }
+
+        // End of mutex lock, for the OSL_LLVM_NO_BITCODE case
+    }
+
+    m_target_lib_helper = TargetLibraryHelper::build(vector_width(),
+                                                     ll.target_isa());
+    OSL_ASSERT(m_target_lib_helper);
+    OSL_ASSERT(m_library_selector == nullptr);
+    m_library_selector = m_target_lib_helper->library_selector();
+
+    m_stat_llvm_setup_time += timer.lap();
+
+    // Set up m_num_used_layers to be the number of layers that are
+    // actually used, and m_layer_remap[] to map original layer numbers
+    // to the shorter list of actually-called layers. We also note that
+    // if m_layer_remap[i] is < 0, it's not a layer that's used.
+    int nlayers = group().nlayers();
+    m_layer_remap.resize(nlayers, -1);
+    m_num_used_layers = 0;
+    if (debug() >= 1)
+        std::cout << "\nLayers used: (group " << group().name() << ")\n";
+    for (int layer = 0; layer < nlayers; ++layer) {
+        // Skip unused or empty layers, unless they are callable entry
+        // points.
+        ShaderInstance* inst = group()[layer];
+        bool is_single_entry = (layer == (nlayers - 1)
+                                && group().num_entry_layers() == 0);
+        if (inst->entry_layer() || is_single_entry
+            || (!inst->unused() && !inst->empty_instance())) {
+            if (debug() >= 1)
+                std::cout << "  " << layer << ' ' << inst->layername() << "\n";
+            m_layer_remap[layer] = m_num_used_layers++;
+        }
+    }
+    shadingsys().m_stat_empty_instances += nlayers - m_num_used_layers;
+
+    initialize_llvm_group();
+
+    // Generate the LLVM IR for each layer.  Skip unused layers.
+    m_llvm_local_mem          = 0;
+    llvm::Function* init_func = build_llvm_init();
+
+#if 0 && defined(OSL_DEV)
+    std::cout << "llvm's data layout of GroupData" << std::endl;
+    ll.dump_struct_data_layout(m_llvm_type_groupdata);
+
+    std::cout << std::endl << std::endl << "llvm's data layout of ShaderGlobalBatch" << std::endl;
+    ll.dump_struct_data_layout(m_llvm_type_sg);
+
+#endif
+    {
+        std::vector<unsigned int> offset_by_index;
+        switch (m_width) {
+        case 8:
+            build_offsets_of_BatchedShaderGlobals<8>(offset_by_index);
+            break;
+        case 16:
+            build_offsets_of_BatchedShaderGlobals<16>(offset_by_index);
+            break;
+        default:
+            OSL_ASSERT(
+                0
+                && "Unsupported width of batch.  Only widths 8 and 16 are allowed");
+            break;
+        };
+        ll.validate_struct_data_layout(m_llvm_type_sg, offset_by_index);
+    }
+
+
+    std::vector<llvm::Function*> funcs(nlayers, NULL);
+    for (int layer = 0; layer < nlayers; ++layer) {
+        set_inst(layer);
+        if (m_layer_remap[layer] != -1) {
+            // If no entry points were specified, the last layer is special,
+            // it's the single entry point for the whole group.
+            bool is_single_entry = (layer == (nlayers - 1)
+                                    && group().num_entry_layers() == 0);
+
+            OSL_DEV_ONLY(std::cout << "build_llvm_instance for layer=" << layer
+                                   << std::endl);
+            funcs[layer] = build_llvm_instance(is_single_entry);
+        }
+    }
+    // llvm::Function* entry_func = group().num_entry_layers() ? NULL : funcs[m_num_used_layers-1];
+    m_stat_llvm_irgen_time += timer.lap();
+
+    if (shadingsys().m_max_local_mem_KB
+        && m_llvm_local_mem / 1024 > shadingsys().m_max_local_mem_KB) {
+        shadingcontext()->errorf(
+            "Shader group \"%s\" needs too much local storage: %d KB",
+            group().name(), m_llvm_local_mem / 1024);
+    }
+
+    // The module contains tons of "library" functions that our generated
+    // IR might call. But probably not. We don't want to incur the overhead
+    // of fully compiling those, so we tell LLVM_Util to turn them into
+    // non-externally-visible symbols (allowing them to be discarded if not
+    // used internal to the module). We need to make exceptions for our
+    // entry points, as well as for all the external functions that are
+    // just declarations (not definitions) in the module (which we have
+    // conveniently stashed in external_function_names).
+#if 0
+    std::vector<std::string> entry_function_names;
+    entry_function_names.push_back (ll.func_name(init_func));
+    for (int layer = 0; layer < nlayers; ++layer) {
+        // set_inst (layer);
+        llvm::Function* f = funcs[layer];
+        if (f && group().is_entry_layer(layer))
+            entry_function_names.push_back (ll.func_name(f));
+    }
+    ll.internalize_module_functions ("osl_", external_function_names, entry_function_names);
+#else
+    std::unordered_set<llvm::Function*> external_functions;
+    external_functions.insert(init_func);
+    for (int layer = 0; layer < nlayers; ++layer) {
+        // set_inst (layer);
+        llvm::Function* f = funcs[layer];
+        // If we plan to call bitcode_string of a layer's function after optimization
+        // it may not exist after optimization unless we treat it as external.
+        if (f && (group().is_entry_layer(layer) || llvm_debug())) {
+            external_functions.insert(f);
+        }
+    }
+    ll.prune_and_internalize_module(external_functions);
+#endif
+
+    // Debug code to dump the pre-optimized bitcode to a file
+    if (llvm_debug() >= 2 || shadingsys().llvm_output_bitcode()) {
+        // Make a safe group name that doesn't have "/" in it! Also beware
+        // filename length limits.
+        std::string safegroup = Strutil::replace(group().name(), "/", ".",
+                                                 true);
+        if (safegroup.size() > 235)
+            safegroup
+                = Strutil::sprintf("TRUNC_%s_%d",
+                                   safegroup.substr(safegroup.size() - 235),
+                                   group().id());
+        std::string name = Strutil::sprintf("%s.ll", safegroup);
+        std::ofstream out(name, std::ios_base::out | std::ios_base::trunc);
+        if (out.good()) {
+            out << ll.bitcode_string(ll.module());
+        } else {
+            shadingcontext()->errorf("Could not write to '%s'", name);
+        }
+    }
+
+    // Optimize the LLVM IR EVEN IF it's a do-nothing group.
+    // We choose to always run a JIT function to allow scalar default values to be
+    // broadcast out to GroupData, so do not skip running if a group().does_nothing()
+    ll.do_optimize();
+
+    m_stat_llvm_opt_time += timer.lap();
+
+    if (llvm_debug()) {
+#if 1
+        // Feel it is more useful to get a dump of the entire optimized module
+        // vs. individual layer functions.  Especially now because we have pruned all
+        // unused function declarations and functions out of the the module.
+        // Big benefit is that the module output can be cut and pasted into
+        // https://godbolt.org/ compiler explorer as LLVM IR with a LLC target
+        // and -mcpu= options to see what machine code will be generated by
+        // different LLC versions and cpu targets
+        std::cout << "module after opt  = \n" << ll.module_string() << "\n";
+#else
+        for (int layer = 0; layer < nlayers; ++layer)
+            if (funcs[layer])
+                std::cout << "func after opt  = "
+                          << ll.bitcode_string(funcs[layer]) << "\n";
+#endif
+        std::cout.flush();
+    }
+
+    // Debug code to dump the post-optimized bitcode to a file
+    if (llvm_debug() >= 2 || shadingsys().llvm_output_bitcode()) {
+        // Make a safe group name that doesn't have "/" in it! Also beware
+        // filename length limits.
+        std::string safegroup = Strutil::replace(group().name(), "/", ".",
+                                                 true);
+        if (safegroup.size() > 235)
+            safegroup
+                = Strutil::sprintf("TRUNC_%s_%d",
+                                   safegroup.substr(safegroup.size() - 235),
+                                   group().id());
+        std::string name = Strutil::sprintf("%s_opt.ll", safegroup);
+        std::ofstream out(name, std::ios_base::out | std::ios_base::trunc);
+        if (out.good()) {
+            out << ll.bitcode_string(ll.module());
+        } else {
+            shadingcontext()->errorf("Could not write to '%s'", name);
+        }
+    }
+
+    // Force the JIT to happen now and retrieve the JITed function pointers
+    // for the initialization and all public entry points.
+    group().llvm_compiled_wide_init(
+        (RunLLVMGroupFuncWide)ll.getPointerToFunction(init_func));
+    for (int layer = 0; layer < nlayers; ++layer) {
+        llvm::Function* f = funcs[layer];
+        if (f && group().is_entry_layer(layer))
+            group().llvm_compiled_wide_layer(
+                layer, (RunLLVMGroupFuncWide)ll.getPointerToFunction(f));
+    }
+    if (group().num_entry_layers())
+        group().llvm_compiled_wide_version(NULL);
+    else
+        group().llvm_compiled_wide_version(
+            group().llvm_compiled_wide_layer(nlayers - 1));
+
+    // We are destroying the entire module below, no reason to bother
+    // destroying individual functions
+
+    // Free the exec and module to reclaim all the memory.  This definitely
+    // saves memory, and has almost no effect on runtime.
+    ll.execengine(NULL);
+
+    // N.B. Destroying the EE should have destroyed the module as well.
+    ll.module(NULL);
+
+    m_stat_llvm_jit_time += timer.lap();
+
+    m_stat_total_llvm_time = timer();
+
+    if (shadingsys().m_compile_report) {
+        shadingcontext()->infof("JITed shader group %s:", group().name());
+        shadingcontext()->infof(
+            "    (%1.2fs = %1.2f setup, %1.2f ir, %1.2f opt, %1.2f jit; local mem %dKB)",
+            m_stat_total_llvm_time, m_stat_llvm_setup_time,
+            m_stat_llvm_irgen_time, m_stat_llvm_opt_time, m_stat_llvm_jit_time,
+            m_llvm_local_mem / 1024);
+    }
+}
+
+
+
+};  // namespace pvt
+OSL_NAMESPACE_EXIT

--- a/src/liboslexec/builtindecl_wide_xmacro.h
+++ b/src/liboslexec/builtindecl_wide_xmacro.h
@@ -1,0 +1,687 @@
+/*
+Copyright (c) 2009-2014 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+// This file contains "declarations" for all the functions that might get
+// called from JITed shader code. But the declaration itself is dependent on
+// the DECL macro, which should be declared by the outer file prior to
+// including this file. Thus, this list may be repurposed and included
+// multiple times, with different DECL definitions.
+
+
+#ifndef DECL
+#    error Do not include this file unless DECL is defined
+#endif
+
+// NOTE: the trailing 'i' at the end of the signature
+// is an 32 bit integer representing the mask (on bits are active lanes)
+
+#define WIDE_NOISE_IMPL_INDIRECT(name)                  \
+    DECL(__OSL_MASKED_OP2(name, Wf, Wf), "WfWfi")       \
+    DECL(__OSL_MASKED_OP2(name, Wf, Wv), "WfWvi")       \
+    DECL(__OSL_MASKED_OP2(name, Wv, Wv), "WvWvi")       \
+    DECL(__OSL_MASKED_OP2(name, Wv, Wf), "WvWfi")       \
+    DECL(__OSL_MASKED_OP3(name, Wv, Wv, Wf), "WvWvWfi") \
+    DECL(__OSL_MASKED_OP3(name, Wf, Wf, Wf), "WfWfWfi") \
+    DECL(__OSL_MASKED_OP3(name, Wf, Wv, Wf), "WfWvWfi") \
+    DECL(__OSL_MASKED_OP3(name, Wv, Wf, Wf), "WvWfWfi")
+
+
+#define WIDE_NOISE_IMPL(name) WIDE_NOISE_IMPL_INDIRECT(name)
+
+
+#define WIDE_NOISE_DERIV_IMPL_INDIRECT(name)             \
+    DECL(__OSL_MASKED_OP2(name, Wdf, Wdf), "xXXi")       \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdf, Wdf), "xXXXi") \
+    DECL(__OSL_MASKED_OP2(name, Wdf, Wdv), "xXXi")       \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdv, Wdf), "xXXXi") \
+    DECL(__OSL_MASKED_OP2(name, Wdv, Wdf), "xXXi")       \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdf, Wdf), "xXXXi") \
+    DECL(__OSL_MASKED_OP2(name, Wdv, Wdv), "xXXi")       \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdv, Wdf), "xXXXi")
+
+#define WIDE_NOISE_DERIV_IMPL(name) WIDE_NOISE_DERIV_IMPL_INDIRECT(name)
+
+
+#define WIDE_GENERIC_NOISE_DERIV_IMPL_INDIRECT(name)         \
+    DECL(__OSL_MASKED_OP2(name, Wdf, Wdf), "xsXXXXXi")       \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdf, Wdf), "xsXXXXXXi") \
+    DECL(__OSL_MASKED_OP2(name, Wdf, Wdv), "xsXXXXXi")       \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdv, Wdf), "xsXXXXXXi") \
+    DECL(__OSL_MASKED_OP2(name, Wdv, Wdf), "xsXXXXXi")       \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdf, Wdf), "xsXXXXXXi") \
+    DECL(__OSL_MASKED_OP2(name, Wdv, Wdv), "xsXXXXXi")       \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdv, Wdf), "xsXXXXXXi")
+
+#define WIDE_GENERIC_NOISE_DERIV_IMPL(name) \
+    WIDE_GENERIC_NOISE_DERIV_IMPL_INDIRECT(name)
+
+
+#define WIDE_PNOISE_IMPL_INDIRECT(name)                             \
+    DECL(__OSL_MASKED_OP3(name, Wf, Wf, Wf), "WfWfWfi")             \
+    DECL(__OSL_MASKED_OP5(name, Wf, Wf, Wf, Wf, Wf), "WfWfWfWfWfi") \
+    DECL(__OSL_MASKED_OP3(name, Wf, Wv, Wv), "WfWvWvi")             \
+    DECL(__OSL_MASKED_OP5(name, Wf, Wv, Wf, Wv, Wf), "WfWvWfWvWfi") \
+    DECL(__OSL_MASKED_OP3(name, Wv, Wf, Wf), "WvWfWfi")             \
+    DECL(__OSL_MASKED_OP5(name, Wv, Wf, Wf, Wf, Wf), "WvWfWfWfWfi") \
+    DECL(__OSL_MASKED_OP3(name, Wv, Wv, Wv), "WvWvWvi")             \
+    DECL(__OSL_MASKED_OP5(name, Wv, Wv, Wf, Wv, Wf), "WvWvWfWvWfi")
+
+
+#define WIDE_PNOISE_IMPL(name) WIDE_PNOISE_IMPL_INDIRECT(name)
+
+
+// NOTE:  any constants passed along with other derivative parameters,
+// are promoted to wide derivatives on the stack by the code generator
+// the upshot of this is that one parameter is a derivative/wide then
+// there will be no combinations with any non-wide parameters
+#define WIDE_PNOISE_DERIV_IMPL_INDIRECT(name)                      \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdf, Wf), "xXXXi")            \
+    DECL(__OSL_MASKED_OP5(name, Wdf, Wdf, Wdf, Wf, Wf), "xXXXXXi") \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdv, Wv), "xXXXi")            \
+    DECL(__OSL_MASKED_OP5(name, Wdf, Wdv, Wdf, Wv, Wf), "xXXXXXi") \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdf, Wf), "xXXXi")            \
+    DECL(__OSL_MASKED_OP5(name, Wdv, Wdf, Wdf, Wf, Wf), "xXXXXXi") \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdv, Wv), "xXXXi")            \
+    DECL(__OSL_MASKED_OP5(name, Wdv, Wdv, Wdf, Wv, Wf), "xXXXXXi")
+
+#define WIDE_PNOISE_DERIV_IMPL(name) WIDE_PNOISE_DERIV_IMPL_INDIRECT(name)
+
+
+#define WIDE_GENERIC_PNOISE_DERIV_IMPL_INDIRECT(name)                  \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdf, Wf), "xsXXXXXXi")            \
+    DECL(__OSL_MASKED_OP5(name, Wdf, Wdf, Wdf, Wf, Wf), "xsXXXXXXXXi") \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdv, Wv), "xsXXXXXXi")            \
+    DECL(__OSL_MASKED_OP5(name, Wdf, Wdv, Wdf, Wv, Wf), "xsXXXXXXXXi") \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdf, Wf), "xsXXXXXXi")            \
+    DECL(__OSL_MASKED_OP5(name, Wdv, Wdf, Wdf, Wf, Wf), "xsXXXXXXXXi") \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdv, Wv), "xsXXXXXXi")            \
+    DECL(__OSL_MASKED_OP5(name, Wdv, Wdv, Wdf, Wv, Wf), "xsXXXXXXXXi")
+
+#define WIDE_GENERIC_PNOISE_DERIV_IMPL(name) \
+    WIDE_GENERIC_PNOISE_DERIV_IMPL_INDIRECT(name)
+
+
+#define WIDE_UNARY_F_OP_IMPL(name)               \
+    DECL(__OSL_OP2(name, Wf, Wf), "xXX")         \
+    DECL(__OSL_MASKED_OP2(name, Wf, Wf), "xXXi") \
+    DECL(__OSL_OP2(name, Wdf, Wdf), "xXX")       \
+    DECL(__OSL_MASKED_OP2(name, Wdf, Wdf), "xXXi")
+
+#define WIDE_UNARY_OP_IMPL(name)                 \
+    WIDE_UNARY_F_OP_IMPL(name)                   \
+    DECL(__OSL_OP2(name, Wv, Wv), "xXX")         \
+    DECL(__OSL_MASKED_OP2(name, Wv, Wv), "xXXi") \
+    DECL(__OSL_OP2(name, Wdv, Wdv), "xXX")       \
+    DECL(__OSL_MASKED_OP2(name, Wdv, Wdv), "xXXi")
+
+
+#define WIDE_UNARY_I_OP_IMPL(name)       \
+    DECL(__OSL_OP2(name, Wi, Wi), "xXX") \
+    DECL(__OSL_MASKED_OP2(name, Wi, Wi), "xXXi")
+
+
+#define WIDE_TEST_F_OP_IMPL(name)        \
+    DECL(__OSL_OP2(name, Wi, Wf), "xXX") \
+    DECL(__OSL_MASKED_OP2(name, Wi, Wf), "xXXi")
+
+
+#define WIDE_UNARY_F_OR_V_OP_IMPL(name)          \
+    DECL(__OSL_OP2(name, Wf, Wf), "xXX")         \
+    DECL(__OSL_MASKED_OP2(name, Wf, Wf), "xXXi") \
+    DECL(__OSL_OP2(name, Wv, Wv), "xXX")         \
+    DECL(__OSL_MASKED_OP2(name, Wv, Wv), "xXXi")
+
+#define WIDE_BINARY_OP_IMPL(name)                        \
+    DECL(__OSL_OP3(name, Wf, Wf, Wf), "xXXX")            \
+    DECL(__OSL_MASKED_OP3(name, Wf, Wf, Wf), "xXXXi")    \
+    DECL(__OSL_OP3(name, Wdf, Wdf, Wdf), "xXXX")         \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdf, Wdf), "xXXXi") \
+    DECL(__OSL_OP3(name, Wdf, Wf, Wdf), "xXXX")          \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wf, Wdf), "xXXXi")  \
+    DECL(__OSL_OP3(name, Wdf, Wdf, Wf), "xXXX")          \
+    DECL(__OSL_MASKED_OP3(name, Wdf, Wdf, Wf), "xXXXi")  \
+    DECL(__OSL_OP3(name, Wv, Wv, Wv), "xXXX")            \
+    DECL(__OSL_MASKED_OP3(name, Wv, Wv, Wv), "xXXXi")    \
+    DECL(__OSL_OP3(name, Wdv, Wdv, Wdv), "xXXX")         \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdv, Wdv), "xXXXi") \
+    DECL(__OSL_OP3(name, Wdv, Wv, Wdv), "xXXX")          \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wv, Wdv), "xXXXi")  \
+    DECL(__OSL_OP3(name, Wdv, Wdv, Wv), "xXXX")          \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdv, Wv), "xXXXi")
+
+
+#define WIDE_BINARY_VF_OP_IMPL(name)                     \
+    DECL(__OSL_OP3(name, Wv, Wv, Wf), "xXXX")            \
+    DECL(__OSL_OP3(name, Wdv, Wdv, Wdf), "xXXX")         \
+    DECL(__OSL_OP3(name, Wdv, Wdv, Wf), "xXXX")          \
+    DECL(__OSL_OP3(name, Wdv, Wv, Wdf), "xXXX")          \
+    DECL(__OSL_MASKED_OP3(name, Wv, Wv, Wf), "xXXXi")    \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdv, Wdf), "xXXXi") \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wdv, Wf), "xXXXi")  \
+    DECL(__OSL_MASKED_OP3(name, Wdv, Wv, Wdf), "xXXXi")
+
+
+#define WIDE_BINARY_F_OR_V_OP_IMPL(name)              \
+    DECL(__OSL_OP3(name, Wf, Wf, Wf), "xXXX")         \
+    DECL(__OSL_MASKED_OP3(name, Wf, Wf, Wf), "xXXXi") \
+    DECL(__OSL_OP3(name, Wv, Wv, Wv), "xXXX")         \
+    DECL(__OSL_MASKED_OP3(name, Wv, Wv, Wv), "xXXXi")
+
+#if 0  // incomplete closure support
+    DECL (osl_add_closure_closure, "CXCC")
+    DECL (osl_mul_closure_float, "CXCf")
+    DECL (osl_mul_closure_color, "CXCc")
+    DECL (osl_allocate_closure_component, "CXii")
+    DECL (osl_allocate_weighted_closure_component, "CXiiX")
+    DECL (osl_closure_to_string, "sXC")
+#endif
+
+DECL(__OSL_OP(format), "xXis*")
+DECL(__OSL_OP(printf), "xXis*")
+DECL(__OSL_OP(error), "xXis*")
+DECL(__OSL_OP(warning), "xXis*")
+DECL(__OSL_OP(fprintf), "xXiss*")
+
+
+DECL(__OSL_MASKED_OP(split), "xXXXXXii")
+
+// DECL (osl_incr_layers_executed, "xX") // original used by wide currently
+
+
+
+WIDE_NOISE_IMPL(cellnoise)
+// commented out in non-wide, there is no derivative version of cellnoise
+//WIDE_NOISE_DERIV_IMPL(cellnoise)
+
+WIDE_NOISE_IMPL(noise)
+WIDE_NOISE_DERIV_IMPL(noise)
+
+WIDE_NOISE_IMPL(snoise)
+WIDE_NOISE_DERIV_IMPL(snoise)
+
+WIDE_NOISE_IMPL(simplexnoise)
+WIDE_NOISE_DERIV_IMPL(simplexnoise)
+
+WIDE_NOISE_IMPL(usimplexnoise)
+WIDE_NOISE_DERIV_IMPL(usimplexnoise)
+
+
+WIDE_PNOISE_IMPL(pnoise)
+WIDE_PNOISE_DERIV_IMPL(pnoise)
+
+WIDE_PNOISE_IMPL(psnoise)
+WIDE_PNOISE_DERIV_IMPL(psnoise)
+
+WIDE_PNOISE_IMPL(pcellnoise)
+// commented out in non-wide, there is no derivative version of pcellnoise
+//WIDE_PNOISE_DERIV_IMPL(pcellnoise)
+
+
+WIDE_GENERIC_NOISE_DERIV_IMPL(gabornoise)
+WIDE_GENERIC_PNOISE_DERIV_IMPL(gaborpnoise)
+
+WIDE_GENERIC_NOISE_DERIV_IMPL(genericnoise)
+WIDE_GENERIC_PNOISE_DERIV_IMPL(genericpnoise)
+
+WIDE_NOISE_IMPL(nullnoise)
+WIDE_NOISE_DERIV_IMPL(nullnoise)
+
+WIDE_NOISE_IMPL(unullnoise)
+WIDE_NOISE_DERIV_IMPL(unullnoise)
+
+//DECL (osl_noiseparams_set_anisotropic, "xXi") // share non-wide impl
+//DECL (osl_noiseparams_set_do_filter, "xXi") // share non-wide impl
+//DECL (osl_noiseparams_set_direction, "xXv") // share non-wide impl
+//DECL (osl_noiseparams_set_bandwidth, "xXf") // share non-wide impl
+//DECL (osl_noiseparams_set_impulses, "xXf")  // share non-wide impl
+
+DECL(__OSL_OP(count_noise), "xX")
+
+// Need wide for combinations of the 3 parameters allowed to be uniform
+// caveat, some combos are unreachable/uneeded
+// When result has a derivative, there is
+// no "easy" have a input parameter be non-derivative based on code
+// analysis promoting all inputs to be derivative base.
+// Some exceptions are possible, such a directly passing a shader global
+// Those cases can be worked around by creating a variable on the stack
+// first vs. directly passing the shader global.  We don't expect this
+// to be encountered, but is possible
+
+DECL(__OSL_MASKED_OP3(spline, Wf, Wf, Wf), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wf, Wf, f), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wf, f, Wf), "xXXXXiii")
+
+
+DECL(__OSL_MASKED_OP3(spline, Wdf, Wdf, Wdf), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdf, Wdf, df), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdf, df, Wdf), "xXXXXiii")
+
+//SM: Check other previously-thought-impossible variants
+DECL(__OSL_MASKED_OP3(spline, Wdf, Wdf, f), "xXXXXiii")
+
+DECL(__OSL_MASKED_OP3(spline, Wv, Wf, Wv), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wv, Wf, v), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wv, f, Wv), "xXXXXiii")
+
+DECL(__OSL_MASKED_OP3(spline, Wdv, Wdf, Wdv), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdv, Wdf, dv), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdv, df, Wdv), "xXXXXiii")
+
+DECL(__OSL_MASKED_OP3(spline, Wdv, Wdf, v), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdv, Wdf, Wv), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdv, df, Wv), "xXXXXiii")
+
+//SM: Check other previously-thought-impossible variants
+DECL(__OSL_MASKED_OP3(spline, Wdf, f, Wdf), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdf, Wf, Wdf), "xXXXXiii")
+
+DECL(__OSL_MASKED_OP3(spline, Wdv, f, Wdv), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdv, Wf, Wdv), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(spline, Wdv, Wf, dv), "xXXXXiii")
+
+//---------------------------------------------------------------
+DECL(__OSL_MASKED_OP3(splineinverse, Wf, Wf, Wf), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(splineinverse, Wf, Wf, f), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(splineinverse, Wf, f, Wf), "xXXXXiii")
+
+//dfdfdf is treated as dfdff
+DECL(__OSL_MASKED_OP3(splineinverse, Wdf, Wdf, Wdf), "xXXXXiii")  //redone
+DECL(__OSL_MASKED_OP3(splineinverse, Wdf, Wdf, df), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(splineinverse, Wdf, df, Wdf), "xXXXXiii")
+//======
+DECL(__OSL_MASKED_OP3(splineinverse, Wdf, Wdf, f), "xXXXXiii")
+
+//dffdf is treated as fff
+DECL(__OSL_MASKED_OP3(splineinverse, Wdf, f, Wdf), "xXXXXiii")
+DECL(__OSL_MASKED_OP3(splineinverse, Wdf, Wf, Wdf), "xXXXXiii")
+
+#if 0  // incomplete
+// setmessage/getmessage involve closures, leave to next iteration
+//DECL (osl_setmessage, "xXsLXisi")
+DECL (osl_pointcloud_search, "iXsXfiiXXii*")
+DECL (osl_pointcloud_get, "iXsXisLX")
+DECL (osl_pointcloud_write, "iXsXiXXX")
+DECL (osl_pointcloud_write_helper, "xXXXisLX")
+//DECL (osl_blackbody_vf, "xXXf")
+//DECL (osl_wavelength_color_vf, "xXXf")
+#endif
+
+DECL(__OSL_MASKED_OP(getmessage), "xXXssLXiisii")
+//DECL (osl_setmessage_uniform_name_wide_data_masked, "xXXLXisii")
+//DECL (osl_setmessage_varying_name_wide_data_masked, "xXXLXisii")
+DECL(__OSL_MASKED_OP(setmessage_uniform_name_wide_data), "xXXLXisii")
+DECL(__OSL_MASKED_OP(setmessage_varying_name_wide_data), "xXXLXisii")
+
+DECL(__OSL_OP(blackbody_vf), "xXXf")
+DECL(__OSL_MASKED_OP2(blackbody, Wv, Wf), "xXXXi")
+
+DECL(__OSL_OP(wavelength_color_vf), "xXXf")
+DECL(__OSL_MASKED_OP2(wavelength_color, Wv, Wf), "xXXXi")
+
+// Code generator handles luminance by itself
+//DECL (osl_luminance_fv, "xXXX")
+//DECL (osl_luminance_dfdv, "xXXX")
+
+DECL(__OSL_OP(prepend_color_from_vs), "xXXs")
+DECL(__OSL_MASKED_OP2(prepend_color_from, Wv, s), "xXXsi")
+DECL(__OSL_MASKED_OP2(prepend_color_from, Wv, Ws), "xXXXi")
+
+// forced masked version only
+DECL(__OSL_MASKED_OP2(prepend_matrix_from, Wm, s), "xXXsi")
+DECL(__OSL_MASKED_OP2(prepend_matrix_from, Wm, Ws), "xXXXi")
+
+// Batched code gen uses a combination of osl_build_transform_matrix
+// with osl_transform_[point|vector|normal] to do the follow functions
+// DECL (osl_get_matrix, "iXXs")  // unneeded
+// DECL (osl_get_inverse_matrix, "iXXs") // unneeded
+// DECL (osl_transform_triple, "iXXiXiXXi") // unneeded
+// DECL (osl_transform_triple_nonlinear, "iXXiXiXXi") // unneeded
+
+DECL(__OSL_MASKED_OP3(build_transform_matrix, Wm, s, s), "iXXXXi")
+DECL(__OSL_MASKED_OP3(build_transform_matrix, Wm, Ws, s), "iXXXXi")
+DECL(__OSL_MASKED_OP3(build_transform_matrix, Wm, s, Ws), "iXXXXi")
+DECL(__OSL_MASKED_OP3(build_transform_matrix, Wm, Ws, Ws), "iXXXXi")
+
+
+DECL(__OSL_OP(dict_find_iis), "iXiX")
+DECL(__OSL_MASKED_OP3(dict_find, Wi, Wi, Ws), "xXXXXi")
+
+DECL(__OSL_OP(dict_find_iss), "iXXX")
+DECL(__OSL_MASKED_OP3(dict_find, Wi, Ws, Ws), "xXXXXi")
+
+DECL(__OSL_OP(dict_next), "iXi")
+DECL(__OSL_MASKED_OP(dict_next), "xXXXi")
+
+DECL(__OSL_OP(dict_value), "iXiXLX")
+DECL(__OSL_MASKED_OP(dict_value), "xXXXXLXi")
+
+
+DECL(__OSL_OP(raytype_name), "iXX")
+DECL(__OSL_MASKED_OP(raytype_name), "xXXXi")
+DECL(__OSL_OP(naninf_check), "xiXiXXiXiiX")
+DECL(__OSL_MASKED_OP1(naninf_check_offset, i), "xiiXiXXiXiiX")
+DECL(__OSL_MASKED_OP1(naninf_check_offset, Wi), "xiiXiXXiXXiX")
+DECL(__OSL_OP(range_check), "iiiXXXiXiXX")
+DECL(__OSL_MASKED_OP(range_check), "xXiiXXXiXiXX")
+DECL(__OSL_OP2(uninit_check_values_offset, X, i), "xLXXXiXiXXiXiXii")
+DECL(__OSL_MASKED_OP2(uninit_check_values_offset, X, Wi), "xiLXXXiXiXXiXiXXi")
+DECL(__OSL_MASKED_OP2(uninit_check_values_offset, WX, i), "xiLXXXiXiXXiXiXii")
+DECL(__OSL_MASKED_OP2(uninit_check_values_offset, WX, Wi), "xiLXXXiXiXXiXiXXi")
+
+DECL(__OSL_OP1(get_attribute, s), "iXiXXiiXXi")
+DECL(__OSL_MASKED_OP1(get_attribute, Ws), "iXiXXiiXXi")
+DECL(__OSL_OP(get_attribute_uniform), "iXiXXiiXX")
+
+// TODO:  shouldn't bind_interpolated_param be MASKED?  change name to reflect
+#ifdef OSL_EXPERIMENTAL_BIND_USER_DATA_WITH_LAYERNAME
+DECL(__OSL_OP(bind_interpolated_param), "iXXXLiXiXiXii")
+#else
+DECL(__OSL_OP(bind_interpolated_param), "iXXLiXiXiXii")
+#endif
+//DECL (osl_get_texture_options, "XX") // uneeded
+DECL(__OSL_OP(get_noise_options), "XX")
+
+// The following are defined inside llvm_ops.cpp. Only include these
+// declarations in the OSL_LLVM_NO_BITCODE case.
+#ifdef OSL_LLVM_NO_BITCODE
+// Because we have to provide the no bitcode versions
+// of these functions anyway, we are not providing
+// bit code versions initially.
+// Can be revisited as an optimization.
+#endif
+
+
+WIDE_UNARY_OP_IMPL(sin)
+WIDE_UNARY_OP_IMPL(cos)
+WIDE_UNARY_OP_IMPL(tan)
+WIDE_UNARY_OP_IMPL(asin)
+WIDE_UNARY_OP_IMPL(acos)  //MAKE_WIDE_UNARY_PERCOMPONENT_OP
+WIDE_UNARY_OP_IMPL(atan)
+WIDE_BINARY_OP_IMPL(atan2)
+WIDE_UNARY_OP_IMPL(sinh)
+WIDE_UNARY_OP_IMPL(cosh)
+WIDE_UNARY_OP_IMPL(tanh)
+
+// DECL (osl_safe_div_iii, "iii") // impl by code generator
+// DECL (osl_safe_div_fff, "fff") // impl by code generator
+// DECL (osl_safe_mod_iii, "iii") // unneeded stdosl.h should have handled int mod(int, int)
+
+DECL(__OSL_OP3(sincos, Wf, Wf, Wf), "xXXX")
+DECL(__OSL_OP3(sincos, Wdf, Wdf, Wf), "xXXX")
+DECL(__OSL_OP3(sincos, Wdf, Wf, Wdf), "xXXX")
+DECL(__OSL_OP3(sincos, Wdf, Wdf, Wdf), "xXXX")
+
+DECL(__OSL_OP3(sincos, Wv, Wv, Wv), "xXXX")
+DECL(__OSL_OP3(sincos, Wdv, Wdv, Wv), "xXXX")
+DECL(__OSL_OP3(sincos, Wdv, Wv, Wdv), "xXXX")
+DECL(__OSL_OP3(sincos, Wdv, Wdv, Wdv), "xXXX")
+
+DECL(__OSL_MASKED_OP3(sincos, Wf, Wf, Wf), "xXXXi")
+DECL(__OSL_MASKED_OP3(sincos, Wdf, Wdf, Wf), "xXXXi")
+DECL(__OSL_MASKED_OP3(sincos, Wdf, Wf, Wdf), "xXXXi")
+DECL(__OSL_MASKED_OP3(sincos, Wdf, Wdf, Wdf), "xXXXi")
+
+DECL(__OSL_MASKED_OP3(sincos, Wv, Wv, Wv), "xXXXi")
+DECL(__OSL_MASKED_OP3(sincos, Wdv, Wdv, Wv), "xXXXi")
+DECL(__OSL_MASKED_OP3(sincos, Wdv, Wv, Wdv), "xXXXi")
+DECL(__OSL_MASKED_OP3(sincos, Wdv, Wdv, Wdv), "xXXXi")
+
+
+WIDE_UNARY_OP_IMPL(log)
+WIDE_UNARY_OP_IMPL(log2)
+WIDE_UNARY_OP_IMPL(log10)
+WIDE_UNARY_OP_IMPL(exp)
+WIDE_UNARY_OP_IMPL(exp2)
+WIDE_UNARY_OP_IMPL(expm1)
+WIDE_BINARY_OP_IMPL(pow)
+WIDE_UNARY_F_OP_IMPL(erf)
+WIDE_UNARY_F_OP_IMPL(erfc)
+
+WIDE_BINARY_VF_OP_IMPL(pow)
+
+WIDE_UNARY_OP_IMPL(sqrt)
+WIDE_UNARY_OP_IMPL(inversesqrt)
+
+WIDE_UNARY_F_OR_V_OP_IMPL(logb)
+WIDE_UNARY_F_OR_V_OP_IMPL(floor)
+
+
+
+WIDE_UNARY_F_OR_V_OP_IMPL(ceil)
+WIDE_UNARY_F_OR_V_OP_IMPL(round)
+WIDE_UNARY_F_OR_V_OP_IMPL(trunc)
+WIDE_UNARY_F_OR_V_OP_IMPL(sign)
+WIDE_BINARY_F_OR_V_OP_IMPL(step)
+
+WIDE_TEST_F_OP_IMPL(isnan)
+WIDE_TEST_F_OP_IMPL(isinf)
+WIDE_TEST_F_OP_IMPL(isfinite)
+WIDE_UNARY_OP_IMPL(abs)
+WIDE_UNARY_I_OP_IMPL(abs)
+WIDE_UNARY_OP_IMPL(fabs)
+
+WIDE_BINARY_F_OR_V_OP_IMPL(fmod)
+// mod for integers is handled by the code generator
+
+DECL(__OSL_OP4(smoothstep, Wf, Wf, Wf, Wf), "xXXXX")
+DECL(__OSL_MASKED_OP4(smoothstep, Wf, Wf, Wf, Wf), "xXXXXi")
+DECL(__OSL_OP4(smoothstep, Wdf, Wdf, Wdf, Wdf), "xXXXX")
+DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wdf, Wdf, Wdf), "xXXXXi")
+DECL(__OSL_OP4(smoothstep, Wdf, Wf, Wdf, Wdf), "xXXXX")
+DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wf, Wdf, Wdf), "xXXXXi")
+DECL(__OSL_OP4(smoothstep, Wdf, Wdf, Wf, Wdf), "xXXXX")
+DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wdf, Wf, Wdf), "xXXXXi")
+DECL(__OSL_OP4(smoothstep, Wdf, Wdf, Wdf, Wf), "xXXXX")
+DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wdf, Wdf, Wf), "xXXXXi")
+DECL(__OSL_OP4(smoothstep, Wdf, Wf, Wf, Wdf), "xXXXX")
+DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wf, Wf, Wdf), "xXXXXi")
+DECL(__OSL_OP4(smoothstep, Wdf, Wdf, Wf, Wf), "xXXXX")
+DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wdf, Wf, Wf), "xXXXXi")
+DECL(__OSL_OP4(smoothstep, Wdf, Wf, Wdf, Wf), "xXXXX")
+DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wf, Wdf, Wf), "xXXXXi")
+
+
+// Replaced by osl_transform_[point|vector|normal]
+// DECL (osl_transform_vmv, "xXXX")
+// DECL (osl_transform_dvmdv, "xXXX")
+// DECL (osl_transformv_vmv, "xXXX")
+// DECL (osl_transformv_dvmdv, "xXXX")
+// DECL (osl_transformn_vmv, "xXXX")
+// DECL (osl_transformn_dvmdv, "xXXX")
+
+DECL(__OSL_MASKED_OP3(transform_point, v, Wv, m), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_point, v, Wv, Wm), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_point, Wv, Wv, Wm), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_point, Wdv, Wdv, Wm), "xXXXii")
+
+DECL(__OSL_MASKED_OP3(transform_point, Wv, Wv, m), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_point, Wdv, Wdv, m), "xXXXii")
+
+DECL(__OSL_MASKED_OP3(transform_vector, v, Wv, m), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_vector, v, Wv, Wm), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_vector, Wv, Wv, Wm), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_vector, Wdv, Wdv, Wm), "xXXXii")
+
+DECL(__OSL_MASKED_OP3(transform_vector, Wv, Wv, m), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_vector, Wdv, Wdv, m), "xXXXii")
+
+
+DECL(__OSL_MASKED_OP3(transform_normal, v, Wv, m), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_normal, v, Wv, Wm), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_normal, Wv, Wv, Wm), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_normal, Wdv, Wdv, Wm), "xXXXii")
+
+DECL(__OSL_MASKED_OP3(transform_normal, Wv, Wv, m), "xXXXii")
+DECL(__OSL_MASKED_OP3(transform_normal, Wdv, Wdv, m), "xXXXii")
+
+DECL(__OSL_MASKED_OP(transform_color), "xXXiXiXXi")
+DECL(__OSL_OP(transform_color), "xXXiXiXX")
+
+
+DECL(__OSL_OP3(dot, Wf, Wv, Wv), "xXXX")
+DECL(__OSL_MASKED_OP3(dot, Wf, Wv, Wv), "xXXXi")
+
+DECL(__OSL_OP3(dot, Wdf, Wdv, Wdv), "xXXX")
+DECL(__OSL_MASKED_OP3(dot, Wdf, Wdv, Wdv), "xXXXi")
+
+DECL(__OSL_OP3(dot, Wdf, Wdv, Wv), "xXXX")
+DECL(__OSL_MASKED_OP3(dot, Wdf, Wdv, Wv), "xXXXi")
+
+DECL(__OSL_OP3(dot, Wdf, Wv, Wdv), "xXXX")
+DECL(__OSL_MASKED_OP3(dot, Wdf, Wv, Wdv), "xXXXi")
+
+
+DECL(__OSL_OP3(cross, Wv, Wv, Wv), "xXXX")
+DECL(__OSL_MASKED_OP3(cross, Wv, Wv, Wv), "xXXXi")
+
+
+DECL(__OSL_OP3(cross, Wdv, Wdv, Wdv), "xXXX")
+DECL(__OSL_MASKED_OP3(cross, Wdv, Wdv, Wdv), "xXXXi")
+
+DECL(__OSL_OP3(cross, Wdv, Wdv, Wv), "xXXX")
+DECL(__OSL_MASKED_OP3(cross, Wdv, Wdv, Wv), "xXXXi")
+
+
+DECL(__OSL_OP3(cross, Wdv, Wv, Wdv), "xXXX")
+DECL(__OSL_MASKED_OP3(cross, Wdv, Wv, Wdv), "xXXXi")
+
+
+DECL(__OSL_OP2(length, Wf, Wv), "xXX")
+DECL(__OSL_MASKED_OP2(length, Wf, Wv), "xXXi")
+DECL(__OSL_OP2(length, Wdf, Wdv), "xXX")
+DECL(__OSL_MASKED_OP2(length, Wdf, Wdv), "xXXi")
+
+
+DECL(__OSL_OP3(distance, Wf, Wv, Wv), "xXXX")
+DECL(__OSL_MASKED_OP3(distance, Wf, Wv, Wv), "xXXXi")
+
+DECL(__OSL_OP3(distance, Wdf, Wdv, Wdv), "xXXX")
+DECL(__OSL_MASKED_OP3(distance, Wdf, Wdv, Wdv), "xXXXi")
+
+DECL(__OSL_OP3(distance, Wdf, Wdv, Wv), "xXXX")
+DECL(__OSL_MASKED_OP3(distance, Wdf, Wdv, Wv), "xXXXi")
+
+DECL(__OSL_OP3(distance, Wdf, Wv, Wdv), "xXXX")
+DECL(__OSL_MASKED_OP3(distance, Wdf, Wv, Wdv), "xXXXi")
+
+
+DECL(__OSL_OP2(normalize, Wv, Wv), "xXX")
+DECL(__OSL_MASKED_OP2(normalize, Wv, Wv), "xXXi")
+DECL(__OSL_OP2(normalize, Wdv, Wdv), "xXX")
+DECL(__OSL_MASKED_OP2(normalize, Wdv, Wdv), "xXXi")
+
+DECL(__OSL_OP3(mul, Wm, Wm, Wm), "xXXX")
+DECL(__OSL_MASKED_OP3(mul, Wm, Wm, Wm), "xXXXi")
+DECL(__OSL_OP3(mul, Wm, Wm, Wf), "xXXX")
+DECL(__OSL_MASKED_OP3(mul, Wm, Wm, Wf), "xXXXi")
+
+// forced masked version only
+DECL(__OSL_MASKED_OP3(div, Wm, Wm, Wm), "xXXXi")
+DECL(__OSL_OP3(div, Wm, Wm, Wf), "xXXX")
+DECL(__OSL_MASKED_OP3(div, Wm, Wm, Wf), "xXXXi")
+DECL(__OSL_MASKED_OP3(div, Wm, Wf, Wm), "xXXXi")
+
+// forced masked version only
+DECL(__OSL_MASKED_OP3(get_from_to_matrix, Wm, s, s), "iXXssi")
+DECL(__OSL_MASKED_OP3(get_from_to_matrix, Wm, s, Ws), "iXXsXi")
+DECL(__OSL_MASKED_OP3(get_from_to_matrix, Wm, Ws, s), "iXXXsi")
+DECL(__OSL_MASKED_OP3(get_from_to_matrix, Wm, Ws, Ws), "iXXXXi")
+
+//varying vs non varying
+DECL(__OSL_OP2(transpose, Wm, Wm), "xXX")
+DECL(__OSL_MASKED_OP2(transpose, Wm, Wm), "xXXi")
+
+DECL(__OSL_OP2(determinant, Wf, Wm), "xXX")
+DECL(__OSL_MASKED_OP2(determinant, Wf, Wm), "xXXi")
+
+// forced masked version only
+DECL(__OSL_MASKED_OP3(concat, Ws, Ws, Ws), "xXXXi")
+DECL(__OSL_MASKED_OP2(strlen, Wi, Ws), "xXXi")
+DECL(__OSL_MASKED_OP2(hash, Wi, Ws), "xXXi")
+DECL(__OSL_MASKED_OP3(getchar, Wi, Ws, Wi), "xXXXi")
+DECL(__OSL_MASKED_OP3(startswith, Wi, Ws, Ws), "xXXXi")
+DECL(__OSL_MASKED_OP3(endswith, Wi, Ws, Ws), "xXXXi")
+DECL(__OSL_MASKED_OP2(stoi, Wi, Ws), "xXXi")
+DECL(__OSL_MASKED_OP2(stof, Wf, Ws), "xXXi")
+DECL(__OSL_MASKED_OP4(substr, Ws, Ws, Wi, Wi), "xXXXXi")
+DECL(__OSL_MASKED_OP(regex_impl), "xXXXXiXii")
+DECL(__OSL_OP(regex_impl), "iXsXisi")
+
+// BATCH texturing manages the BatchedTextureOptions
+// directly in LLVM ir, and has no need for wide versions
+// of osl_texture_set_XXX functions
+DECL(__OSL_MASKED_OP(texture), "iXXXXXXXXXXiXiXiXi")
+DECL(__OSL_MASKED_OP(texture3d), "iXXXXXXXiXiXiXi")
+#if 0  // incomplete
+DECL (osl_environment, "iXXXXXXXiXXXXXXX")
+#endif
+DECL(__OSL_MASKED_OP(get_textureinfo), "iXXXXXi")
+DECL(__OSL_OP(get_textureinfo_uniform), "iXXXXXX")
+
+// Wide Code generator will set trace options directly in LLVM IR
+// without calling helper functions
+//DECL (osl_trace_set_mindist, "xXf") // unneeded
+//DECL (osl_trace_set_maxdist, "xXf") // unneeded
+//DECL (osl_trace_set_shade, "xXi") // unneeded
+//DECL (osl_trace_set_traceset, "xXs") // unneeded
+DECL(__OSL_MASKED_OP(trace), "xXXXXXXXXXi")
+
+DECL(__OSL_OP(calculatenormal), "xXXX")
+DECL(__OSL_MASKED_OP(calculatenormal), "xXXXi")
+DECL(__OSL_OP2(area, Wf, Wdv), "xXX")
+DECL(__OSL_MASKED_OP2(area, Wf, Wdv), "xXXi")
+DECL(__OSL_OP2(filterwidth, Wf, Wdf), "xXX")
+DECL(__OSL_OP2(filterwidth, Wv, Wdv), "xXX")
+
+DECL(__OSL_MASKED_OP2(filterwidth, Wf, Wdf), "xXXi")
+DECL(__OSL_MASKED_OP2(filterwidth, Wv, Wdv), "xXXi")
+
+DECL(__OSL_OP(raytype_bit), "iXi")
+
+
+// Clean up local definitions
+#undef WIDE_NOISE_IMPL_INDIRECT
+#undef WIDE_NOISE_IMPL
+#undef WIDE_NOISE_DERIV_IMPL_INDIRECT
+#undef WIDE_NOISE_DERIV_IMPL
+#undef WIDE_GENERIC_NOISE_DERIV_IMPL_INDIRECT
+#undef WIDE_GENERIC_NOISE_DERIV_IMPL
+#undef WIDE_PNOISE_IMPL_INDIRECT
+#undef WIDE_PNOISE_IMPL
+#undef WIDE_PNOISE_DERIV_IMPL_INDIRECT
+#undef WIDE_PNOISE_DERIV_IMPL
+
+#undef WIDE_UNARY_OP_IMPL
+#undef WIDE_UNARY_I_OP_IMPL
+#undef WIDE_UNARY_F_OR_V_OP_IMPL
+#undef WIDE_TEST_F_OP_IMPL
+#undef WIDE_BINARY_OP_IMPL
+#undef WIDE_BINARY_F_OR_V_OP_IMPL
+#undef WIDE_BINARY_FI_OP_IMPL
+#undef WIDE_BINARY_VF_OP_IMPL

--- a/src/liboslexec/builtindecl_wide_xmacro.h
+++ b/src/liboslexec/builtindecl_wide_xmacro.h
@@ -1,30 +1,6 @@
-/*
-Copyright (c) 2009-2014 Sony Pictures Imageworks Inc., et al.
-All Rights Reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of Sony Pictures Imageworks nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 
 // This file contains "declarations" for all the functions that might get

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -128,9 +128,10 @@ struct OpDescriptor {
                             //     no side effects
     int flags;              // other flags
     OpDescriptor () { }
-    OpDescriptor (const char *n, OpLLVMGen ll, OpFolder fold=NULL,
-                  bool simple=false, int flags=0)
-        : name(n), llvmgen(ll), folder(fold), simple_assign(simple), flags(flags)
+    OpDescriptor (const char *n, OpLLVMGen ll, OpLLVMGenWide llw,
+                  OpFolder fold=NULL, bool simple=false, int flags=0)
+        : name(n), llvmgen(ll), llvmgenwide(llw), folder(fold),
+          simple_assign(simple), flags(flags)
     {}
 
     enum FlagValues { None=0, Tex=1, SideEffects=2 };

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -102,6 +102,7 @@ typedef std::shared_ptr<ShaderInstance> ShaderInstanceRef;
 class Dictionary;
 class RuntimeOptimizer;
 class BackendLLVM;
+class BatchedBackendLLVM;
 struct ConnectedParam;
 
 void print_closure (std::ostream &out, const ClosureColor *closure, ShadingSystemImpl *ss);
@@ -116,10 +117,12 @@ typedef int (*OpFolder) (RuntimeOptimizer &rop, int opnum);
 
 /// Signature of an LLVM-IR-generating method
 typedef bool (*OpLLVMGen) (BackendLLVM &rop, int opnum);
+typedef bool (*OpLLVMGenWide) (BatchedBackendLLVM &rop, int opnum);
 
 struct OpDescriptor {
     ustring name;           // name of op
     OpLLVMGen llvmgen;      // llvm-generating routine
+    OpLLVMGenWide llvmgenwide; // wide version of llvm-generating routine
     OpFolder folder;        // constant-folding routine
     bool simple_assign;     // wholly overwrites arg0, no other writes,
                             //     no side effects
@@ -903,6 +906,7 @@ private:
     friend class ShaderInstance;
     friend class RuntimeOptimizer;
     friend class BackendLLVM;
+    friend class BatchedBackendLLVM;
 };
 
 
@@ -1643,6 +1647,7 @@ private:
 
     friend class OSL::pvt::ShadingSystemImpl;
     friend class OSL::pvt::BackendLLVM;
+    friend class OSL::pvt::BatchedBackendLLVM;
     friend class ShadingContext;
 };
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -12,6 +12,7 @@
 #include "oslexec_pvt.h"
 #include <OSL/genclosure.h>
 #include "backendllvm.h"
+#include "batched_backendllvm.h"
 #include <OSL/oslquery.h>
 
 #include <OpenImageIO/filesystem.h>
@@ -3346,8 +3347,8 @@ ShadingSystemImpl::Batched<WidthT>::jit_group (ShaderGroup &group, ShadingContex
     double locking_time = timer();
 
     // TODO:  Add BatchedBackendLLVM in subsequent pull request
-    // BatchedBackendLLVM lljitter (m_ssi, group, ctx, WidthT);
-    // lljitter.run ();
+    BatchedBackendLLVM lljitter (m_ssi, group, ctx, WidthT);
+    lljitter.run ();
 
     // Keep OSL instructions around in case someone
     // wants the scalar version jitted
@@ -3364,13 +3365,13 @@ ShadingSystemImpl::Batched<WidthT>::jit_group (ShaderGroup &group, ShadingContex
     spin_lock stat_lock (m_ssi.m_stat_mutex);
     m_ssi.m_stat_opt_locking_time += locking_time;
     m_ssi.m_stat_optimization_time += timer();
-//    m_ssi.m_stat_total_llvm_time += lljitter.m_stat_total_llvm_time;
-//    m_ssi.m_stat_llvm_setup_time += lljitter.m_stat_llvm_setup_time;
-//    m_ssi.m_stat_llvm_irgen_time += lljitter.m_stat_llvm_irgen_time;
-//    m_ssi.m_stat_llvm_opt_time += lljitter.m_stat_llvm_opt_time;
-//    m_ssi.m_stat_llvm_jit_time += lljitter.m_stat_llvm_jit_time;
-//    m_ssi.m_stat_max_llvm_local_mem = std::max (m_ssi.m_stat_max_llvm_local_mem,
-//                                          lljitter.m_llvm_local_mem);
+    m_ssi.m_stat_total_llvm_time += lljitter.m_stat_total_llvm_time;
+    m_ssi.m_stat_llvm_setup_time += lljitter.m_stat_llvm_setup_time;
+    m_ssi.m_stat_llvm_irgen_time += lljitter.m_stat_llvm_irgen_time;
+    m_ssi.m_stat_llvm_opt_time += lljitter.m_stat_llvm_opt_time;
+    m_ssi.m_stat_llvm_jit_time += lljitter.m_stat_llvm_jit_time;
+    m_ssi.m_stat_max_llvm_local_mem = std::max (m_ssi.m_stat_max_llvm_local_mem,
+                                          lljitter.m_llvm_local_mem);
 
     // TODO: not sure how to count these given batched vs. not
     m_ssi.m_stat_groups_compiled += 1;

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1011,9 +1011,12 @@ static void
 shading_system_setup_op_descriptors (ShadingSystemImpl::OpDescriptorMap& op_descriptor)
 {
 #define OP2(alias,name,ll,fold,simp,flag)                                \
+    extern bool llvm_gen_##ll (BatchedBackendLLVM &rop, int opnum);      \
     extern bool llvm_gen_##ll (BackendLLVM &rop, int opnum);             \
     extern int  constfold_##fold (RuntimeOptimizer &rop, int opnum);     \
     op_descriptor[ustring(#alias)] = OpDescriptor(#name, llvm_gen_##ll,  \
+    /* future PR will populate batched_llvm_gen.cpp */                   \
+                                /* llvm_gen_##ll*/nullptr,               \
                                                   constfold_##fold, simp, flag);
 #define OP(name,ll,fold,simp,flag) OP2(name,name,ll,fold,simp,flag)
 #define TEX OpDescriptor::Tex

--- a/src/liboslexec/wide/define_opname_macros.h
+++ b/src/liboslexec/wide/define_opname_macros.h
@@ -1,0 +1,70 @@
+/*
+Copyright (c) 2009-2018 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef __OSL_WIDTH
+#    error must define __OSL_WIDTH to number of SIMD lanes before including this header
+#endif
+
+#ifndef __OSL_TARGET_ISA
+#    error must define __OSL_TARGET_ISA to AVX512, AVX2, AVX, SSE4_2, or x64 before including this header
+#endif
+
+
+#define __OSL_LIBRARY_SELECTOR \
+    __OSL_CONCAT5(b, __OSL_WIDTH, _, __OSL_TARGET_ISA, _)
+
+
+#define __OSL_OP(NAME) __OSL_CONCAT3(osl_, __OSL_LIBRARY_SELECTOR, NAME)
+#define __OSL_MASKED_OP(NAME) \
+    __OSL_CONCAT4(osl_, __OSL_LIBRARY_SELECTOR, NAME, _masked)
+
+#define __OSL_OP1(NAME, A) \
+    __OSL_CONCAT5(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A)
+#define __OSL_MASKED_OP1(NAME, A) \
+    __OSL_CONCAT6(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, _masked)
+
+#define __OSL_OP2(NAME, A, B) \
+    __OSL_CONCAT6(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B)
+#define __OSL_MASKED_OP2(NAME, A, B) \
+    __OSL_CONCAT7(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B, _masked)
+
+#define __OSL_OP3(NAME, A, B, C) \
+    __OSL_CONCAT7(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B, C)
+#define __OSL_MASKED_OP3(NAME, A, B, C) \
+    __OSL_CONCAT8(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B, C, _masked)
+
+#define __OSL_OP4(NAME, A, B, C, D) \
+    __OSL_CONCAT8(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B, C, D)
+#define __OSL_MASKED_OP4(NAME, A, B, C, D) \
+    __OSL_CONCAT9(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B, C, D, _masked)
+
+#define __OSL_OP5(NAME, A, B, C, D, E) \
+    __OSL_CONCAT9(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B, C, D, E)
+#define __OSL_MASKED_OP5(NAME, A, B, C, D, E)                            \
+    __OSL_CONCAT10(osl_, __OSL_LIBRARY_SELECTOR, NAME, _, A, B, C, D, E, \
+                   _masked)

--- a/src/liboslexec/wide/define_opname_macros.h
+++ b/src/liboslexec/wide/define_opname_macros.h
@@ -1,30 +1,6 @@
-/*
-Copyright (c) 2009-2018 Sony Pictures Imageworks Inc., et al.
-All Rights Reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of Sony Pictures Imageworks nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 #ifndef __OSL_WIDTH
 #    error must define __OSL_WIDTH to number of SIMD lanes before including this header

--- a/src/liboslexec/wide/undef_opname_macros.h
+++ b/src/liboslexec/wide/undef_opname_macros.h
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2009-2018 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#undef __OSL_OP
+#undef __OSL_MASKED_OP
+#undef __OSL_OP1
+#undef __OSL_MASKED_OP1
+#undef __OSL_OP2
+#undef __OSL_MASKED_OP2
+#undef __OSL_OP3
+#undef __OSL_MASKED_OP3
+#undef __OSL_OP4
+#undef __OSL_OP4
+#undef __OSL_MASKED_OP5
+#undef __OSL_MASKED_OP5
+
+#undef __OSL_LIBRARY_SELECTOR

--- a/src/liboslexec/wide/undef_opname_macros.h
+++ b/src/liboslexec/wide/undef_opname_macros.h
@@ -1,30 +1,6 @@
-/*
-Copyright (c) 2009-2018 Sony Pictures Imageworks Inc., et al.
-All Rights Reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of Sony Pictures Imageworks nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 #undef __OSL_OP
 #undef __OSL_MASKED_OP


### PR DESCRIPTION
Add implementation for BatchedBackendLLVM.  BatchedBackendLLVM implements the same set of functionality as BackendLLVM does, except it's implementation and many of it's methods handle wide data type (for symbols identified as varying.  Many methods exist for (re)use by batched_llvm_gen and batched_llvm_instance.cpp.  A common theme is additional "bool is_uniform" parameter to identify if the operation we are generated code for is uniform or not.  We cannot rely on the Symbol itself, as an operation will be varying if just 1 of its inputs is varying.  This means that when uniform symbols are loaded as arguments, they will need to be widened/broadcast to participate in the varying operation.  Additionally "bool index_is_uniform" is used to generate gather/scatters vs. a wide load when symbols are varying.  Please remember the underlying "wide" data types are Structure of Arrays (SOA) and all address calculations have been modified inside BatchedBackendLLVM to work with SOA's.

Introduce helper class FuncSpec to encapsulate building function names that include a batch width and target ISA along with uniform and varying parameters.

Introduce TargetLibraryHelper interface and factory method to construct a Concrete TargetLibraryHelper
that provides a prefex string that all function calls will be prefixed with
and correctly initialize a function map for the shading system with
the functions from the target ISA library. Intent is batch size and target ISA specific shared libaries will be built and the correct one be loaded based on host machine.

Introduce TempScope.  Any calls to getOrAllocateTemp during the lifetime of a TempScope will be associated with the latest TempScope on the stack and when that TempScope's lifetime ends, any temp allocations will be marked unused and will be available for reuse by the next call to getOrAllocateTemp.

Introduce liboslexec/wide/define_opname_macros.h to define macros to consistently build OSL library function names including batch width, target isa, 0 to 5 arguments, and optionally masking.

Added builtindecl_wide_xmacro.h which is the equivalent of builtindecl.h for identifying the function names and signatures of OSL library functions that exist in batch size and target ISA specific shared libraries.


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

