### PR TITLE
Fix crash generating closure functions calls with LLVM 11

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -3430,8 +3430,9 @@ LLVM_Util::call_function (llvm::Value *func, cspan<llvm::Value *> args)
 #endif
     //llvm_gen_debug_printf (std::string("start ") + std::string(name));
 #if OSL_LLVM_VERSION >= 110
-    OSL_DASSERT(llvm::isa<llvm::Function>(func));
-    llvm::Value *r = builder().CreateCall(llvm::cast<llvm::Function>(func), llvm::ArrayRef<llvm::Value *>(args.data(), args.size()));
+    llvm::Value* r = builder().CreateCall(
+        llvm::cast<llvm::FunctionType>(func->getType()->getPointerElementType()), func,
+        llvm::ArrayRef<llvm::Value*>(args.data(), args.size()));
 #else
     llvm::Value *r = builder().CreateCall (func, llvm::ArrayRef<llvm::Value *>(args.data(), args.size()));
 #endif


### PR DESCRIPTION
## Description

Generating code for calling `prepare_closure` and `gen_closure` was crashing in Blender, with macOS arm64 and LLVM 11.

The code now matches the implementation of the removed LLVM function. For reference:
https://github.com/llvm/llvm-project/commit/836ce9db7f13f15bd8e4c00ab7a07d2b9f946b5e

## Tests

Existing OSL tests were already crashing, so this is covered.

## Checklist:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.