### PR TITLE
CMake 3.20 compatibility

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ Dependencies
 OSL requires the following dependencies or tools.
 NEW or CHANGED dependencies since the last major release are **bold**.
 
-* Build system: [CMake](https://cmake.org/) 3.12 or newer (tested through 3.18)
+* Build system: [CMake](https://cmake.org/) 3.12 or newer (tested through 3.20)
 
 * A suitable C++11 compiler to build OSL itself, which may be any of:
    - GCC 4.8.5 or newer (tested through gcc 10)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 
 MY_MAKE_FLAGS ?=
 MY_NINJA_FLAGS ?=
-MY_CMAKE_FLAGS += -g3
+MY_CMAKE_FLAGS ?=
 BUILDSENTINEL ?= Makefile
 NINJA ?= ninja
 CMAKE ?= cmake


### PR DESCRIPTION
The -g3 flag has disappeared.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
