### PR TITLE
Imath 3 support: ImathLimits.h no longer exists

### DIFF
--- a/src/include/OSL/Imathx/Imathx.h
+++ b/src/include/OSL/Imathx/Imathx.h
@@ -161,12 +161,12 @@ affineInverse(const Matrix44 &m)
 				ScalarT(1));
 
     auto r = m.x[0][0] * s.x[0][0] + m.x[0][1] * s.x[1][0] + m.x[0][2] * s.x[2][0];
-    auto abs_r = IMATH_INTERNAL_NAMESPACE::abs (r);
+    auto abs_r = std::abs (r);
 
     int may_have_divided_by_zero = 0;
     if (OSL_UNLIKELY(abs_r < ScalarT(1)))
     {
-    	auto mr = abs_r / Imath::limits<ScalarT>::smallest();
+        auto mr = abs_r / std::numeric_limits<ScalarT>::min();
 #if 0
         OSL_PRAGMA(unroll)
         for (int i = 0; i < 3; ++i)
@@ -174,7 +174,7 @@ affineInverse(const Matrix44 &m)
             OSL_PRAGMA(unroll)
             for (int j = 0; j < 3; ++j)
             {
-                if (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[i][j]))
+                if (mr <= std::abs (s.x[i][j]))
                 {
                     may_have_divided_by_zero = 1;
                 }
@@ -184,15 +184,15 @@ affineInverse(const Matrix44 &m)
         // NOTE: using bitwise OR to avoid C++ semantics that cannot evaluate
         // the right hand side of logical OR unless left hand side is false
         if (
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][0])) |
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][1])) |
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[0][2])) |
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][0])) |
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][1])) |
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[1][2])) |
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][0])) |
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][1])) |
-            (mr <= IMATH_INTERNAL_NAMESPACE::abs (s.x[2][2]))
+            (mr <= std::abs (s.x[0][0])) |
+            (mr <= std::abs (s.x[0][1])) |
+            (mr <= std::abs (s.x[0][2])) |
+            (mr <= std::abs (s.x[1][0])) |
+            (mr <= std::abs (s.x[1][1])) |
+            (mr <= std::abs (s.x[1][2])) |
+            (mr <= std::abs (s.x[2][0])) |
+            (mr <= std::abs (s.x[2][1])) |
+            (mr <= std::abs (s.x[2][2]))
             ) {
             may_have_divided_by_zero = 1;
         }

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -16,7 +16,6 @@
                              (100*OPENEXR_VERSION_MINOR) + \
                              OPENEXR_VERSION_PATCH)
 #if OSL_OPENEXR_VERSION >= 20599 /* 2.5.99: pre-3.0 */
-#   include <Imath/ImathLimits.h>
 #   include <Imath/ImathVec.h>
 #   include <Imath/ImathMatrix.h>
 #   include <Imath/ImathColor.h>


### PR DESCRIPTION
Also change some refs to std::abs rather than deprecated Imath functions.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

