### PR TITLE
Fix unnecessary error messages to stderr for broken point clouds

### DIFF
--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -76,7 +76,7 @@ PointCloud::get (ustring filename, bool write)
     // Not found. Create a new one.
     Partio::ParticlesDataMutable *partio_cloud = NULL;
     if (!write) {
-        partio_cloud = Partio::read(filename.c_str());
+        partio_cloud = Partio::read(filename.c_str(), false);
         if (! partio_cloud)
             return NULL;
     } else {


### PR DESCRIPTION
Signed-off-by: sandip shukla <sandipshukla11@gmail.com>


## Description

Fix unnecessary error messages to stderr for broken point clouds by changing the 
verbose parameter of the Partio::read() calls to false.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

