### PR TITLE
Build: be robust to certain OpenEXR 2.x config files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       CMAKE_CXX_STANDARD: 17
       PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
-      OPENEXR_VERSION: v2.5.3
+      OPENEXR_VERSION: v2.5.5
       OPENIMAGEIO_VERSION: RB-2.2
     steps:
       - uses: actions/checkout@v2
@@ -168,7 +168,7 @@ jobs:
             build/*/testsuite/*/*.*
             build/*/CMake*.{txt,log}
 
-  vfxplatform-2021-exrmaster:
+  vfxplatform-2021-exr3:
     name: "Linux VFXP-2021 gcc9/C++17 llvm11 py3.7 boost-1.70 exr-3.0 OIIO-2.2 avx2"
     runs-on: ubuntu-latest
     container:
@@ -375,7 +375,7 @@ jobs:
       CMAKE_CXX_STANDARD: 17
       LLVM_VERSION: 10.0.0
       USE_SIMD: avx2,f16c
-      OPENEXR_VERSION: v2.5.3
+      OPENEXR_VERSION: v2.5.5
       OPENIMAGEIO_VERSION: master
       OPENIMAGEIO_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.0.1
       PUGIXML_VERSION: v1.10

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -7,11 +7,15 @@
 include(CMakeFindDependencyMacro)
 
 # add here all the find_dependency() whenever switching to config based dependencies
-if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.5)
+if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 3.0)
+    find_dependency(Imath @OpenEXR_VERSION@)
+elseif (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.4 AND @FOUND_OPENEXR_WITH_CONFIG@)
+    find_dependency(IlmBase @OpenEXR_VERSION@)
     find_dependency(OpenEXR @OpenEXR_VERSION@)
-    # N.B. Only do this for OpenEXR >= 2.5, difficult to rely on their
-    # exported configs before that.
+    find_dependency(ZLIB @ZLIB_VERSION@)  # Because OpenEXR doesn't do it
+    find_dependency(Threads)  # Because OpenEXR doesn't do it
 endif ()
+
 
 find_dependency(OpenImageIO @OpenImageIO_VERSION@ REQUIRED)
 

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -90,7 +90,7 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
             "-I${PROJECT_SOURCE_DIR}/src/include"
             "-I${PROJECT_SOURCE_DIR}/src/cuda_common"
             "-I${OpenImageIO_INCLUDES}"
-            "-I${ILMBASE_INCLUDE_DIR}"
+            "-I${IMATH_INCLUDES}"
             "-I${Boost_INCLUDE_DIRS}"
             ${LLVM_COMPILE_FLAGS} ${CUDA_LIB_FLAGS} ${CLANG_MSVC_FIX}
             -D__CUDACC__ -DOSL_COMPILING_TO_BITCODE=1 -DNDEBUG -DOIIO_NO_SSE -D__CUDADEVRT_INTERNAL__

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -13,6 +13,13 @@ function ( NVCC_COMPILE cuda_src ptx_generated extra_nvcc_args )
     set (${ptx_generated} ${cuda_ptx} PARENT_SCOPE)
     file ( GLOB cuda_headers "${cuda_src_dir}/*.h" )
 
+    list (TRANSFORM IMATH_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_IMATH_INCLUDES)
+    list (TRANSFORM OPENEXR_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_OPENEXR_INCLUDES)
+    list (TRANSFORM OpenImageIO_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_OpenImageIO_INCLUDES)
+
     add_custom_command ( OUTPUT ${cuda_ptx}
         COMMAND ${CUDA_NVCC_EXECUTABLE}
             "-I${OPTIX_INCLUDES}"
@@ -21,8 +28,9 @@ function ( NVCC_COMPILE cuda_src ptx_generated extra_nvcc_args )
             "-I${CMAKE_BINARY_DIR}/include"
             "-I${PROJECT_SOURCE_DIR}/src/include"
             "-I${PROJECT_SOURCE_DIR}/src/cuda_common"
-            "-I${OpenImageIO_INCLUDES}"
-            "-I${IMATH_INCLUDES}"
+            ${ALL_OpenImageIO_INCLUDES}
+            ${ALL_IMATH_INCLUDES}
+            ${ALL_OPENEXR_INCLUDES}
             "-I${Boost_INCLUDE_DIRS}"
             "-DFMT_DEPRECATED=\"\""
             ${LLVM_COMPILE_FLAGS}
@@ -81,6 +89,13 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
         set (CLANG_MSVC_FIX "${CLANG_MSVC_FIX} -Wno-ignored-attributes -Wno-unknown-attributes")
     endif ()
 
+    list (TRANSFORM IMATH_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_IMATH_INCLUDES)
+    list (TRANSFORM OPENEXR_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_OPENEXR_INCLUDES)
+    list (TRANSFORM OpenImageIO_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_OpenImageIO_INCLUDES)
+
     add_custom_command (OUTPUT ${bc_cuda}
         COMMAND ${LLVM_BC_GENERATOR}
             "-I${OPTIX_INCLUDES}"
@@ -89,8 +104,9 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
             "-I${CMAKE_BINARY_DIR}/include"
             "-I${PROJECT_SOURCE_DIR}/src/include"
             "-I${PROJECT_SOURCE_DIR}/src/cuda_common"
-            "-I${OpenImageIO_INCLUDES}"
-            "-I${IMATH_INCLUDES}"
+            ${ALL_OpenImageIO_INCLUDES}
+            ${ALL_IMATH_INCLUDES}
+            ${ALL_OPENEXR_INCLUDES}
             "-I${Boost_INCLUDE_DIRS}"
             ${LLVM_COMPILE_FLAGS} ${CUDA_LIB_FLAGS} ${CLANG_MSVC_FIX}
             -D__CUDACC__ -DOSL_COMPILING_TO_BITCODE=1 -DNDEBUG -DOIIO_NO_SSE -D__CUDADEVRT_INTERNAL__

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -103,6 +103,12 @@ if (MSVC AND NOT LINKSTATIC)
     add_definitions (-DOPENEXR_DLL) # Is this needed for new versions?
 endif ()
 
+if (OPENEXR_VERSION VERSION_GREATER_EQUAL 2.5.99)
+    set (OSL_USING_IMATH 3)
+else ()
+    set (OSL_USING_IMATH 2)
+endif ()
+
 
 # OpenImageIO
 checked_find_package (OpenImageIO REQUIRED

--- a/src/cmake/modules/FindOpenEXR.cmake
+++ b/src/cmake/modules/FindOpenEXR.cmake
@@ -48,6 +48,7 @@ find_package(OpenEXR CONFIG)
 
 if (TARGET OpenEXR::OpenEXR AND TARGET Imath::Imath)
     # OpenEXR 3.x if both of these targets are found
+    set (FOUND_OPENEXR_WITH_CONFIG 1)
     if (NOT OpenEXR_FIND_QUIETLY)
         message (STATUS "Found CONFIG for OpenEXR 3 (OPENEXR_VERSION=${OpenEXR_VERSION})")
     endif ()
@@ -74,8 +75,10 @@ if (TARGET OpenEXR::OpenEXR AND TARGET Imath::Imath)
         list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
     endif ()
 
-elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND OPENEXR_VERSION VERSION_GREATER_EQUAL 2.4)
+elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND
+        (OPENEXR_VERSION VERSION_GREATER_EQUAL 2.4 OR OpenEXR_VERSION VERSION_GREATER_EQUAL 2.4))
     # OpenEXR 2.4 or 2.5 with exported config
+    set (FOUND_OPENEXR_WITH_CONFIG 1)
     if (NOT OpenEXR_FIND_QUIETLY)
         message (STATUS "Found CONFIG for OpenEXR 2 (OPENEXR_VERSION=${OpenEXR_VERSION})")
     endif ()
@@ -102,9 +105,17 @@ elseif (TARGET OpenEXR::IlmImf AND TARGET IlmBase::Imath AND OPENEXR_VERSION VER
         list (APPEND ILMBASE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
     endif ()
 
+    # Correct for how old OpenEXR config exports set the directory one
+    # level lower than we prefer it.
+    string(REGEX REPLACE "include/OpenEXR$" "include" ILMBASE_INCLUDES "${ILMBASE_INCLUDES}")
+    string(REGEX REPLACE "include/OpenEXR$" "include" IMATH_INCLUDES "${IMATH_INCLUDES}")
+    string(REGEX REPLACE "include/OpenEXR$" "include" OPENEXR_INCLUDES "${OPENEXR_INCLUDES}")
+
 else ()
     # OpenEXR 2.x older versions without a config or whose configs we don't
     # trust.
+
+    set (FOUND_OPENEXR_WITH_CONFIG 0)
 
 # Other standard issue macros
 include (FindPackageHandleStandardArgs)

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -11,15 +11,11 @@
 
 
 // All the things we need from Imath.
-#include <OpenEXR/OpenEXRConfig.h>
-#define OSL_OPENEXR_VERSION ((10000*OPENEXR_VERSION_MAJOR) + \
-                             (100*OPENEXR_VERSION_MINOR) + \
-                             OPENEXR_VERSION_PATCH)
-#if OSL_OPENEXR_VERSION >= 20599 /* 2.5.99: pre-3.0 */
+#define OSL_USING_IMATH @OSL_USING_IMATH@
+#if OSL_USING_IMATH >= 3
 #   include <Imath/ImathVec.h>
 #   include <Imath/ImathMatrix.h>
 #   include <Imath/ImathColor.h>
