### PR TITLE
CI script typo kept mac from recognizing ARCH properly

### DIFF
--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -9,7 +9,7 @@
 # with 'source', not in a separate shell.
 
 # Figure out the platform
-if [[ $$RUNNER_OS == macOS ]] ; then
+if [[ $RUNNER_OS == macOS ]] ; then
     export ARCH=macosx
 elif [[ $RUNNER_OS == Linux ]] ; then
     export ARCH=linux64
@@ -19,6 +19,7 @@ elif [[ `uname -m` == aarch64 ]] ; then
     export ARCH=aarch64
 else
     export ARCH=unknown
+    exit -1
 fi
 export PLATFORM=$ARCH
 


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>

