### PR TITLE
Fully split oslquery and oslnoise libraries from oslexec

### DIFF
--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -24,19 +24,16 @@ set (lib_src
           batched_backendllvm.cpp
           batched_llvm_gen.cpp
           batched_llvm_instance.cpp
-          ../liboslnoise/gabornoise.cpp
-          ../liboslnoise/simplexnoise.cpp
     )
 
 if (BUILD_SHARED_LIBS)
-    # oslcomp and oslquery symbols used in oslexec
+    # oslcomp symbols used in oslexec
     list(APPEND lib_src
         ../liboslcomp/ast.cpp
         ../liboslcomp/codegen.cpp
         ../liboslcomp/oslcomp.cpp
         ../liboslcomp/symtab.cpp
         ../liboslcomp/typecheck.cpp
-        ../liboslquery/oslquery.cpp
         )
 endif ()
 
@@ -222,6 +219,7 @@ endif()
 
 target_link_libraries (${local_lib}
     PUBLIC
+        oslquery oslnoise
         OpenImageIO::OpenImageIO
         # For OpenEXR/Imath 3.x:
         $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>


### PR DESCRIPTION
liboslquery and liboslnoise exist as separate libraries for apps that
only need to query shader parameters or use OSL's noise functions,
respectively, but dont want to pull in the rest of OSL and all its
heavy dependencies (including LLVM). But liboslexec also needs that
functionality and so separately put the individual modules inside.

This was causing some problems for a tricky use case, and I can't
think of a good reason for it to be done this way now. So in this
patch I remove the redundant modules and just make liboslquery and
liboslnoise into *link dependencies* of liboslexec. None of this
should affect downstream projects, I don't think; linking against
liboslexec ought to just automatically pull in those other libs.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