-#   define OSL_USING_IMATH 3
 #else
     // OpenEXR 2.x lacks the Cuda decorators we need, so we replicated some
     // Imath files in OSL/Imathx, adding the decorations needed for them to
@@ -29,7 +25,6 @@
 #   include <OSL/Imathx/ImathMatrix.h>
 #   include <OSL/Imathx/ImathColor.h>
 #   include <OSL/matrix22.h>
-#   define OSL_USING_IMATH 2
 #endif
 
 // The fmt library causes trouble for Cuda. Work around by disabling it from

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -253,6 +253,10 @@ macro ( LLVM_COMPILE llvm_src srclist )
 
     list (TRANSFORM IMATH_INCLUDES PREPEND -I
           OUTPUT_VARIABLE ALL_IMATH_INCLUDES)
+    list (TRANSFORM OPENEXR_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_OPENEXR_INCLUDES)
+    list (TRANSFORM OpenImageIO_INCLUDES PREPEND -I
+          OUTPUT_VARIABLE ALL_OpenImageIO_INCLUDES)
 
     # Command to turn the .cpp file into LLVM assembly language .s, into
     # LLVM bitcode .bc, then back into a C++ file with the bc embedded!
@@ -262,7 +266,7 @@ macro ( LLVM_COMPILE llvm_src srclist )
           "-I${CMAKE_CURRENT_SOURCE_DIR}"
           "-I${CMAKE_SOURCE_DIR}/src/include"
           "-I${CMAKE_BINARY_DIR}/include"
