### PR TITLE
OSLCompiler : Check for write errors

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -484,6 +484,13 @@ OSLCompilerImpl::compile(string_view filename,
             write_oso_file(OIIO::Strutil::join(options, " "),
                            preprocess_result);
             OSL_DASSERT(m_osofile == nullptr);
+
+            oso_output.close();
+            if (!oso_output.good()) {
+                errorf(ustring(), 0, "Failed to write to \"%s\"",
+                       m_output_filename);
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This fixes #1352 by checking for write errors after writing the `.oso` file. Without it, empty files could be written without error after running out of disk space.

## Tests

I have not added any new tests, although in #1352 I did provide an example script to demonstrate the problem. I've been unable to find a way of simulating an empty disk without requiring root privilege, which I presume makes it unsuitable as a test.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

