### PR TITLE
Now that gcc minimum is gcc6, remove use of boost::regex

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -318,26 +318,6 @@ endif ()
 include (CMakePushCheckState)
 include (CheckCXXSourceRuns)
 
-###########################################################################
-# Find out if it's safe for us to use std::regex or if we need boost.regex.
-# This is primarily about gcc 4.8 having a broken regex implementation.
-# This will be obsolete once our minimum supported gcc is >= 4.9.
-#
-cmake_push_check_state ()
-check_cxx_source_runs("
-      #include <regex>
-      int main() {
-          std::string r = std::regex_replace(std::string(\"abc\"), std::regex(\"b\"), \" \");
-          return r == \"a c\" ? 0 : -1;
-      }"
-      USE_STD_REGEX)
-cmake_pop_check_state ()
-if (USE_STD_REGEX)
-    add_definitions (-DUSE_STD_REGEX)
-else ()
-    add_definitions (-DUSE_BOOST_REGEX)
-endif ()
-
 
 ###########################################################################
 # Code coverage options

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -49,9 +49,6 @@ if (BOOST_CUSTOM)
     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
 else ()
     set (Boost_COMPONENTS filesystem system thread)
-    if (NOT USE_STD_REGEX)
-        list (APPEND Boost_COMPONENTS regex)
-    endif ()
     # The FindBoost.cmake interface is broken if it uses boost's installed
     # cmake output (e.g. boost 1.70.0, cmake <= 3.14). Specifically it fails
     # to set the expected variables printed below. So until that's fixed

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -1407,8 +1407,8 @@ DECLFOLDER(constfold_regex_search)
         OSL_DASSERT(Subj.typespec().is_string() && Reg.typespec().is_string());
         ustring s (Subj.get_string());
         ustring r (Reg.get_string());
-        regex reg (r.string());
-        int result = regex_search (s.string(), reg);
+        std::regex reg(r.string());
+        int result = std::regex_search(s.string(), reg);
         int cind = rop.add_constant (result);
         rop.turn_into_assign (op, cind, "const fold regex_search");
         return 1;

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -570,14 +570,14 @@ ShadingContext::symbol_data (const Symbol &sym) const
 
 
 
-const regex &
+const std::regex&
 ShadingContext::find_regex (ustring r)
 {
     RegexMap::const_iterator found = m_regex_map.find (r);
     if (found != m_regex_map.end())
         return *found->second;
     // otherwise, it wasn't found, add it
-    m_regex_map[r].reset (new regex(r.c_str()));
+    m_regex_map[r].reset(new std::regex(r.c_str()));
     m_shadingsys.m_stat_regexes += 1;
     // std::cerr << "Made new regex for " << r << "\n";
     return *m_regex_map[r];

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -125,12 +125,12 @@ osl_regex_impl (void *sg_, const char *subject_, void *results, int nresults,
     ShaderGlobals *sg = (ShaderGlobals *)sg_;
     ShadingContext *ctx = sg->context;
     const std::string &subject (ustring::from_unique(subject_).string());
-    match_results<std::string::const_iterator> mresults;
-    const regex &regex (ctx->find_regex (USTR(pattern)));
+    std::match_results<std::string::const_iterator> mresults;
+    const std::regex &regex (ctx->find_regex (USTR(pattern)));
     if (nresults > 0) {
         std::string::const_iterator start = subject.begin();
-        int res = fullmatch ? regex_match (subject, mresults, regex)
-                            : regex_search (subject, mresults, regex);
+        int res = fullmatch ? std::regex_match(subject, mresults, regex)
+                            : std::regex_search(subject, mresults, regex);
         int *m = (int *)results;
         for (int r = 0;  r < nresults;  ++r) {
             if (r/2 < (int)mresults.size()) {
@@ -144,8 +144,8 @@ osl_regex_impl (void *sg_, const char *subject_, void *results, int nresults,
         }
         return res;
     } else {
-        return fullmatch ? regex_match (subject, regex)
-                         : regex_search (subject, regex);
+        return fullmatch ? std::regex_match(subject, regex)
+                         : std::regex_search(subject, regex);
     }
 }
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <memory>
 #include <list>
+#include <regex>
 #include <set>
 #include <unordered_map>
 
@@ -32,12 +33,6 @@
 #include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/refcnt.h>
 #include <OpenImageIO/color.h>
-
-#ifdef USE_BOOST_REGEX
-# include <boost/regex.hpp>
-#else
-# include <regex>
-#endif
 
 #include <OSL/genclosure.h>
 #include <OSL/llvm_util.h>
@@ -71,20 +66,6 @@ namespace Strutil = OIIO::Strutil;
 OSL_NAMESPACE_ENTER
 
 
-#ifdef USE_BOOST_REGEX
-  using boost::regex;
-  using boost::regex_search;
-  using boost::regex_match;
-  using boost::match_results;
-#else
-  using std::regex;
-  using std::regex_search;
-  using std::regex_match;
-  using std::match_results;
-#endif
-
-
-
 
 struct PerThreadInfo
 {
@@ -95,8 +76,6 @@ struct PerThreadInfo
     std::stack<ShadingContext *> context_pool;
     LLVM_Util::PerThreadInfo llvm_thread_info;
 };
-
-
 
 
 
@@ -1877,7 +1856,7 @@ public:
     /// Return a reference to a compiled regular expression for the
     /// given string, being careful to cache already-created ones so we
     /// aren't constantly compiling new ones.
-    const regex & find_regex (ustring r);
+    const std::regex& find_regex (ustring r);
 
     /// Return a pointer to the shading group for this context.
     ///
@@ -2012,7 +1991,7 @@ private:
     // Heap memory
     std::unique_ptr<char, decltype(&OIIO::aligned_free)> m_heap { nullptr, &OIIO::aligned_free };
     size_t m_heapsize = 0;
-    typedef std::unordered_map<ustring, std::unique_ptr<regex>, ustringHash> RegexMap;
+    using RegexMap = std::unordered_map<ustring, std::unique_ptr<std::regex>, ustringHash>;
     RegexMap m_regex_map;               ///< Compiled regex's
     MessageList m_messages;             ///< Message blackboard
     int m_max_warnings;                 ///< To avoid processing too many warnings

--- a/src/liboslexec/wide/wide_opstring.cpp
+++ b/src/liboslexec/wide/wide_opstring.cpp
@@ -277,12 +277,12 @@ OSL_BATCHOP int __OSL_OP(regex_impl)(void* bsg_, const char* subject_,
     OSL_ASSERT(ustring::is_unique(pattern));
 
     const std::string& subject(ustring::from_unique(subject_).string());
-    match_results<std::string::const_iterator> mresults;
-    const regex& regex(ctx->find_regex(USTR(pattern)));
+    std::match_results<std::string::const_iterator> mresults;
+    const std::regex& regex(ctx->find_regex(USTR(pattern)));
     if (nresults > 0) {
         std::string::const_iterator start = subject.begin();
-        int res = fullmatch ? regex_match(subject, mresults, regex)
-                            : regex_search(subject, mresults, regex);
+        int res = fullmatch ? std::regex_match(subject, mresults, regex)
+                            : std::regex_search(subject, mresults, regex);
         int* m  = (int*)results;
         for (int r = 0; r < nresults; ++r) {
             if (r / 2 < (int)mresults.size()) {
@@ -328,12 +328,12 @@ OSL_BATCHOP void __OSL_MASKED_OP(regex_impl)(void* bsg_, void* wsuccess_ptr,
         auto results = wresults[lane];
 
         const std::string& subject = usubject.string();
-        match_results<std::string::const_iterator> mresults;
-        const regex& regex(ctx->find_regex(USTR(pattern)));
+        std::match_results<std::string::const_iterator> mresults;
+        const std::regex& regex(ctx->find_regex(USTR(pattern)));
         if (nresults > 0) {
             std::string::const_iterator start = subject.begin();
-            int res = fullmatch ? regex_match(subject, mresults, regex)
-                                : regex_search(subject, mresults, regex);
+            int res = fullmatch ? std::regex_match(subject, mresults, regex)
+                                : std::regex_search(subject, mresults, regex);
             for (int r = 0; r < nresults; ++r) {
                 if (r / 2 < (int)mresults.size()) {
                     if ((r & 1) == 0)


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>