-          "-I${OpenImageIO_INCLUDES}"
+          ${ALL_OpenImageIO_INCLUDES}
           ${ALL_IMATH_INCLUDES}
           "-isystem ${Boost_INCLUDE_DIRS}"
           -DOSL_COMPILING_TO_BITCODE=1

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -379,7 +379,7 @@ foreach(target_lib ${liboslexec_target_libs})
     target_include_directories (${target_lib}
         PUBLIC
             ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-            ${ILMBASE_INCLUDES}
+            ${IMATH_INCLUDES}
         )
     target_compile_definitions (${target_lib}
         PRIVATE
@@ -403,7 +403,6 @@ foreach(target_lib ${liboslexec_target_libs})
             ${ILMBASE_LIBRARIES}
         PRIVATE
             pugixml::pugixml
-            ${ZLIB_LIBRARIES}
             ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
             ${CLANG_LIBRARIES}
             ${LLVM_LIBRARIES} ${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBRARIES}
@@ -461,7 +460,6 @@ target_link_libraries (${local_lib}
         ${ILMBASE_LIBRARIES}
     PRIVATE
         pugixml::pugixml
-        ${ZLIB_LIBRARIES}
         ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
         ${CLANG_LIBRARIES}
         ${LLVM_LIBRARIES} ${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBRARIES}

--- a/src/liboslnoise/CMakeLists.txt
+++ b/src/liboslnoise/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library (oslnoise ${liboslnoise_srcs})
 target_include_directories (oslnoise
     PUBLIC
         ${CMAKE_INSTALL_FULL_INCLUDEDIR}
+        ${IMATH_INCLUDES}
     PRIVATE
         ../liboslexec)
 target_link_libraries (oslnoise

--- a/src/liboslquery/CMakeLists.txt
+++ b/src/liboslquery/CMakeLists.txt
@@ -12,8 +12,8 @@ add_library (${local_lib} ${lib_src})
 target_include_directories (${local_lib}
     PUBLIC
         ${CMAKE_INSTALL_FULL_INCLUDEDIR}
+        ${IMATH_INCLUDES}
     PRIVATE
-        # ${IMATH_INCLUDES}
         ../liboslexec)
 target_link_libraries (${local_lib}
     PUBLIC


### PR DESCRIPTION
Ever since adding OpenEXR 3.0 support, we had some cases where
installations that built the 2.x IlmBase and OpenEXR portions
separately and installing to separate areas, had trouble being found
properly.

Remove the need to include OpenEXR/OpenEXRConfig.h

Also make some minor changes to ci.yml to make sure we are documenting
the right openexr versions used for each test.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
