### PR TITLE
LLVM 12 compatibility fixes

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1389,6 +1389,11 @@ LLVM_Util::make_jit_execengine (std::string *err,
     options.RelaxELFRelocations = false;
     //options.DebuggerTuning = llvm::DebuggerKind::GDB;
 
+    // TODO: Find equivalent function for PrintMachineCode post LLVM 12
+    #if OSL_LLVM_VERSION < 120
+      options.PrintMachineCode = dumpasm();
+    #endif
+
     engine_builder.setTargetOptions(options);
 
     detect_cpu_features(requestedISA, !jit_fma());

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -701,7 +701,8 @@ LLVM_Util::debug_pop_function()
     // that has been finalized, point it back to the compilation unit
     OSL_ASSERT(m_builder);
     OSL_ASSERT(m_builder->getCurrentDebugLocation().get() != nullptr);
-    m_builder->SetCurrentDebugLocation(llvm::DebugLoc::get(static_cast<unsigned int>(1),
+    m_builder->SetCurrentDebugLocation(llvm::DILocation::get(getCurrentDebugScope()->getContext(),
+                static_cast<unsigned int>(1),
                 static_cast<unsigned int>(0), /* column?  we don't know it, may be worth tracking through osl->oso*/
                 getCurrentDebugScope()));
 
@@ -776,7 +777,8 @@ LLVM_Util::debug_set_location(ustring sourcefile, int sourceline)
     }
     if (newDebugLocation) {
         llvm::DebugLoc debug_location =
-                llvm::DebugLoc::get(static_cast<unsigned int>(sourceline),
+                llvm::DILocation::get(sp->getContext(),
+                        static_cast<unsigned int>(sourceline),
                         static_cast<unsigned int>(0), /* column?  we don't know it, may be worth tracking through osl->oso*/
                         sp,
                         inlineSite);
@@ -958,7 +960,8 @@ LLVM_Util::new_builder (llvm::BasicBlock *block)
     m_builder = new IRBuilder (block);
     if (this->debug_is_enabled()) {
         OSL_ASSERT(getCurrentDebugScope());
-        m_builder->SetCurrentDebugLocation(llvm::DebugLoc::get(static_cast<unsigned int>(1),
+        m_builder->SetCurrentDebugLocation(llvm::DILocation::get(getCurrentDebugScope()->getContext(),
+                static_cast<unsigned int>(1),
                 static_cast<unsigned int>(0), /* column?  we don't know it, may be worth tracking through osl->oso*/
                 getCurrentDebugScope()));
     }
@@ -1386,7 +1389,6 @@ LLVM_Util::make_jit_execengine (std::string *err,
     options.RelaxELFRelocations = false;
     //options.DebuggerTuning = llvm::DebuggerKind::GDB;
 
-    options.PrintMachineCode = dumpasm();
     engine_builder.setTargetOptions(options);
 
     detect_cpu_features(requestedISA, !jit_fma());


### PR DESCRIPTION
## Description
Currently if you try and build with a system using LLVM 12 the build will fail. To fix this I have updated and removed deprecated features.
- Removed use of options.PrintMachineCode since this has been removed as of llvm 12.  [LLVM commit of removal](https://github.com/llvm/llvm-project/commit/589c646a7e5fb03223340476f7ffb67fd9628726#diff-bead32db0e4ea40b9f9f5a5149ea3e21ed0e815ffa25a8a6916b0d77f2eed61f)
- Converted uses of DebugLoc::get to DILocation::get since it has been depricated and remove as of llvm 12 [LLVM commit of removal](https://github.com/llvm/llvm-project/commit/41c3b271399229976d9885233db79ebbbe0383c6)

DebugLoc and DILocation are basically equivalent from what i can tell.
I'm unsure if print machine code is used seems like a debug option.

I originally made this fix for 1.11.11.0 and it compiled and worked fine with blender.

I'm not familiar with this project. Nor am I a C++ developer.
So feel free to ignore and fix another way.

## Tests

- I haven't written any new test cases.
- I have tested my 1.11.11.0 version of the fix with blender and it compiled and worked fine.
- I have tried compiling this fix for master on my own machine but hit other issues related to this file. But i don't think its caused by this change.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x ] My code follows the prevailing code style of this project.

