### PR TITLE
CMake 3.20 safety

### DIFF
--- a/src/build-scripts/build_cmake.bash
+++ b/src/build-scripts/build_cmake.bash
@@ -26,7 +26,7 @@ fi
 if [[ `uname` == "Linux" && `uname -m` == "aarch64" ]] ; then
     mkdir -p ${CMAKE_INSTALL_DIR} || true
     curl --location https://anaconda.org/conda-forge/cmake/3.17.0/download/linux-aarch64/cmake-3.17.0-h28c56e5_0.tar.bz2 -o cmake-3.17.0-h28c56e5_0.tar.bz2
-    tar -xjvf cmake-3.17.0-h28c56e5_0.tar.bz2 -C ${CMAKE_INSTALL_DIR}
+    tar -xjf cmake-3.17.0-h28c56e5_0.tar.bz2 -C ${CMAKE_INSTALL_DIR}
     export PATH=${CMAKE_INSTALL_DIR}/bin:$PATH
 
     # In case we ever need to build from scratch:

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Utility script to download and build LLVM & clang
 #
@@ -43,5 +43,5 @@ if [[ `uname` == "Linux" ]] ; then
     mv clang+llvm*/* $LLVM_INSTALL_DIR
     export LLVM_DIRECTORY=$LLVM_INSTALL_DIR
     export PATH=${LLVM_INSTALL_DIR}/bin:$PATH
-    ls -a $LLVM_DIRECTORY
+    # ls -a $LLVM_DIRECTORY
 fi

--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -44,7 +44,10 @@ echo "git checkout ${OPENCOLORIO_VERSION} --force"
 git checkout ${OPENCOLORIO_VERSION} --force
 mkdir -p build
 cd build
-time cmake --config Release -DCMAKE_INSTALL_PREFIX=${OPENCOLORIO_INSTALL_DIR} -DCMAKE_CXX_FLAGS="${OPENCOLORIO_CXX_FLAGS}" ${OPENCOLORIO_BUILDOPTS} ..
+time cmake -DCMAKE_BUILD_TYPE=Release \
+           -DCMAKE_INSTALL_PREFIX=${OPENCOLORIO_INSTALL_DIR} \
+           -DCMAKE_CXX_FLAGS="${OPENCOLORIO_CXX_FLAGS}" \
+           ${OPENCOLORIO_BUILDOPTS} ..
 time cmake --build . --config Release --target install
 popd
 

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -53,14 +53,14 @@ if [[ ${OPENEXR_VERSION} == "v2.2.0" ]] || [[ ${OPENEXR_VERSION} == "v2.2.1" ]] 
     mkdir -p ${OPENEXR_BUILD_DIR}/IlmBase && true
     mkdir -p ${OPENEXR_BUILD_DIR}/OpenEXR && true
     cd ${OPENEXR_BUILD_DIR}/IlmBase
-    cmake --config ${OPENEXR_BUILD_TYPE} ${OPENEXR_GENERATOR_CMD} \
+    cmake -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} ${OPENEXR_GENERATOR_CMD} \
             -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
             -DCMAKE_CXX_FLAGS="${OPENEXR_CXX_FLAGS}" \
             -DCMAKE_CXX_STANDARD=11 \
             ${OPENEXR_CMAKE_FLAGS} ${OPENEXR_SOURCE_DIR}/IlmBase
     time cmake --build . --target install --config ${OPENEXR_BUILD_TYPE}
     cd ${OPENEXR_BUILD_DIR}/OpenEXR
-    cmake --config ${OPENEXR_BUILD_TYPE} ${OPENEXR_GENERATOR_CMD} \
+    cmake -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} ${OPENEXR_GENERATOR_CMD} \
             -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}\;${OPENEXR_INSTALL_DIR}" \
             -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
             -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
@@ -71,7 +71,7 @@ if [[ ${OPENEXR_VERSION} == "v2.2.0" ]] || [[ ${OPENEXR_VERSION} == "v2.2.1" ]] 
 elif [[ ${OPENEXR_VERSION} == "v2.3.0" ]] ; then
     # Simplified setup for 2.3+
     cd ${OPENEXR_BUILD_DIR}
-    cmake --config ${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \
+    cmake -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \
             -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
             -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
             -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
@@ -84,7 +84,7 @@ elif [[ ${OPENEXR_VERSION} == "v2.3.0" ]] ; then
 else
     # Simplified setup for 2.4+
     cd ${OPENEXR_BUILD_DIR}
-    cmake --config ${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \
+    cmake -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} -G "$CMAKE_GENERATOR" \
             -DCMAKE_INSTALL_PREFIX="${OPENEXR_INSTALL_DIR}" \
             -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
             -DILMBASE_PACKAGE_PREFIX="${OPENEXR_INSTALL_DIR}" \
@@ -92,6 +92,8 @@ else
             -DBUILD_TESTING=0 \
             -DPYILMBASE_ENABLE=0 \
             -DOPENEXR_VIEWERS_ENABLE=0 \
+            -DINSTALL_OPENEXR_EXAMPLES=0 \
+            -DOPENEXR_INSTALL_EXAMPLES=0 \
             -DCMAKE_INSTALL_LIBDIR=lib \
             -DCMAKE_CXX_FLAGS="${OPENEXR_CXX_FLAGS}" \
             ${OPENEXR_CMAKE_FLAGS} ${OPENEXR_SOURCE_DIR}

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -39,8 +39,7 @@ git checkout ${PUGIXML_VERSION} --force
 
 mkdir -p ${PUGIXML_BUILD_DIR}
 cd ${PUGIXML_BUILD_DIR}
-time cmake --config Release \
-           -DCMAKE_BUILD_TYPE=Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${PUGIXML_INSTALL_DIR} \
            -DBUILD_SHARED_LIBS=ON \
            -DBUILD_TESTS=OFF \

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -43,7 +43,7 @@ git checkout ${PYBIND11_VERSION} --force
 
 mkdir -p ${PYBIND11_BUILD_DIR}
 cd ${PYBIND11_BUILD_DIR}
-time cmake --config Release \
+time cmake -DCMAKE_BUILD_TYPE=Release \
            -DCMAKE_INSTALL_PREFIX=${PYBIND11_INSTALL_DIR} \
            -DPYBIND11_TEST=OFF \
            ${PYBIND11_BUILD_OPTS} ..

--- a/testsuite/example-cuda/run.py
+++ b/testsuite/example-cuda/run.py
@@ -5,6 +5,6 @@
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 
-command += run_app("cmake --config Release data >> build.txt 2>&1", silent=True)
+command += run_app("cmake -DCMAKE_BUILD_TYPE=Release data >> build.txt 2>&1", silent=True)
 command += run_app("cmake --build . >> build.txt 2>&1", silent=True)
 command += run_app("bin/example-cuda test_add >> out.txt")

--- a/testsuite/example-deformer/osldeformer.cpp
+++ b/testsuite/example-deformer/osldeformer.cpp
@@ -25,13 +25,10 @@ This could easily be implemented as just one simple shader, but for
 illustrative purposes we will set it up as a 3-node shader network.
 
 
-To build:
+To build (using CMake >= 3.13, which has -B and -S):
 
-    mkdir build
-    cd build
-    cmake --config Release ..
-    cmake --build .
-    cd ..
+    cmake -S . -B build
+    cmake --build build
 
 Note that you must have OSL_ROOT set to an installed OSL in order for CMake
 to find it properly.

--- a/testsuite/example-deformer/run.py
+++ b/testsuite/example-deformer/run.py
@@ -5,6 +5,6 @@
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 
-command += run_app ("cmake --config Release data >> build.txt", silent=True)
+command += run_app ("cmake -DCMAKE_BUILD_TYPE=Release data >> build.txt", silent=True)
 command += run_app ("cmake --build . >> build.txt", silent=True)
 command += run_app ("bin/osldeformer >> out.txt")


### PR DESCRIPTION
It seems that our liberal use of cmake argument `--config` should only
be used in conjunction with the `--build` flag, not for the initial
configuration step. Apparently this was just silently ignored for a
long time, but for CMake 3.20, it is an error and breaks a lot of our
CI cases and our build_blah.bash scripts.

A couple of other minor cosmetic fixes in those scripts as well.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
