### PR TITLE
CI: Use ccache + GitHub 'cache' action to greatly speed up CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,19 @@ jobs:
       image: aswf/ci-osl:2019-clang7
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++
@@ -61,6 +74,19 @@ jobs:
       image: aswf/ci-osl:2020
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++
@@ -87,6 +113,19 @@ jobs:
       image: aswf/ci-osl:2021-clang11
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++
@@ -115,6 +154,19 @@ jobs:
       image: aswf/ci-osl:2021-clang11
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++
@@ -146,6 +198,19 @@ jobs:
       image: aswftesting/ci-osl:2019-clang10
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++
@@ -176,6 +241,19 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++-7
@@ -205,6 +283,19 @@ jobs:
       image: aswf/ci-osl:2019-clang9
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: clang++
@@ -231,6 +322,19 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++-8
@@ -261,6 +365,19 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++-10
@@ -297,6 +414,19 @@ jobs:
       image: aswf/ci-osl:2019-clang7
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: g++
@@ -326,6 +456,19 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /Users/runner/.ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
       - name: all
         env:
           CXX: clang++
@@ -352,73 +495,6 @@ jobs:
           path: |
             build/*/testsuite/*/*.*
             build/*/CMake*.{txt,log}
-
-  # windows:
-  #   name: "Windows"
-  #   runs-on: windows-2019
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Setup Nuget.exe
-  #       uses: warrenbuckley/Setup-Nuget@v1
-  #     - name: all
-  #       shell: bash
-  #       env:
-  #         PYTHON_VERSION: 3.6
-  #         CMAKE_GENERATOR: "Visual Studio 16 2019"
-  #         OPENEXR_VERSION: v2.4.1
-  #       run: |
-  #           source src/build-scripts/ci-startup.bash
-  #           source src/build-scripts/gh-win-installdeps.bash
-  #           source src/build-scripts/ci-build-and-test.bash
-  #    - uses: actions/upload-artifact@v2
-  #      if: failure()
-  #      with:
-  #        name: ${{ github.job }}
-  #        path: build/*/testsuite/*/*.*
-
-  # sanitizer:
-  #   name: "Sanitizers"
-  #   runs-on: ubuntu-18.04
-  #   if: github.event_name == 'pull_request' || contains(github.ref, 'san') || contains(github.ref, 'RB') || contains(github.ref, 'release') || contains(github.ref, 'master') || contains(github.ref, 'gh')
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     #- uses: docker://aswfstaging/ci-base:2019
-  #     - name: all
-  #       env:
-  #         CXX: g++-7
-  #         CMAKE_CXX_STANDARD: 14
-  #         SANITIZE: address
-  #         USE_PYTHON: 0
-  #       run: |
-  #           source src/build-scripts/ci-startup.bash
-  #           source src/build-scripts/gh-installdeps.bash
-  #           source src/build-scripts/ci-build-and-test.bash
-  #    - uses: actions/upload-artifact@v2
-  #      if: failure()
-  #      with:
-  #        name: ${{ github.job }}
-  #        path: build/*/testsuite/*/*.*
-
-  # linux-static:
-  #   name: "Linux static libs: gcc7, C++14, exr2.3"
-  #   runs-on: ubuntu-18.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     #- uses: docker://aswfstaging/ci-base:2019
-  #     - name: all
-  #       env:
-  #         CXX: g++-7
-  #         CMAKE_CXX_STANDARD: 14
-  #         BUILD_SHARED_LIBS: OFF
-  #       run: |
-  #           source src/build-scripts/ci-startup.bash
-  #           source src/build-scripts/gh-installdeps.bash
-  #           source src/build-scripts/ci-build-and-test.bash
-  #    - uses: actions/upload-artifact@v2
-  #      if: failure()
-  #      with:
-  #        name: ${{ github.job }}
-  #        path: build/*/testsuite/*/*.*
 
   clang-format:
     # Test formatting. This test entry doesn't do a full build, it just runs

--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -30,8 +30,15 @@ echo "Architecture is $ARCH"
 echo "Build platform name is $PLATFORM"
 
 # Environment variables we always need
+export PATH=/usr/local/bin/_ccache:/usr/lib/ccache:$PATH
 export USE_CCACHE=${USE_CCACHE:=1}
 export CCACHE_CPP2=1
+export CCACHE_DIR=/tmp/ccache
+if [[ "${RUNNER_OS}" == "macOS" ]] ; then
+    export CCACHE_DIR=$HOME/.ccache
+fi
+mkdir -p $CCACHE_DIR
+
 export OSL_ROOT=$PWD/dist/$PLATFORM
 export DYLD_LIBRARY_PATH=$OSL_ROOT/lib:$DYLD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$OSL_ROOT/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
This speeds up CI builds by 50% or more, for PRs that are minor
changes by reusing the compiled results from previous runs.  Most of
the remaining time cannot be squeezed down -- it's the instantiation
of docker containers and running the testsuite itself. But the build
(including of dependencies we build from scratch) is dramatically
faster.

At the same time, remove some commented-out test matrix cases. When/if
we re-enable those tests, we can add those back.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
