### PR TITLE
Fix guard so errorfmt is not used with too early an OIIO version

### DIFF
--- a/src/liboslexec/shadeimage.cpp
+++ b/src/liboslexec/shadeimage.cpp
@@ -32,7 +32,7 @@ shade_image (ShadingSystem &shadingsys, ShaderGroup &group,
     if (! roi.defined())
         roi = buf.roi();
     if (buf.spec().format != TypeDesc::FLOAT) {
-#if OIIO_VERSION >= 20200
+#if OIIO_VERSION >= 20300
         buf.errorfmt("Cannot OSL::shade_image() into a {} buffer, float is required",
                      buf.spec().format);
 #else


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>

