### PR TITLE
Bump the default C++ mode to 14

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -27,7 +27,7 @@ message (STATUS "CMAKE_CXX_COMPILER_ID  = ${CMAKE_CXX_COMPILER_ID}")
 ###########################################################################
 # C++ language standard
 #
-set (CMAKE_CXX_STANDARD 11 CACHE STRING
+set (CMAKE_CXX_STANDARD 14 CACHE STRING
      "C++ standard to prefer (11, 14, 17, 20, etc.)")
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
This leaves the minimum C++ at 11, but bumps the default (if not set by
the user via CMAKE_CXX_STANDARD) from 11 to 14.

This is meant to start identifying any problems people have switching
to 14. We anticipate a hard switch to 14 minimum before the next OSL
major release. This change is in master only (i.e. future OSL), we would
never change minimum or default C++ standard in the supported release
branches (currently OSL 1.11.x).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
