### PR TITLE
Update old Strutil::format to new fmt conventions

### DIFF
--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -94,8 +94,8 @@ BatchedBackendLLVM::llvm_call_layer(int layer, bool unconditional)
     //std::string name = Strutil::format ("%s_%s_%d", m_library_selector,  parent->layername().c_str(),
     //                                  parent->id());
     std::string name
-        = Strutil::format("%s_%s", m_library_selector,
-                          layer_function_name(group(), *parent).c_str());
+        = Strutil::fmt::format("{}_{}", m_library_selector,
+                               layer_function_name(group(), *parent));
 
     // Mark the call as a fast call
     llvm::Value* funccall = ll.call_function(name.c_str(), args);

--- a/src/liboslexec/shadeimage.cpp
+++ b/src/liboslexec/shadeimage.cpp
@@ -32,8 +32,13 @@ shade_image (ShadingSystem &shadingsys, ShaderGroup &group,
     if (! roi.defined())
         roi = buf.roi();
     if (buf.spec().format != TypeDesc::FLOAT) {
-        buf.error ("Cannot OSL::shade_image() into a %f buffer, float is required",
-                   buf.spec().format);
+#if OIIO_VERSION >= 20200
+        buf.errorfmt("Cannot OSL::shade_image() into a {} buffer, float is required",
+                     buf.spec().format);
+#else
+        buf.error("Cannot OSL::shade_image() into a %s buffer, float is required",
+                  buf.spec().format);
+#endif
         return false;
     }
 


### PR DESCRIPTION
The old ones will someday be deprecated, so just doing some opportunistic cleanup.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
