### PR TITLE
PR/BatchedMatrix

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -175,8 +175,8 @@ macro (osl_add_all_tests)
     # special installed tests.
     TESTSUITE ( aastep allowconnect-err and-or-not-synonyms arithmetic
                 arithmetic-reg
-                array array-copy-reg array-derivs array-range array-aassign
-                array-assign-reg array-length-reg
+                array array-reg array-copy-reg array-derivs array-range 
+                array-aassign array-assign-reg array-length-reg
                 blackbody blendmath breakcont breakcont-reg
                 bug-array-heapoffsets bug-locallifetime bug-outputinit
                 bug-param-duplicate bug-peep bug-return
@@ -203,7 +203,8 @@ macro (osl_add_all_tests)
                 layers layers-Ciassign layers-entry layers-lazy layers-lazyerror
                 layers-nonlazycopy layers-repeatedoutputs
                 linearstep
-                logic loop matrix max-reg message
+                logic loop matrix matrix-reg matrix-arithmetic-reg 
+                matrix-compref-reg max-reg message
                 mergeinstances-duplicate-entrylayers
                 mergeinstances-nouserdata mergeinstances-vararray
                 metadata-braces min-reg miscmath missing-shader
@@ -262,7 +263,7 @@ macro (osl_add_all_tests)
                 texture-width texture-withderivs texture-wrap
                 trailing-commas
                 transitive-assign
-                transform transformc trig typecast
+                transform transform-reg transformc trig typecast
                 unknown-instruction
                 userdata userdata-passthrough
                 vararray-connect vararray-default

--- a/src/include/OSL/Imathx/Imathx.h
+++ b/src/include/OSL/Imathx/Imathx.h
@@ -452,4 +452,43 @@ multiplyMatrixByMatrix (const Matrix44 &a,
 
 }
 
+// Calculate the determinant of a 2x2 matrix.
+template<typename F>
+static OSL_FORCEINLINE OSL_HOSTDEVICE F
+det2x2(F a, F b, F c, F d)
+{
+    return a * d - b * c;
+}
+
+// calculate the determinant of a 3x3 matrix in the form:
+//     | a1,  b1,  c1 |
+//     | a2,  b2,  c2 |
+//     | a3,  b3,  c3 |
+template<typename F>
+static OSL_FORCEINLINE OSL_HOSTDEVICE F
+det3x3(F a1, F a2, F a3, F b1, F b2, F b3, F c1, F c2, F c3)
+{
+    return a1 * det2x2( b2, b3, c2, c3 )
+         - b1 * det2x2( a2, a3, c2, c3 )
+         + c1 * det2x2( a2, a3, b2, b3 );
+}
+
+// calculate the determinant of a 4x4 matrix.
+template<typename F>
+static OSL_FORCEINLINE OSL_HOSTDEVICE F
+det4x4(const Imath::Matrix44<F>& m)
+{
+    // Changed all Vec3 subscripts to access data members versus array casts
+    // assign to individual variable names to aid selecting correct elements
+    F a1 = m.x[0][0], b1 = m.x[0][1], c1 = m.x[0][2], d1 = m.x[0][3];
+    F a2 = m.x[1][0], b2 = m.x[1][1], c2 = m.x[1][2], d2 = m.x[1][3];
+    F a3 = m.x[2][0], b3 = m.x[2][1], c3 = m.x[2][2], d3 = m.x[2][3];
+    F a4 = m.x[3][0], b4 = m.x[3][1], c4 = m.x[3][2], d4 = m.x[3][3];
+    return a1 * det3x3( b2, b3, b4, c2, c3, c4, d2, d3, d4)
+         - b1 * det3x3( a2, a3, a4, c2, c3, c4, d2, d3, d4)
+         + c1 * det3x3( a2, a3, a4, b2, b3, b4, d2, d3, d4)
+         - d1 * det3x3( a2, a3, a4, b2, b3, b4, c2, c3, c4);
+}
+
+
 OSL_NAMESPACE_EXIT

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -6,6 +6,7 @@
 # please update wide_target_combine_text_and_rodata.ld
 set ( liboslexec_target_srcs
     wide/wide_opalgebraic
+    wide/wide_opmatrix
     wide/wide_opstring
     wide/wide_shadingsys
     )

--- a/src/liboslexec/builtindecl_wide_xmacro.h
+++ b/src/liboslexec/builtindecl_wide_xmacro.h
@@ -329,6 +329,8 @@ DECL(__OSL_OP(prepend_color_from_vs), "xXXs")
 DECL(__OSL_MASKED_OP2(prepend_color_from, Wv, s), "xXXsi")
 DECL(__OSL_MASKED_OP2(prepend_color_from, Wv, Ws), "xXXXi")
 
+#endif
+
 // forced masked version only
 DECL(__OSL_MASKED_OP2(prepend_matrix_from, Wm, s), "xXXsi")
 DECL(__OSL_MASKED_OP2(prepend_matrix_from, Wm, Ws), "xXXXi")
@@ -345,6 +347,7 @@ DECL(__OSL_MASKED_OP3(build_transform_matrix, Wm, Ws, s), "iXXXXi")
 DECL(__OSL_MASKED_OP3(build_transform_matrix, Wm, s, Ws), "iXXXXi")
 DECL(__OSL_MASKED_OP3(build_transform_matrix, Wm, Ws, Ws), "iXXXXi")
 
+#ifdef __OSL_TBD
 
 DECL(__OSL_OP(dict_find_iis), "iXiX")
 DECL(__OSL_MASKED_OP3(dict_find, Wi, Wi, Ws), "xXXXXi")
@@ -490,6 +493,7 @@ DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wdf, Wf, Wf), "xXXXXi")
 DECL(__OSL_OP4(smoothstep, Wdf, Wf, Wdf, Wf), "xXXXX")
 DECL(__OSL_MASKED_OP4(smoothstep, Wdf, Wf, Wdf, Wf), "xXXXXi")
 
+#endif
 
 // Replaced by osl_transform_[point|vector|normal]
 // DECL (osl_transform_vmv, "xXXX")
@@ -523,6 +527,8 @@ DECL(__OSL_MASKED_OP3(transform_normal, Wdv, Wdv, Wm), "xXXXii")
 
 DECL(__OSL_MASKED_OP3(transform_normal, Wv, Wv, m), "xXXXii")
 DECL(__OSL_MASKED_OP3(transform_normal, Wdv, Wdv, m), "xXXXii")
+
+#ifdef __OSL_TBD
 
 DECL(__OSL_MASKED_OP(transform_color), "xXXiXiXXi")
 DECL(__OSL_OP(transform_color), "xXXiXiXX")
@@ -580,6 +586,8 @@ DECL(__OSL_MASKED_OP2(normalize, Wv, Wv), "xXXi")
 DECL(__OSL_OP2(normalize, Wdv, Wdv), "xXX")
 DECL(__OSL_MASKED_OP2(normalize, Wdv, Wdv), "xXXi")
 
+#endif
+
 DECL(__OSL_OP3(mul, Wm, Wm, Wm), "xXXX")
 DECL(__OSL_MASKED_OP3(mul, Wm, Wm, Wm), "xXXXi")
 DECL(__OSL_OP3(mul, Wm, Wm, Wf), "xXXX")
@@ -603,8 +611,6 @@ DECL(__OSL_MASKED_OP2(transpose, Wm, Wm), "xXXi")
 
 DECL(__OSL_OP2(determinant, Wf, Wm), "xXX")
 DECL(__OSL_MASKED_OP2(determinant, Wf, Wm), "xXXi")
-
-#endif
 
 // forced masked version only
 DECL(__OSL_MASKED_OP3(concat, Ws, Ws, Ws), "xXXXi")

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -317,7 +317,7 @@ osl_transform_triple_nonlinear (void *sg_, void *Pin, int Pin_derivs,
                                  from, to, vectype);
 }
 
-
+#if 0
 // Calculate the determinant of a 2x2 matrix.
 template <typename F>
 OSL_HOSTDEVICE inline F det2x2(F a, F b, F c, F d)
@@ -351,6 +351,7 @@ OSL_HOSTDEVICE inline F det4x4(const Imath::Matrix44<F> &m)
          + c1 * det3x3( a2, a3, a4, b2, b3, b4, d2, d3, d4)
          - d1 * det3x3( a2, a3, a4, b2, b3, b4, c2, c3, c4);
 }
+#endif
 
 OSL_SHADEOP OSL_HOSTDEVICE float
 osl_determinant_fm (void *m)

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -317,41 +317,7 @@ osl_transform_triple_nonlinear (void *sg_, void *Pin, int Pin_derivs,
                                  from, to, vectype);
 }
 
-#if 0
-// Calculate the determinant of a 2x2 matrix.
-template <typename F>
-OSL_HOSTDEVICE inline F det2x2(F a, F b, F c, F d)
-{
-    return a * d - b * c;
-}
 
-// calculate the determinant of a 3x3 matrix in the form:
-//     | a1,  b1,  c1 |
-//     | a2,  b2,  c2 |
-//     | a3,  b3,  c3 |
-template <typename F>
-OSL_HOSTDEVICE inline F det3x3(F a1, F a2, F a3, F b1, F b2, F b3, F c1, F c2, F c3)
-{
-    return a1 * det2x2( b2, b3, c2, c3 )
-         - b1 * det2x2( a2, a3, c2, c3 )
-         + c1 * det2x2( a2, a3, b2, b3 );
-}
-
-// calculate the determinant of a 4x4 matrix.
-template <typename F>
-OSL_HOSTDEVICE inline F det4x4(const Imath::Matrix44<F> &m)
-{
-    // assign to individual variable names to aid selecting correct elements
-    F a1 = m.x[0][0], b1 = m.x[0][1], c1 = m.x[0][2], d1 = m.x[0][3];
-    F a2 = m.x[1][0], b2 = m.x[1][1], c2 = m.x[1][2], d2 = m.x[1][3];
-    F a3 = m.x[2][0], b3 = m.x[2][1], c3 = m.x[2][2], d3 = m.x[2][3];
-    F a4 = m.x[3][0], b4 = m.x[3][1], c4 = m.x[3][2], d4 = m.x[3][3];
-    return a1 * det3x3( b2, b3, b4, c2, c3, c4, d2, d3, d4)
-         - b1 * det3x3( a2, a3, a4, c2, c3, c4, d2, d3, d4)
-         + c1 * det3x3( a2, a3, a4, b2, b3, b4, d2, d3, d4)
-         - d1 * det3x3( a2, a3, a4, b2, b3, b4, c2, c3, c4);
-}
-#endif
 
 OSL_SHADEOP OSL_HOSTDEVICE float
 osl_determinant_fm (void *m)

--- a/src/liboslexec/wide/wide_opmatrix.cpp
+++ b/src/liboslexec/wide/wide_opmatrix.cpp
@@ -1,0 +1,1470 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+/////////////////////////////////////////////////////////////////////////
+/// \file
+///
+/// Shader interpreter implementation of matrix operations.
+///
+/////////////////////////////////////////////////////////////////////////
+#include <OSL/oslconfig.h>
+
+#include <OSL/batched_rendererservices.h>
+#include <OSL/batched_shaderglobals.h>
+#include <OSL/wide.h>
+
+#include <OpenImageIO/fmath.h>
+
+#include "oslexec_pvt.h"
+
+OSL_NAMESPACE_ENTER
+namespace __OSL_WIDE_PVT {
+
+OSL_USING_DATA_WIDTH(__OSL_WIDTH)
+
+using BatchedRendererServices = OSL::BatchedRendererServices<__OSL_WIDTH>;
+
+#include "define_opname_macros.h"
+
+namespace {
+
+// invoke is helper to ensure a functor is compiled inside a
+// actual function call vs. inlining.
+// Useful for keeping the slow path from fusing
+// with a streamlined SIMD loop or influencing
+// register usage
+template<typename FunctorT>
+OSL_NOINLINE void
+invoke(FunctorT f);
+
+template<typename FunctorT>
+void
+invoke(FunctorT f)
+{
+    f();
+}
+
+template<typename T>
+OSL_FORCEINLINE bool
+testIfAnyLaneIsOn(const Wide<T>& wvalues)
+{
+#if OSL_NON_INTEL_CLANG
+    int anyLaneIsOn = 0;
+    OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH) reduction(max : anyLaneIsOn))
+    for (int i = 0; i < __OSL_WIDTH; ++i) {
+        if (wvalues[i] > anyLaneIsOn)
+            anyLaneIsOn = wvalues[i];
+    }
+    return anyLaneIsOn;
+#else
+    // NOTE: do not explicitly vectorize as it would require a
+    // reduction.  Instead let compiler optimize this itself.
+    bool anyLaneIsOn = false;
+    for (int i = 0; i < __OSL_WIDTH; ++i) {
+        if (wvalues[i] != T(0))
+            anyLaneIsOn = true;
+    }
+    return anyLaneIsOn;
+#endif
+}
+
+
+OSL_FORCEINLINE void
+invert_wide_matrix(Masked<Matrix44> wresult, Wide<const Matrix44> wmatrix)
+{
+    if (wresult.mask().any_on()) {
+        Block<int> notAffineBlock;
+        Wide<int> wnotAffine(notAffineBlock);
+
+        OSL_FORCEINLINE_BLOCK
+        {
+            OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+            for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+                Matrix44 m     = wmatrix[lane];
+                bool is_affine = true;
+                if (wresult.mask()[lane]) {
+                    is_affine = test_if_affine(m);
+                    if (is_affine) {
+                        Matrix44 r                = OSL::affineInverse(m);
+                        wresult[ActiveLane(lane)] = r;
+                    }
+                }
+                wnotAffine[lane]
+                    = (!is_affine);  // false when lane is masked off
+            }
+        }
+
+        if (testIfAnyLaneIsOn(wnotAffine)) {
+            invoke([=]() -> void {
+                for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+                    if (wnotAffine[lane]) {
+                        OSL_DASSERT(wresult.mask().is_on(lane));
+                        Matrix44 m                = wmatrix[lane];
+                        Matrix44 invm             = OSL::nonAffineInverse(m);
+                        wresult[ActiveLane(lane)] = invm;
+                    }
+                }
+            });
+        }
+    }
+}
+
+
+Mask
+default_get_matrix(BatchedRendererServices* bsr, BatchedShaderGlobals* bsg,
+                   Masked<Matrix44> wresult, Wide<const ustring> wfrom,
+                   Wide<const float> wtime)
+{
+    Mask ok(false);
+    foreach_unique(wfrom, wresult.mask(),
+                   [=, &ok](const ustring& from, Mask from_mask) {
+                       // Reuse the uniform from implementation by restricting results to
+                       // just the lanes with the same value of "from".
+                       Masked<Matrix44> wsub_result(wresult.data(), from_mask);
+                       Mask sub_ok = bsr->get_matrix(bsg, wsub_result, from,
+                                                     wtime);
+                       ok |= sub_ok;
+                   });
+    return ok;
+}
+
+// Avoid calling virtual functions and allow the default implementations
+// to exist in target specific libraries.  We use a dispatch helper
+// to call the virtual function ONLY if it is overriden, otherwise
+// execute the ISA optimized default version built right here.
+OSL_FORCEINLINE Mask
+dispatch_get_matrix(BatchedRendererServices* bsr, BatchedShaderGlobals* bsg,
+                    Masked<Matrix44> result, Wide<const ustring> from,
+                    Wide<const float> time)
+{
+    if (bsr->is_overridden_get_matrix_WmWsWf()) {
+        return bsr->get_matrix(bsg, result, from, time);
+    } else {
+        return default_get_matrix(bsr, bsg, result, from, time);
+    }
+}
+
+Mask
+default_get_inverse_matrix(BatchedRendererServices* bsr,
+                           BatchedShaderGlobals* bsg, Masked<Matrix44> result,
+                           Wide<const TransformationPtr> xform,
+                           Wide<const float> time)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Block<Matrix44> wmatrix;
+        Mask succeeded
+            = bsr->get_matrix(bsg, Masked<Matrix44>(wmatrix, result.mask()),
+                              xform, time);
+        invert_wide_matrix(result & succeeded, wmatrix);
+        return succeeded;
+    }
+}
+
+OSL_FORCEINLINE Mask
+dispatch_get_inverse_matrix(BatchedRendererServices* bsr,
+                            BatchedShaderGlobals* bsg, Masked<Matrix44> result,
+                            Wide<const TransformationPtr> xform,
+                            Wide<const float> time)
+{
+    if (bsr->is_overridden_get_inverse_matrix_WmWxWf()) {
+        return bsr->get_inverse_matrix(bsg, result, xform, time);
+    } else {
+        return default_get_inverse_matrix(bsr, bsg, result, xform, time);
+    }
+}
+
+
+Mask
+default_get_inverse_matrix(BatchedRendererServices* bsr,
+                           BatchedShaderGlobals* bsg, Masked<Matrix44> result,
+                           ustring to, Wide<const float> time)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Block<Matrix44> wmatrix;
+        Mask succeeded
+            = bsr->get_matrix(bsg, Masked<Matrix44>(wmatrix, result.mask()), to,
+                              time);
+        invert_wide_matrix(result & succeeded, wmatrix);
+        return succeeded;
+    }
+}
+
+OSL_FORCEINLINE Mask
+dispatch_get_inverse_matrix(BatchedRendererServices* bsr,
+                            BatchedShaderGlobals* bsg, Masked<Matrix44> result,
+                            ustring to, Wide<const float> time)
+{
+    if (bsr->is_overridden_get_inverse_matrix_WmsWf()) {
+        return bsr->get_inverse_matrix(bsg, result, to, time);
+    } else {
+        return default_get_inverse_matrix(bsr, bsg, result, to, time);
+    }
+}
+
+
+Mask
+default_get_inverse_matrix(BatchedRendererServices* bsr,
+                           BatchedShaderGlobals* bsg, Masked<Matrix44> wresult,
+                           Wide<const ustring> wto, Wide<const float> wtime)
+{
+    if (bsr->is_overridden_get_inverse_matrix_WmsWf()) {
+        Mask ok(false);
+        foreach_unique(wto, wresult.mask(),
+                       [=, &ok](const ustring& to, Mask from_mask) {
+                           // Reuse the uniform from implementation by restricting results to
+                           // just the lanes with the same value of "from".
+                           Masked<Matrix44> wsub_result(wresult.data(),
+                                                        from_mask);
+                           Mask sub_ok = bsr->get_inverse_matrix(bsg,
+                                                                 wsub_result,
+                                                                 to, wtime);
+                           ok |= sub_ok;
+                       });
+        return ok;
+    } else {
+        OSL_FORCEINLINE_BLOCK
+        {
+            Block<Matrix44> wmatrix;
+            Mask succeeded = dispatch_get_matrix(bsr, bsg, wresult, wto, wtime);
+            invert_wide_matrix(wresult & succeeded, wmatrix);
+            return succeeded;
+        }
+    }
+}
+
+OSL_FORCEINLINE Mask
+dispatch_get_inverse_matrix(BatchedRendererServices* bsr,
+                            BatchedShaderGlobals* bsg, Masked<Matrix44> result,
+                            Wide<const ustring> to, Wide<const float> time)
+{
+    if (bsr->is_overridden_get_inverse_matrix_WmWsWf()) {
+        return bsr->get_inverse_matrix(bsg, result, to, time);
+    } else {
+        return default_get_inverse_matrix(bsr, bsg, result, to, time);
+    }
+}
+
+}  // namespace
+
+OSL_BATCHOP void __OSL_OP3(mul, Wm, Wm, Wf)(void* wr_, void* wa_, void* wb_)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wa(wa_);
+        Wide<const float> wb(wb_);
+        Wide<Matrix44> wr(wr_);
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 a = wa[lane];
+            float b    = wb[lane];
+            Matrix44 r = a * b;
+            wr[lane]   = r;
+        }
+    }
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(mul, Wm, Wm, Wf)(void* wr_, void* wa_,
+                                                   void* wb_,
+                                                   unsigned int mask_value)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wa(wa_);
+        Wide<const float> wb(wb_);
+        Masked<Matrix44> wr(wr_, Mask(mask_value));
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 a = wa[lane];
+            float b    = wb[lane];
+            Matrix44 r = a * b;
+            wr[lane]   = r;
+        }
+    }
+}
+
+OSL_BATCHOP void __OSL_OP3(mul, Wm, Wm, Wm)(void* wr_, void* wa_, void* wb_)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wa(wa_);
+        Wide<const Matrix44> wb(wb_);
+        Wide<Matrix44> wr(wr_);
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 a = wa[lane];
+            Matrix44 b = wb[lane];
+            // Need inlinable version for vectorization
+            // Matrix44 r = a * b;
+            // TODO: replace Matrix * Matrix implementation
+            // in IMATH with inlinable equivalent of multiplyMatrixByMatrix
+            wr[lane] = multiplyMatrixByMatrix(a, b);
+        }
+    }
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(mul, Wm, Wm, Wm)(void* wr_, void* wa_,
+                                                   void* wb_,
+                                                   unsigned int mask_value)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wa(wa_);
+        Wide<const Matrix44> wb(wb_);
+        Masked<Matrix44> wr(wr_, Mask(mask_value));
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 a = wa[lane];
+            Matrix44 b = wb[lane];
+            // Need inlinable version for vectorization
+            // Matrix44 r = a * b;
+            wr[lane] = multiplyMatrixByMatrix(a, b);
+        }
+    }
+}
+
+
+OSL_BATCHOP void __OSL_MASKED_OP3(div, Wm, Wm, Wm)(void* wr_, void* wa_,
+                                                   void* wb_,
+                                                   unsigned int mask_value)
+{
+    Wide<const Matrix44> wa(wa_);
+    Wide<const Matrix44> wb(wb_);
+    Masked<Matrix44> wresult(wr_, Mask(mask_value));
+
+    Block<int> notAffineBlock;
+    Wide<int> wnotAffine(notAffineBlock);
+
+    // Rather than calling b.inverse() which has to handle affine and
+    // non-affine matrices, we will test if b is affine and only
+    // vectorize the fast path and create a test to skip the
+    // slow path for non-affine inverses and avoiding attempting to
+    // vectorize the slow path.
+    OSL_FORCEINLINE_BLOCK
+    {
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 a     = wa[lane];
+            Matrix44 b     = wb[lane];
+            bool is_affine = true;
+            if (wresult.mask()[lane]) {
+                is_affine = test_if_affine(b);
+                if (is_affine) {
+                    wresult[ActiveLane(lane)]
+                        = multiplyMatrixByMatrix(a, OSL::affineInverse(b));
+                }
+            }
+            wnotAffine[lane] = (!is_affine);  // false when lane is masked off
+        }
+    }
+
+    if (testIfAnyLaneIsOn(wnotAffine)) {
+        invoke([=]() -> void {
+            // DO NOT VECTORIZE the slow path
+            for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+                if (wnotAffine[lane]) {
+                    OSL_DASSERT(wresult.mask().is_on(lane));
+                    Matrix44 a = wa[lane];
+                    Matrix44 b = wb[lane];
+                    Matrix44 r                = a * OSL::nonAffineInverse(b);
+                    wresult[ActiveLane(lane)] = r;
+                }
+            }
+        });
+    }
+}
+
+OSL_BATCHOP void __OSL_OP3(div, Wm, Wm, Wf)(void* wr_, void* wa_, void* wb_)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wa(wa_);
+        Wide<const float> wb(wb_);
+        Wide<Matrix44> wr(wr_);
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 a = wa[lane];
+            float b    = wb[lane];
+            Matrix44 r = a * (1.0f / b);
+            wr[lane]   = r;
+        }
+    }
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(div, Wm, Wm, Wf)(void* wr_, void* wa_,
+                                                   void* wb_,
+                                                   unsigned int mask_value)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wa(wa_);
+        Wide<const float> wb(wb_);
+        Masked<Matrix44> wr(wr_, Mask(mask_value));
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 a = wa[lane];
+            float b    = wb[lane];
+            if (wr.mask()[lane]) {
+                Matrix44 r           = a * (1.0f / b);
+                wr[ActiveLane(lane)] = r;
+            }
+        }
+    }
+}
+
+
+OSL_BATCHOP void __OSL_MASKED_OP3(div, Wm, Wf, Wm)(void* wr_, void* wa_,
+                                                   void* wb_,
+                                                   unsigned int mask_value)
+{
+    Wide<const float> wa(wa_);
+    Wide<const Matrix44> wb(wb_);
+    Masked<Matrix44> wresult(wr_, Mask(mask_value));
+
+    Block<int> notAffineBlock;
+    Wide<int> wnotAffine(notAffineBlock);
+
+    // Rather than calling b.inverse() which has to handle affine and
+    // non-affine matrices, we will test if b is affine and only
+    // vectorize the fast path and create a test to skip the
+    // slow path for non-affine inverses and avoiding attempting to
+    // vectorize the slow path.
+    OSL_FORCEINLINE_BLOCK
+    {
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            const float a    = wa[lane];
+            const Matrix44 b = wb[lane];
+            bool is_affine   = true;
+            if (wresult.mask()[lane]) {
+                is_affine = test_if_affine(b);
+                if (is_affine) {
+                    Matrix44 r = a * OSL::affineInverse(b);
+
+                    wresult[ActiveLane(lane)] = r;
+                }
+            }
+            wnotAffine[lane] = (!is_affine);  // false when lane is masked off
+        }
+    }
+
+    if (testIfAnyLaneIsOn(wnotAffine)) {
+        invoke([=]() -> void {
+            for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+                if (wnotAffine[lane]) {
+                    OSL_DASSERT(wresult.mask().is_on(lane));
+                    float a    = wa[lane];
+                    Matrix44 b = wb[lane];
+                    Matrix44 r                = a * OSL::nonAffineInverse(b);
+                    wresult[ActiveLane(lane)] = r;
+                }
+            }
+        });
+    }
+}
+
+OSL_BATCHOP void __OSL_OP2(transpose, Wm, Wm)(void* wr_, void* wm_)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wm(wm_);
+        Wide<Matrix44> wr(wr_);
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 m = wm[lane];
+            // Call inlineable transposed
+            //Matrix44 r = m.transposed();
+            // TODO: replace Matrix::transposed implementation
+            // in IMATH with equivalent of inlinedTransposed
+            Matrix44 r = inlinedTransposed(m);
+            wr[lane]   = r;
+        }
+    }
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP2(transpose, Wm, Wm)(void* wr_, void* wm_,
+                                                     unsigned int mask_value)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wm(wm_);
+        Masked<Matrix44> wr(wr_, Mask(mask_value));
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 m = wm[lane];
+            // Call inlineable transposed
+            //Matrix44 r = m.transposed();
+            Matrix44 r = inlinedTransposed(m);
+            wr[lane]   = r;
+        }
+    }
+}
+
+namespace {
+OSL_NOINLINE void
+makeIdentity(Masked<Matrix44> wrm)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 ident(1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f,
+                           0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
+            wrm[lane] = ident;
+        }
+    }
+}
+
+OSL_FORCEINLINE Mask
+impl_get_uniform_from_matrix_masked(void* bsg_, Masked<Matrix44> wrm,
+                                    const char* from)
+{
+    auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ShadingContext* ctx = bsg->uniform.context;
+
+    if (USTR(from) == Strings::common
+        || USTR(from) == ctx->shadingsys().commonspace_synonym()) {
+        makeIdentity(wrm);
+
+        return wrm.mask();
+    }
+
+    if (USTR(from) == Strings::shader) {
+        ctx->batched<__OSL_WIDTH>().renderer()->get_matrix(
+            bsg, wrm, bsg->varying.shader2common, bsg->varying.time);
+        // NOTE: matching scalar version of code which ignores the renderservices return value
+        return wrm.mask();
+    }
+    if (USTR(from) == Strings::object) {
+        ctx->batched<__OSL_WIDTH>().renderer()->get_matrix(
+            bsg, wrm, bsg->varying.object2common, bsg->varying.time);
+        // NOTE: matching scalar version of code which ignores the renderservices return value
+        return wrm.mask();
+    }
+
+    Mask succeeded = ctx->batched<__OSL_WIDTH>().renderer()->get_matrix(
+        bsg, wrm, USTR(from), bsg->varying.time);
+    auto failedResults = wrm & succeeded.invert();
+    if (failedResults.mask().any_on()) {
+        makeIdentity(failedResults);
+        ShadingContext* ctx = bsg->uniform.context;
+        if (ctx->shadingsys().unknown_coordsys_error()) {
+            ctx->errorf("Unknown transformation \"%s\"", from);
+        }
+    }
+    return succeeded;
+}
+
+OSL_FORCEINLINE Mask
+impl_get_uniform_to_inverse_matrix_masked(void* bsg_, Masked<Matrix44> wrm,
+                                          const char* to)
+{
+    auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ShadingContext* ctx = bsg->uniform.context;
+
+    if (USTR(to) == Strings::common
+        || USTR(to) == ctx->shadingsys().commonspace_synonym()) {
+        makeIdentity(wrm);
+        return wrm.mask();
+    }
+    if (USTR(to) == Strings::shader) {
+        dispatch_get_inverse_matrix(ctx->batched<__OSL_WIDTH>().renderer(), bsg,
+                                    wrm, bsg->varying.shader2common,
+                                    bsg->varying.time);
+        // NOTE: matching scalar version of code which ignores the renderservices return value
+        return wrm.mask();
+    }
+    if (USTR(to) == Strings::object) {
+        dispatch_get_inverse_matrix(ctx->batched<__OSL_WIDTH>().renderer(), bsg,
+                                    wrm, bsg->varying.object2common,
+                                    bsg->varying.time);
+        // NOTE: matching scalar version of code which ignores the renderservices return value
+        return wrm.mask();
+    }
+
+    // Based on the 1 function that calls this function
+    // the results of the failed data lanes will get overwritten
+    // so no need to make sure that the values are valid (assuming FP exceptions are disabled)
+    Mask succeeded
+        = dispatch_get_inverse_matrix(ctx->batched<__OSL_WIDTH>().renderer(),
+                                      bsg, wrm, USTR(to), bsg->varying.time);
+
+    auto failedResults = wrm & succeeded.invert();
+    if (failedResults.mask().any_on()) {
+        makeIdentity(failedResults);
+        if (ctx->shadingsys().unknown_coordsys_error()) {
+            ctx->errorf("Unknown transformation \"%s\"", to);
+        }
+    }
+    return succeeded;
+}
+
+template<typename ResultAccessorT, typename FromAccessorT, typename ToAccessorT>
+OSL_FORCEINLINE void
+impl_wide_mat_multiply(ResultAccessorT wresult, FromAccessorT wfrom,
+                       ToAccessorT wto)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        // No savings from using a WeakMask
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 mat_From = wfrom[lane];
+            Matrix44 mat_To   = wto[lane];
+
+            // Need to call inlinable version
+            //Matrix44 result = mat_From * mat_To;
+            wresult[lane] = multiplyMatrixByMatrix(mat_From, mat_To);
+        }
+    }
+}
+
+OSL_FORCEINLINE Mask
+impl_get_varying_from_matrix_batched(BatchedShaderGlobals* bsg,
+                                     ShadingContext* ctx,
+                                     Wide<const ustring> wFrom,
+                                     Masked<Matrix44> wMfrom)
+{
+    // Deal with a varying 'from' space
+    ustring commonspace_synonym = ctx->shadingsys().commonspace_synonym();
+
+    Mask commonSpaceMask(false);
+    Mask shaderSpaceMask(false);
+    Mask objectSpaceMask(false);
+    Mask namedSpaceMask(false);
+
+    OSL_FORCEINLINE_BLOCK
+    {
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            ustring from = wFrom[lane];
+            if (wMfrom.mask()[lane]) {
+                if (from == Strings::common || from == commonspace_synonym) {
+                    commonSpaceMask.set_on(lane);
+                } else if (from == Strings::shader) {
+                    shaderSpaceMask.set_on(lane);
+                } else if (from == Strings::object) {
+                    objectSpaceMask.set_on(lane);
+                } else {
+                    namedSpaceMask.set_on(lane);
+                }
+            }
+        }
+    }
+
+    if (commonSpaceMask.any_on()) {
+        Masked<Matrix44> mfrom(wMfrom.data(), commonSpaceMask);
+        makeIdentity(mfrom);
+    }
+    const auto& sgbv = bsg->varying;
+    if (shaderSpaceMask.any_on()) {
+        Masked<Matrix44> mfrom(wMfrom.data(), shaderSpaceMask);
+        ctx->batched<__OSL_WIDTH>().renderer()->get_matrix(bsg, mfrom,
+                                                           sgbv.shader2common,
+                                                           sgbv.time);
+        // NOTE: matching scalar version of code which ignores the renderservices return value
+    }
+    if (objectSpaceMask.any_on()) {
+        Masked<Matrix44> mfrom(wMfrom.data(), objectSpaceMask);
+        ctx->batched<__OSL_WIDTH>().renderer()->get_matrix(bsg, mfrom,
+                                                           sgbv.object2common,
+                                                           sgbv.time);
+        // NOTE: matching scalar version of code which ignores the renderservices return value
+    }
+    // Only named lookups can fail, so we can just subtract those lanes
+    Mask succeeded(wMfrom.mask());
+    if (namedSpaceMask.any_on()) {
+        Masked<Matrix44> mfrom(wMfrom.data(), namedSpaceMask);
+
+        Mask success = ctx->batched<__OSL_WIDTH>().renderer()->get_matrix(
+            bsg, mfrom, wFrom, sgbv.time);
+
+        Mask failedLanes = success.invert() & namedSpaceMask;
+        if (failedLanes.any_on()) {
+            Masked<Matrix44> mto_failed(wMfrom.data(), failedLanes);
+            makeIdentity(mto_failed);
+            if (ctx->shadingsys().unknown_coordsys_error()) {
+                for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+                    if (failedLanes[lane]) {
+                        ustring from = wFrom[lane];
+                        ctx->batched<__OSL_WIDTH>().errorf(
+                            Mask(Lane(lane)), "Unknown transformation \"%s\"",
+                            from);
+                    }
+                }
+            }
+
+            // Remove any failed lanes from the success mask
+            succeeded &= ~failedLanes;
+        }
+    }
+    return succeeded;
+}
+}  // namespace
+
+OSL_BATCHOP void __OSL_MASKED_OP2(prepend_matrix_from, Wm,
+                                  s)(void* bsg_, void* wr, const char* from,
+                                     unsigned int mask_value)
+{
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+
+    Block<Matrix44> wMfrom;
+    Masked<Matrix44> from_matrix(wMfrom, Mask(mask_value));
+    /*Mask succeeded =*/
+    impl_get_uniform_from_matrix_masked(bsg, from_matrix, from);
+
+    Masked<Matrix44> wrm(wr, Mask(mask_value));
+
+    impl_wide_mat_multiply(wrm, from_matrix, wrm);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP2(prepend_matrix_from, Wm,
+                                  Ws)(void* bsg_, void* wr, void* w_from_name,
+                                      unsigned int mask_value)
+{
+    auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ShadingContext* ctx = bsg->uniform.context;
+
+    Wide<const ustring> wFromName(w_from_name);
+
+    Block<Matrix44> wMfrom;
+    Masked<Matrix44> from_matrix(wMfrom, Mask(mask_value));
+    /*Mask succeeded =*/
+    impl_get_varying_from_matrix_batched(bsg, ctx, wFromName, from_matrix);
+
+    Masked<Matrix44> wrm(wr, Mask(mask_value));
+
+    impl_wide_mat_multiply(wrm, from_matrix, wrm);
+}
+
+
+namespace {
+OSL_FORCEINLINE Mask
+impl_get_varying_to_matrix_masked(BatchedShaderGlobals* bsg,
+                                  ShadingContext* ctx, Wide<const ustring> wTo,
+                                  Masked<Matrix44> wMto)
+{
+    // Deal with a varying 'to' space
+    ustring commonspace_synonym = ctx->shadingsys().commonspace_synonym();
+
+    Mask commonSpaceMask(false);
+    Mask shaderSpaceMask(false);
+    Mask objectSpaceMask(false);
+    Mask namedSpaceMask(false);
+
+    OSL_FORCEINLINE_BLOCK
+    {
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            ustring to = wTo[lane];
+            if (wMto.mask()[lane]) {
+                if (to == Strings::common || to == commonspace_synonym) {
+                    commonSpaceMask.set_on(lane);
+                } else if (to == Strings::shader) {
+                    shaderSpaceMask.set_on(lane);
+                } else if (to == Strings::object) {
+                    objectSpaceMask.set_on(lane);
+                } else {
+                    namedSpaceMask.set_on(lane);
+                }
+            }
+        }
+    }
+
+    if (commonSpaceMask.any_on()) {
+        Masked<Matrix44> mto(wMto.data(), commonSpaceMask);
+        makeIdentity(mto);
+    }
+    const auto& sgbv = bsg->varying;
+    if (shaderSpaceMask.any_on()) {
+        Masked<Matrix44> mto(wMto.data(), shaderSpaceMask);
+        dispatch_get_inverse_matrix(ctx->batched<__OSL_WIDTH>().renderer(), bsg,
+                                    mto, sgbv.shader2common, sgbv.time);
+        // NOTE: matching scalar version of code which ignores the renderservices return value
+    }
+    if (objectSpaceMask.any_on()) {
+        Masked<Matrix44> mto(wMto.data(), objectSpaceMask);
+        dispatch_get_inverse_matrix(ctx->batched<__OSL_WIDTH>().renderer(), bsg,
+                                    mto, sgbv.object2common, sgbv.time);
+        // NOTE: matching scalar version of code which ignores the renderservices return value
+    }
+    // Only named lookups can fail, so we can just subtract those lanes
+    Mask succeeded(wMto.mask());
+    if (namedSpaceMask.any_on()) {
+        Masked<Matrix44> mto(wMto.data(), namedSpaceMask);
+
+        Mask success = dispatch_get_inverse_matrix(
+            ctx->batched<__OSL_WIDTH>().renderer(), bsg, mto, wTo, sgbv.time);
+
+        Mask failedLanes = success.invert() & namedSpaceMask;
+        if (failedLanes.any_on()) {
+            Masked<Matrix44> mto(wMto.data(), failedLanes);
+            makeIdentity(mto);
+            if (ctx->shadingsys().unknown_coordsys_error()) {
+                for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+                    if (failedLanes[lane]) {
+                        ustring to = wTo[lane];
+                        ctx->batched<__OSL_WIDTH>().errorf(
+                            Mask(Lane(lane)), "Unknown transformation \"%s\"",
+                            to);
+                    }
+                }
+            }
+
+            // Remove any failed lanes from the success mask
+            succeeded &= ~failedLanes;
+        }
+    }
+    return succeeded;
+}
+
+
+OSL_FORCEINLINE Mask
+impl_get_uniform_from_to_matrix_masked(BatchedShaderGlobals* bsg,
+                                       Masked<Matrix44> wrm, const char* from,
+                                       const char* to)
+{
+    Block<Matrix44> wMfrom, wMto;
+    Masked<Matrix44> from_matrix(wMfrom, wrm.mask());
+    Mask succeeded = impl_get_uniform_from_matrix_masked(bsg, from_matrix,
+                                                         from);
+
+    // NOTE: even if we failed to get a from matrix, it should have been set to
+    // identity, so we still need to try to get the to matrix for the original mask
+    Masked<Matrix44> to_matrix(wMto, wrm.mask());
+    succeeded &= impl_get_uniform_to_inverse_matrix_masked(bsg, to_matrix, to);
+
+    impl_wide_mat_multiply(wrm, from_matrix, to_matrix);
+    return succeeded;
+}
+}  // namespace
+
+OSL_BATCHOP int __OSL_MASKED_OP3(get_from_to_matrix, Wm, s,
+                                 s)(void* bsg_, void* wr, const char* from,
+                                    const char* to, unsigned int mask_value)
+{
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    Masked<Matrix44> wrm(wr, Mask(mask_value));
+    return impl_get_uniform_from_to_matrix_masked(bsg, wrm, from, to).value();
+}
+
+
+OSL_BATCHOP int __OSL_MASKED_OP3(get_from_to_matrix, Wm, s,
+                                 Ws)(void* bsg_, void* wr, const char* from,
+                                     void* w_to_ptr, unsigned int mask_value)
+{
+    auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ShadingContext* ctx = bsg->uniform.context;
+    Block<Matrix44> wMfrom;
+    Masked<Matrix44> from_matrix(wMfrom, Mask(mask_value));
+    Mask succeeded = impl_get_uniform_from_matrix_masked(bsg, from_matrix,
+                                                         from);
+
+    Wide<const ustring> wToSpace(w_to_ptr);
+    Block<Matrix44> wMto;
+    // NOTE: even if we failed to get a from matrix, it should have been set to
+    // identity, so we still need to try to get the to matrix for the original mask
+    Masked<Matrix44> to_matrix(wMto, Mask(mask_value));
+    succeeded &= impl_get_varying_to_matrix_masked(bsg, ctx, wToSpace,
+                                                   to_matrix);
+
+    Masked<Matrix44> wrm(wr, Mask(mask_value));
+    impl_wide_mat_multiply(wrm, from_matrix, to_matrix);
+    return succeeded.value();
+}
+
+
+OSL_BATCHOP int __OSL_MASKED_OP3(get_from_to_matrix, Wm, Ws,
+                                 s)(void* bsg_, void* wr, void* w_from_ptr,
+                                    const char* to, unsigned int mask_value)
+{
+    auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ShadingContext* ctx = bsg->uniform.context;
+
+    Wide<const ustring> wFromName(w_from_ptr);
+
+    Block<Matrix44> wMto;
+    Masked<Matrix44> to_matrix(wMto, Mask(mask_value));
+    Mask succeeded = impl_get_uniform_to_inverse_matrix_masked(bsg, to_matrix,
+                                                               to);
+
+    Block<Matrix44> wMfrom;
+    // NOTE: even if we failed to get a to matrix, it should have been set to
+    // identity, so we still need to try to get the to matrix for the original mask
+    Masked<Matrix44> from_matrix(wMfrom, Mask(mask_value));
+    succeeded &= impl_get_varying_from_matrix_batched(bsg, ctx, wFromName,
+                                                      from_matrix);
+
+    Masked<Matrix44> wrm(wr, Mask(mask_value));
+    impl_wide_mat_multiply(wrm, from_matrix, to_matrix);
+    return succeeded.value();
+}
+
+
+OSL_BATCHOP int __OSL_MASKED_OP3(get_from_to_matrix, Wm, Ws,
+                                 Ws)(void* bsg_, void* wr, void* w_from_ptr,
+                                     void* w_to_ptr, unsigned int mask_value)
+{
+    auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ShadingContext* ctx = bsg->uniform.context;
+
+    Wide<const ustring> wFromName(w_from_ptr);
+
+    Block<Matrix44> wMfrom;
+    Masked<Matrix44> from_matrix(wMfrom, Mask(mask_value));
+    Mask succeeded = impl_get_varying_from_matrix_batched(bsg, ctx, wFromName,
+                                                          from_matrix);
+
+    Wide<const ustring> wToSpace(w_to_ptr);
+    Block<Matrix44> wMto;
+    // NOTE: even if we failed to get a from matrix, it should have been set to
+    // identity, so we still need to try to get the to matrix for the original mask
+    Masked<Matrix44> to_matrix(wMto, Mask(mask_value));
+    succeeded &= impl_get_varying_to_matrix_masked(bsg, ctx, wToSpace,
+                                                   to_matrix);
+
+    Masked<Matrix44> wrm(wr, Mask(mask_value));
+    impl_wide_mat_multiply(wrm, from_matrix, to_matrix);
+    return succeeded.value();
+}
+
+
+// NOTE:  For batched transforms, a different dispatch approach is used.
+// Instead of calling a single transform_triple function with lots of
+// conditionals to select/dispatch the correct code, a 2 steps are taken.
+// First call an explicitly named function (osl_build_transform_matrix_??_masked)
+// is called that represents the uniformity for the different from & to spaces
+// is called building a transform matrix.
+// Second call an explicitly named function (osl_transform_[point|vector|normal]_??_masked)
+// is called that represents the uniformity and data types of the src and destination triples.
+// Also zeroing of derivatives is left to the code generator.
+
+OSL_BATCHOP int __OSL_MASKED_OP3(build_transform_matrix, Wm, s,
+                                 s)(void* bsg_, void* WM_, void* from_,
+                                    void* to_, unsigned int mask_value)
+{
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+
+    Mask mask(mask_value);
+    Masked<Matrix44> mm(WM_, mask);
+    ShadingContext* ctx = bsg->uniform.context;
+
+    ustring from = USTR(from_);
+    ustring to   = USTR(to_);
+
+    Mask succeeded;
+    // Avoid matrix concatenation if possible by detecting when the
+    // adjacent matrix would be identity
+    // We don't expect both from and to == common, so we are not
+    // optimizing for it
+    if (from == Strings::common
+        || from == ctx->shadingsys().commonspace_synonym()) {
+        succeeded = impl_get_uniform_to_inverse_matrix_masked(bsg, mm,
+                                                              to.c_str());
+    } else if (to == Strings::common
+               || to == ctx->shadingsys().commonspace_synonym()) {
+        succeeded = impl_get_uniform_from_matrix_masked(bsg, mm, from.c_str());
+    } else {
+        succeeded = impl_get_uniform_from_to_matrix_masked(bsg, mm,
+                                                           from.c_str(),
+                                                           to.c_str());
+    }
+    return succeeded.value();
+}
+
+OSL_BATCHOP int __OSL_MASKED_OP3(build_transform_matrix, Wm, Ws,
+                                 s)(void* bsg_, void* WM_, void* wfrom_,
+                                    void* to_, unsigned int mask_value)
+{
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+
+    Mask mask(mask_value);
+    Masked<Matrix44> wrm(WM_, mask);
+
+    Wide<const ustring> wfrom_space(wfrom_);
+
+    ustring to_space = USTR(to_);
+
+    Block<Matrix44> wMfrom, wMto;
+    Masked<Matrix44> from_matrix(wMfrom, wrm.mask());
+    ShadingContext* ctx = bsg->uniform.context;
+
+    Mask succeeded = impl_get_varying_from_matrix_batched(bsg, ctx, wfrom_space,
+                                                          from_matrix);
+    Masked<Matrix44> to_matrix(wMto, wrm.mask() & succeeded);
+    succeeded &= impl_get_uniform_to_inverse_matrix_masked(bsg, to_matrix,
+                                                           to_space.c_str());
+
+    impl_wide_mat_multiply(wrm, from_matrix, to_matrix);
+    return succeeded.value();
+}
+
+OSL_BATCHOP int __OSL_MASKED_OP3(build_transform_matrix, Wm, s,
+                                 Ws)(void* bsg_, void* WM_, void* from_,
+                                     void* wto_, unsigned int mask_value)
+{
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+
+    Mask mask(mask_value);
+    Masked<Matrix44> wrm(WM_, mask);
+
+    ustring from = USTR(from_);
+    Wide<const ustring> wto_space(wto_);
+
+    Block<Matrix44> wMfrom, wMto;
+    Masked<Matrix44> from_matrix(wMfrom, wrm.mask());
+    ShadingContext* ctx = bsg->uniform.context;
+
+    Mask succeeded = impl_get_uniform_from_matrix_masked(bsg, from_matrix,
+                                                         from.c_str());
+    Masked<Matrix44> to_matrix(wMto, wrm.mask() & succeeded);
+    succeeded &= impl_get_varying_to_matrix_masked(bsg, ctx, wto_space,
+                                                   to_matrix);
+
+    impl_wide_mat_multiply(wrm, from_matrix, to_matrix);
+
+    return succeeded.value();
+}
+
+OSL_BATCHOP int __OSL_MASKED_OP3(build_transform_matrix, Wm, Ws,
+                                 Ws)(void* bsg_, void* WM_, void* wfrom_,
+                                     void* wto_, unsigned int mask_value)
+{
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+
+    Mask mask(mask_value);
+    Masked<Matrix44> wrm(WM_, mask);
+
+    Wide<const ustring> wfrom_space(wfrom_);
+    Wide<const ustring> wto_space(wto_);
+
+    Block<Matrix44> wMfrom, wMto;
+    Masked<Matrix44> from_matrix(wMfrom, wrm.mask());
+    ShadingContext* ctx = bsg->uniform.context;
+
+    Mask succeeded = impl_get_varying_from_matrix_batched(bsg, ctx, wfrom_space,
+                                                          from_matrix);
+    Masked<Matrix44> to_matrix(wMto, wrm.mask() & succeeded);
+    succeeded &= impl_get_varying_to_matrix_masked(bsg, ctx, wto_space,
+                                                   to_matrix);
+
+    impl_wide_mat_multiply(wrm, from_matrix, to_matrix);
+
+    return succeeded.value();
+}
+
+namespace {
+template<typename InputAccessorT>
+OSL_FORCEINLINE void
+impl_copy_untransformed_lanes(InputAccessorT inVec, void* Pout, Mask succeeded,
+                              Mask op_mask)
+{
+    typedef typename InputAccessorT::NonConstValueType data_type;
+    // if Pin != Pout, we still need to copy inactive data over to Pout
+    // Handle cleaning up any data lanes that did not succeed
+    if (((void*)&inVec.data() != Pout)) {
+        // For any lanes we failed to get a matrix for
+        // just copy the input to the output values
+        // NOTE:  As we only only want to copy lanes that failed,
+        // we will invert our success mask
+        Mask failed = succeeded.invert() & op_mask;
+        if (OSL_UNLIKELY(failed.any_on())) {
+            OSL_FORCEINLINE_BLOCK
+            {
+                Masked<data_type> failedOutVec(Pout, failed);
+                OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+                for (int i = 0; i < __OSL_WIDTH; ++i) {
+                    failedOutVec[i] = inVec[i];
+                }
+            }
+        }
+    }
+}
+
+template<typename InputAccessorT, typename MatrixAccessorT>
+OSL_FORCEINLINE void
+impl_transform_point_masked(void* Pin, void* Pout, void* transform,
+                            unsigned int mask_transform,
+                            unsigned int mask_value)
+{
+    typedef typename InputAccessorT::NonConstValueType data_type;
+
+    // ignore derivs because output doesn't need it
+    OSL_FORCEINLINE_BLOCK
+    {
+        Mask mask(mask_value);
+        Mask succeeded(mask_transform);
+
+        InputAccessorT inPoints(Pin);
+        // only operate on active lanes
+        Mask activeMask = mask & succeeded;
+
+        Masked<data_type> wresult(Pout, activeMask);
+        MatrixAccessorT wM(transform);
+
+        // Transform with Vector semantics
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            const Matrix44 m  = wM[lane];
+            const data_type v = inPoints[lane];
+
+            if (wresult.mask()[lane]) {
+                data_type r;
+
+                // Do to illegal aliasing in OpenEXR version
+                // we call our own flavor without aliasing
+                robust_multVecMatrix(m, v, r);
+
+                wresult[ActiveLane(lane)] = r;
+            }
+        }
+
+        impl_copy_untransformed_lanes(inPoints, Pout, succeeded, mask);
+    }
+}
+}  // namespace
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_point, v, Wv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    // TODO: see if we can get gen_transform to call the vvm version then do a masked broadcast
+    impl_transform_point_masked<UniformAsWide<const Vec3>,
+                                UniformAsWide<const Matrix44>>(Pin, Pout,
+                                                               transform,
+                                                               mask_transform,
+                                                               mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_point, v, Wv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_point_masked<UniformAsWide<const Vec3>, Wide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_point, Wv, Wv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_point_masked<Wide<const Vec3>, Wide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_point, Wdv, Wdv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_point_masked<Wide<const Dual2<Vec3>>, Wide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_point, Wv, Wv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    impl_transform_point_masked<Wide<const Vec3>, UniformAsWide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_point, Wdv, Wdv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    impl_transform_point_masked<Wide<const Dual2<Vec3>>,
+                                UniformAsWide<const Matrix44>>(Pin, Pout,
+                                                               transform,
+                                                               mask_transform,
+                                                               mask_value);
+}
+
+namespace {
+template<typename InputAccessorT, typename MatrixAccessorT>
+OSL_FORCEINLINE void
+impl_transform_vector_masked(void* Pin, void* Pout, void* transform,
+                             unsigned int mask_transform,
+                             unsigned int mask_value)
+{
+    typedef typename InputAccessorT::NonConstValueType data_type;
+
+    // ignore derivs because output doesn't need it
+    OSL_FORCEINLINE_BLOCK
+    {
+        Mask mask(mask_value);
+        Mask succeeded(mask_transform);
+
+        InputAccessorT inPoints(Pin);
+        // only operate on active lanes
+        Mask activeMask = mask & succeeded;
+
+        Masked<data_type> wresult(Pout, activeMask);
+        MatrixAccessorT wM(transform);
+
+        // Transform with Vector semantics
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 m  = wM[lane];
+            data_type v = inPoints[lane];
+            if (wresult.mask()[lane]) {
+                // Do to illegal aliasing in OpenEXR version
+                // we call our own flavor without aliasing
+                //M.multDirMatrix (v, VEC(result));
+                // TODO: update multDirMatrix to equivalent of multiplyDirByMatrix
+                wresult[ActiveLane(lane)] = multiplyDirByMatrix(m, v);
+            }
+        }
+
+        impl_copy_untransformed_lanes(inPoints, Pout, succeeded, mask);
+    }
+}
+}  // namespace
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_vector, v, Wv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    // TODO: see if we can get gen_transform to call the vvm version then do a masked broadcast
+    impl_transform_vector_masked<UniformAsWide<const Vec3>,
+                                 UniformAsWide<const Matrix44>>(Pin, Pout,
+                                                                transform,
+                                                                mask_transform,
+                                                                mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_vector, v, Wv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_vector_masked<UniformAsWide<const Vec3>,
+                                 Wide<const Matrix44>>(Pin, Pout, transform,
+                                                       mask_transform,
+                                                       mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_vector, Wv, Wv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_vector_masked<Wide<const Vec3>, Wide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_vector, Wdv, Wdv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_vector_masked<Wide<const Dual2<Vec3>>, Wide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_vector, Wv, Wv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    impl_transform_vector_masked<Wide<const Vec3>, UniformAsWide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_vector, Wdv, Wdv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    impl_transform_vector_masked<Wide<const Dual2<Vec3>>,
+                                 UniformAsWide<const Matrix44>>(Pin, Pout,
+                                                                transform,
+                                                                mask_transform,
+                                                                mask_value);
+}
+
+namespace {
+template<typename InputAccessorT, typename MatrixAccessorT>
+OSL_FORCEINLINE void
+impl_transform_normal_masked(void* Pin, void* Pout, void* transform,
+                             unsigned int mask_transform,
+                             unsigned int mask_value)
+{
+    typedef typename InputAccessorT::NonConstValueType data_type;
+
+    Mask mask(mask_value);
+    Mask succeeded(mask_transform);
+
+    // only operate on active lanes
+    Mask activeMask = mask & succeeded;
+
+    Masked<data_type> wresult(Pout, activeMask);
+    InputAccessorT inPoints(Pin);
+    MatrixAccessorT wM(transform);
+
+    // Transform with Normal semantics
+
+    Block<int> notAffineBlock;
+    Wide<int> wnotAffine(notAffineBlock);
+
+    OSL_FORCEINLINE_BLOCK
+    {
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            data_type v    = inPoints[lane];
+            Matrix44 M     = wM[lane];
+            bool is_affine = true;
+            if (wresult.mask()[lane]) {
+                is_affine = test_if_affine(M);
+                if (is_affine) {
+                    wresult[ActiveLane(lane)] = multiplyDirByMatrix(
+                        inlinedTransposed(OSL::affineInverse(M)), v);
+                }
+            }
+            wnotAffine[lane] = (!is_affine);  // false when lane is masked off
+        }
+    }
+
+    if (testIfAnyLaneIsOn(wnotAffine)) {
+        invoke([=]() -> void {
+            for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+                if (wnotAffine[lane]) {
+                    OSL_DASSERT(wresult.mask().is_on(lane));
+
+                    data_type v = inPoints[lane];
+                    Matrix44 M  = wM[lane];
+
+                    //M.inverse().transposed().multDirMatrix (v, r);
+                    // Use helper that has specializations for Dual2
+                    wresult[ActiveLane(lane)] = multiplyDirByMatrix(
+                        inlinedTransposed(nonAffineInverse(M)), v);
+                }
+            }
+        });
+    }
+
+    impl_copy_untransformed_lanes(inPoints, Pout, succeeded, mask);
+}
+}  // namespace
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_normal, v, Wv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    // TODO: see if we can get gen_transform to call the vvm version then do a masked broadcast
+    impl_transform_normal_masked<UniformAsWide<const Vec3>,
+                                 UniformAsWide<const Matrix44>>(Pin, Pout,
+                                                                transform,
+                                                                mask_transform,
+                                                                mask_value);
+}
+
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_normal, v, Wv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_normal_masked<UniformAsWide<const Vec3>,
+                                 Wide<const Matrix44>>(Pin, Pout, transform,
+                                                       mask_transform,
+                                                       mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_normal, Wv, Wv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_normal_masked<Wide<const Vec3>, Wide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_normal, Wdv, Wdv,
+                                  Wm)(void* Pin, void* Pout, void* transform,
+                                      unsigned int mask_transform,
+                                      unsigned int mask_value)
+{
+    impl_transform_normal_masked<Wide<const Dual2<Vec3>>, Wide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_normal, Wv, Wv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    impl_transform_normal_masked<Wide<const Vec3>, UniformAsWide<const Matrix44>>(
+        Pin, Pout, transform, mask_transform, mask_value);
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP3(transform_normal, Wdv, Wdv,
+                                  m)(void* Pin, void* Pout, void* transform,
+                                     unsigned int mask_transform,
+                                     unsigned int mask_value)
+{
+    impl_transform_normal_masked<Wide<const Dual2<Vec3>>,
+                                 UniformAsWide<const Matrix44>>(Pin, Pout,
+                                                                transform,
+                                                                mask_transform,
+                                                                mask_value);
+}
+
+OSL_BATCHOP void __OSL_OP2(determinant, Wf, Wm)(void* wr_, void* wm_)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wm(wm_);
+        Wide<float> wr(wr_);
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 m = wm[lane];
+            float r    = det4x4(m);
+            wr[lane]   = r;
+        }
+    }
+}
+
+OSL_BATCHOP void __OSL_MASKED_OP2(determinant, Wf, Wm)(void* wr_, void* wm_,
+                                                       unsigned int mask_value)
+{
+    OSL_FORCEINLINE_BLOCK
+    {
+        Wide<const Matrix44> wm(wm_);
+        Masked<float> wr(wr_, Mask(mask_value));
+
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            Matrix44 m = wm[lane];
+            float r    = det4x4(m);
+            wr[lane]   = r;
+        }
+    }
+}
+
+}  // namespace __OSL_WIDE_PVT
+OSL_NAMESPACE_EXIT
+
+#include "undef_opname_macros.h"

--- a/testsuite/array-reg/run.py
+++ b/testsuite/array-reg/run.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_float.tif test_varying_index_float")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_int.tif test_varying_index_int")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_string.tif test_varying_index_string")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_matrix.tif test_varying_index_matrix")
+outputs.append ("out_varying_index_float.tif")
+outputs.append ("out_varying_index_int.tif")
+outputs.append ("out_varying_index_string.tif")
+outputs.append ("out_varying_index_matrix.tif")
+
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_color.tif test_varying_index_color")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_point.tif test_varying_index_point")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_vector.tif test_varying_index_vector")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_normal.tif test_varying_index_normal")
+outputs.append ("out_varying_index_color.tif")
+outputs.append ("out_varying_index_point.tif")
+outputs.append ("out_varying_index_vector.tif")
+outputs.append ("out_varying_index_normal.tif")
+
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_out_of_bounds_index_int.tif test_varying_out_of_bounds_index_int")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_out_of_bounds_index_float.tif test_varying_out_of_bounds_index_float")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_out_of_bounds_index_string.tif test_varying_out_of_bounds_index_string")
+outputs.append ("out_varying_out_of_bounds_index_int.tif")
+outputs.append ("out_varying_out_of_bounds_index_float.tif")
+outputs.append ("out_varying_out_of_bounds_index_string.tif")
+
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_ray.tif test_varying_index_ray")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_cube.tif test_varying_index_cube")
+outputs.append ("out_varying_index_ray.tif")
+outputs.append ("out_varying_index_cube.tif")
+
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_float.tif test_varying_index_varying_float")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_int.tif test_varying_index_varying_int")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_point.tif test_varying_index_varying_point")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_normal.tif test_varying_index_varying_normal")
+outputs.append ("out_varying_index_varying_float.tif")
+outputs.append ("out_varying_index_varying_int.tif")
+outputs.append ("out_varying_index_varying_point.tif")
+outputs.append ("out_varying_index_varying_normal.tif")
+
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_vector.tif test_varying_index_varying_vector")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_color.tif test_varying_index_varying_color")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_string.tif test_varying_index_varying_string")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_matrix.tif test_varying_index_varying_matrix")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_varying_index_varying_ray.tif test_varying_index_varying_ray")
+outputs.append ("out_varying_index_varying_vector.tif")
+outputs.append ("out_varying_index_varying_color.tif")
+outputs.append ("out_varying_index_varying_string.tif")
+outputs.append ("out_varying_index_varying_matrix.tif")
+outputs.append ("out_varying_index_varying_ray.tif")
+
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_float.tif test_uniform_index_varying_float")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_int.tif test_uniform_index_varying_int")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_point.tif test_uniform_index_varying_point")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_normal.tif test_uniform_index_varying_normal")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_vector.tif test_uniform_index_varying_vector")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_color.tif test_uniform_index_varying_color")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_string.tif test_uniform_index_varying_string")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_matrix.tif test_uniform_index_varying_matrix")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_uniform_index_varying_ray.tif test_uniform_index_varying_ray")
+outputs.append ("out_uniform_index_varying_float.tif")
+outputs.append ("out_uniform_index_varying_int.tif")
+outputs.append ("out_uniform_index_varying_point.tif")
+outputs.append ("out_uniform_index_varying_normal.tif")
+outputs.append ("out_uniform_index_varying_vector.tif")
+outputs.append ("out_uniform_index_varying_color.tif")
+outputs.append ("out_uniform_index_varying_string.tif")
+outputs.append ("out_uniform_index_varying_matrix.tif")
+outputs.append ("out_uniform_index_varying_ray.tif")
+
+
+# expect a few LSB failures
+failthresh = 0.008
+failpercent = 3
+

--- a/testsuite/array-reg/test_uniform_index_varying_color.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_color.osl
@@ -1,0 +1,18 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_uniform_index_varying_color (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    color carray[3] = { color(.1,u,.3), P[0]+P[1], color(.3,.3,v) };
+
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndex = res[0]%3;
+    color indirectC = carray[uniformIndex];
+    
+    Cout = indirectC;
+}

--- a/testsuite/array-reg/test_uniform_index_varying_float.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_float.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_uniform_index_varying_float (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    float rarray[3] = { 0.1*u, 0.2, 0.3 };
+    float garray[3] = { 0.2, 0.4*P[0], 0.6*P[1] };
+    float barray[3] = { 0.3, 0.5, 0.8*v };
+    
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndex = res[0]%3;
+    
+    float indirectR = rarray[uniformIndex];
+    float indirectG = garray[uniformIndex];
+    float indirectB = barray[uniformIndex];
+    
+    Cout = color(indirectR,indirectG,indirectB);
+}

--- a/testsuite/array-reg/test_uniform_index_varying_int.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_int.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_uniform_index_varying_int (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    int rarray[3] = { int(10*u), 20, 30 };
+    int garray[3] = { 20, int(40*P[0]), int(60*P[1]) };
+    int barray[3] = { 30, 50, int(80*v) };
+    
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndex = res[0]%3;
+    
+    int indirectR = rarray[uniformIndex];
+    int indirectG = garray[uniformIndex];
+    int indirectB = barray[uniformIndex];
+    
+    Cout = color(indirectR/100.0,indirectG/100.0,indirectB/100.0);
+}

--- a/testsuite/array-reg/test_uniform_index_varying_matrix.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_matrix.osl
@@ -1,0 +1,33 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_uniform_index_varying_matrix (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    float s0 = 1.0/3.0;
+    float s1 = 2.0/3.0;
+    float s2 = 1;
+    matrix marray[3] = { matrix(s0,0,0,0,
+                                0,s0*u,0,0,
+                                0,0,s0*v,0,
+                                0,0,0,1),
+                         matrix(s1*u,0,0,0,
+                                0,s1*v,0,0,
+                                0,0,s1,0,
+                                0,0,0,1),
+                         matrix(s2,0,0,0,
+                                0,s2,0,0,
+                                0,0,s2,0,
+                                0,0,0,1) };
+    
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndex = res[0]%3;
+    matrix indirectM = marray[uniformIndex];
+    
+    point tp = transform(indirectM,P);
+    Cout = color(tp);    
+}

--- a/testsuite/array-reg/test_uniform_index_varying_normal.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_normal.osl
@@ -1,0 +1,18 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_uniform_index_varying_normal (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    normal narray[3] = { normal(.1,u,.3), P[0]+P[1], normal(.3,.3,v) };
+    
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndex = res[0]%3;
+    normal indirectN = narray[uniformIndex];
+    
+    Cout = indirectN;
+}

--- a/testsuite/array-reg/test_uniform_index_varying_point.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_point.osl
@@ -1,0 +1,18 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_uniform_index_varying_point (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    point parray[3] = { point(.1,u,.3), P[0]+P[1], point(.3,.3,v) };
+    
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndex = res[0]%3;
+    point indirectP = parray[uniformIndex];
+    
+    Cout = indirectP;
+}

--- a/testsuite/array-reg/test_uniform_index_varying_ray.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_ray.osl
@@ -1,0 +1,33 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+struct ray {
+    point pos;
+    vector dir;
+};
+
+shader
+test_uniform_index_varying_ray (output color Cout = color(0,0,0))
+{
+
+    // Test array referencing with varying index
+    ray ray_array[3];
+    ray_array[0].pos = point(.1*u,.2,.3);
+    ray_array[0].dir = vector(.4,.5*P[0],.6*P[1]); 
+    ray_array[1].pos = point(.7,.8,.9);
+    ray_array[1].dir = vector(1.0*v,1.1,1.2); 
+    ray_array[2].pos = point(1.3,1.4*u,1.5);
+    ray_array[2].dir = vector(1.6,1.7,1.8*P[2]); 
+    
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndex = res[0]%3;
+    ray indirectRay = ray_array[uniformIndex];
+
+    int uniformIndex2 = (res[0]+1)%3;
+    ray indirectRay2 = ray_array[uniformIndex2];
+    
+    Cout = color(indirectRay2.pos[0]*indirectRay.dir[2], indirectRay2.pos[1]*indirectRay.dir[1], indirectRay2.pos[2]*indirectRay.dir[0]);
+}

--- a/testsuite/array-reg/test_uniform_index_varying_string.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_string.osl
@@ -1,0 +1,57 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+float power_of_2_string_to_float(string val) 
+{
+    if (val == "256") {
+        return 256/256.0;
+    }
+    if (val == "128") {
+        return 128/256.0;
+    }
+    if (val == "64") {
+        return 64/256.0;
+    }
+    if (val == "32") {
+        return 32/256.0;
+    }
+    if (val == "16") {
+        return 16/256.0;
+    }
+    if (val == "8") {
+        return 8/256.0;
+    }
+    if (val == "4") {
+        return 4/256.0;
+    }
+    if (val == "2") {
+        return 2/256.0;
+    }
+    if (val == "1") {
+        return 1/256.0;
+    }
+    return 0;
+ }
+
+shader
+test_uniform_index_varying_string (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    string rarray[3] = { "2", "256", "8" };
+    
+    if (P[0] > 0.2) {
+        rarray[1] = "4";
+    }
+    
+    
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndexR = res[0]%3;
+    
+    string indirectR = rarray[uniformIndexR];
+    
+    Cout[0] = power_of_2_string_to_float(indirectR);
+}
+

--- a/testsuite/array-reg/test_uniform_index_varying_vector.osl
+++ b/testsuite/array-reg/test_uniform_index_varying_vector.osl
@@ -1,0 +1,18 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_uniform_index_varying_vector (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    vector varray[3] = { vector(.1,u,.3), P[0]+P[1], vector(.3,.3,v) };
+    
+    // Using getattribute to obtain a uniform, but non-const index    
+    int res[2];
+    getattribute("camera:resolution", res);
+    int uniformIndex = res[0]%3;
+    vector indirectV = varray[uniformIndex];
+    
+    Cout = indirectV;
+}

--- a/testsuite/array-reg/test_varying_index_color.osl
+++ b/testsuite/array-reg/test_varying_index_color.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_color (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    color carray[3] = { color(.1,.2,.3), 0.2, color(.3,.3,.3) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    color indirectC = carray[varyingIndex];
+    
+    Cout = indirectC;    
+}

--- a/testsuite/array-reg/test_varying_index_cube.osl
+++ b/testsuite/array-reg/test_varying_index_cube.osl
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+struct cube {
+    point pos[8];
+};
+
+shader
+test_varying_index_cube (output color Cout = color(0,0,0))
+{
+
+    // Test array referencing with varying index
+    cube ca;
+    for(int i=0;i < 8; ++i) {
+        ca.pos[i] = point((.1*i)/4, (.2*i)/4 , (.3*i)/4);
+    }
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    int varyingIndex2 = int(P[0]*256)%3;
+    int varyingIndex3 = int(P[0]*256 + 128)%3;
+
+    color r = ca.pos[varyingIndex];
+    color g = ca.pos[varyingIndex2];
+    color b = ca.pos[varyingIndex3];
+    
+    Cout = color((r[0] + r[1] + r[2]), 
+                 (g[0] + g[1] + g[2]), 
+                 (b[0] + b[1] + b[2]));
+}

--- a/testsuite/array-reg/test_varying_index_float.osl
+++ b/testsuite/array-reg/test_varying_index_float.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_float (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    float rarray[3] = { 0.1, 0.2, 0.3 };
+    float garray[3] = { 0.2, 0.4, 0.6 };
+    float barray[3] = { 0.3, 0.5, 0.8 };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    float indirectR = rarray[varyingIndex];
+    float indirectG = garray[varyingIndex];
+    float indirectB = barray[varyingIndex];
+    
+    Cout = color(indirectR,indirectG,indirectB);
+}

--- a/testsuite/array-reg/test_varying_index_int.osl
+++ b/testsuite/array-reg/test_varying_index_int.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_int (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    int rarray[3] = { 1, 2, 3 };
+    int garray[3] = { 2, 4, 6 };
+    int barray[3] = { 3, 5, 8 };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    int indirectR = rarray[varyingIndex];
+    int indirectG = garray[varyingIndex];
+    int indirectB = barray[varyingIndex];
+    
+    Cout = color(indirectR/10.0,indirectG/10.0,indirectB/10.0);
+}

--- a/testsuite/array-reg/test_varying_index_matrix.osl
+++ b/testsuite/array-reg/test_varying_index_matrix.osl
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_matrix (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    float s0 = 1.0/3.0;
+    float s1 = 2.0/3.0;
+    float s2 = 1;
+    matrix marray[3] = { matrix(s0,0,0,0,
+                                0,s0,0,0,
+                                0,0,s0,0,
+                                0,0,0,1),
+                         matrix(s1,0,0,0,
+                                0,s1,0,0,
+                                0,0,s1,0,
+                                0,0,0,1),
+                         matrix(s2,0,0,0,
+                                0,s2,0,0,
+                                0,0,s2,0,
+                                0,0,0,1) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    matrix indirectM = marray[varyingIndex];
+    
+    point tp = transform(indirectM,P);
+    Cout = color(tp);    
+}

--- a/testsuite/array-reg/test_varying_index_normal.osl
+++ b/testsuite/array-reg/test_varying_index_normal.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_normal (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    normal narray[3] = { normal(.1,.2,.3), 0.2, normal(.3,.3,.3) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    normal indirectN = narray[varyingIndex];
+    
+    Cout = indirectN;    
+}

--- a/testsuite/array-reg/test_varying_index_point.osl
+++ b/testsuite/array-reg/test_varying_index_point.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_point (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    point parray[3] = { point(.1,.2,.3), 0.2, point(.3,.3,.3) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    point indirectP = parray[varyingIndex];
+    
+    Cout = indirectP;    
+}

--- a/testsuite/array-reg/test_varying_index_ray.osl
+++ b/testsuite/array-reg/test_varying_index_ray.osl
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+struct ray {
+    point pos;
+    vector dir;
+};
+
+shader
+test_varying_index_ray (output color Cout = color(0,0,0))
+{
+
+    // Test array referencing with varying index
+    ray ray_array[3];
+    ray_array[0].pos = point(.1,.2,.3);
+    ray_array[0].dir = vector(.4,.5,.6); 
+    ray_array[1].pos = point(.7,.8,.9);
+    ray_array[1].dir = vector(1.0,1.1,1.2); 
+    ray_array[2].pos = point(1.3,1.4,1.5);
+    ray_array[2].dir = vector(1.6,1.7,1.8); 
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    ray indirectRay = ray_array[varyingIndex];
+
+    int varyingIndex2 = int(P[0]*256)%3;
+    ray indirectRay2 = ray_array[varyingIndex2];
+    
+    Cout = color(indirectRay2.pos[0]*indirectRay.dir[2], indirectRay2.pos[1]*indirectRay.dir[1], indirectRay2.pos[2]*indirectRay.dir[0]);
+}

--- a/testsuite/array-reg/test_varying_index_string.osl
+++ b/testsuite/array-reg/test_varying_index_string.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_string (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    string rarray[3] = { "2", "4", "8" };
+    string garray[3] = { "16", "32", "64" };
+    string barray[3] = { "128", "256", "1" };
+    
+    int varyingIndexR = int(clamp(P[0]*3, 0, 2));
+    int varyingIndexG = int(P[0]*256)%3;
+    int varyingIndexB = int(P[0]*64)%3;
+    string indirectR = rarray[varyingIndexR];
+    string indirectG = garray[varyingIndexG];
+    string indirectB = barray[varyingIndexB];
+    
+    Cout[0] = stoi(indirectR)/256.0;
+    Cout[1] = stoi(indirectG)/256.0;
+    Cout[2] = stoi(indirectB)/256.0;
+}

--- a/testsuite/array-reg/test_varying_index_varying_color.osl
+++ b/testsuite/array-reg/test_varying_index_varying_color.osl
@@ -1,0 +1,17 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_varying_color (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    color carray[3] = { color(.1,u,.3), P[0]+P[1], color(.3,.3,v) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    color indirectC = carray[varyingIndex];
+    
+    Cout = indirectC;
+    
+    //printf ("carray[varyingIndex] = (%g)\n", indirectC);    
+}

--- a/testsuite/array-reg/test_varying_index_varying_float.osl
+++ b/testsuite/array-reg/test_varying_index_varying_float.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_varying_float (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    float rarray[3] = { 0.1*u, 0.2, 0.3 };
+    float garray[3] = { 0.2, 0.4*P[0], 0.6*P[1] };
+    float barray[3] = { 0.3, 0.5, 0.8*v };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    float indirectR = rarray[varyingIndex];
+    float indirectG = garray[varyingIndex];
+    float indirectB = barray[varyingIndex];
+    
+    Cout = color(indirectR,indirectG,indirectB);
+}

--- a/testsuite/array-reg/test_varying_index_varying_int.osl
+++ b/testsuite/array-reg/test_varying_index_varying_int.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_varying_int (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    int rarray[3] = { int(10*u), 20, 30 };
+    int garray[3] = { 20, int(40*P[0]), int(60*P[1]) };
+    int barray[3] = { 30, 50, int(80*v) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    int indirectR = rarray[varyingIndex];
+    int indirectG = garray[varyingIndex];
+    int indirectB = barray[varyingIndex];
+    
+    Cout = color(indirectR/100.0,indirectG/100.0,indirectB/100.0);
+}

--- a/testsuite/array-reg/test_varying_index_varying_matrix.osl
+++ b/testsuite/array-reg/test_varying_index_varying_matrix.osl
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_varying_matrix (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    float s0 = 1.0/3.0;
+    float s1 = 2.0/3.0;
+    float s2 = 1;
+    matrix marray[3] = { matrix(s0,0,0,0,
+                                0,s0*u,0,0,
+                                0,0,s0*v,0,
+                                0,0,0,1),
+                         matrix(s1*u,0,0,0,
+                                0,s1*v,0,0,
+                                0,0,s1,0,
+                                0,0,0,1),
+                         matrix(s2,0,0,0,
+                                0,s2,0,0,
+                                0,0,s2,0,
+                                0,0,0,1) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    matrix indirectM = marray[varyingIndex];
+    
+    point tp = transform(indirectM,P);
+    Cout = color(tp);    
+}

--- a/testsuite/array-reg/test_varying_index_varying_normal.osl
+++ b/testsuite/array-reg/test_varying_index_varying_normal.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_varying_normal (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    normal narray[3] = { normal(.1,u,.3), P[0]+P[1], normal(.3,.3,v) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    normal indirectN = narray[varyingIndex];
+    
+    Cout = indirectN;
+}

--- a/testsuite/array-reg/test_varying_index_varying_point.osl
+++ b/testsuite/array-reg/test_varying_index_varying_point.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_varying_point (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    point parray[3] = { point(.1,u,.3), P[0]+P[1], point(.3,.3,v) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    point indirectP = parray[varyingIndex];
+    
+    Cout = indirectP;
+}

--- a/testsuite/array-reg/test_varying_index_varying_ray.osl
+++ b/testsuite/array-reg/test_varying_index_varying_ray.osl
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+struct ray {
+    point pos;
+    vector dir;
+};
+
+shader
+test_varying_index_varying_ray (output color Cout = color(0,0,0))
+{
+
+    // Test array referencing with varying index
+    ray ray_array[3];
+    ray_array[0].pos = point(.1*u,.2,.3);
+    ray_array[0].dir = vector(.4,.5*P[0],.6*P[1]); 
+    ray_array[1].pos = point(.7,.8,.9);
+    ray_array[1].dir = vector(1.0*v,1.1,1.2); 
+    ray_array[2].pos = point(1.3,1.4*u,1.5);
+    ray_array[2].dir = vector(1.6,1.7,1.8*P[2]); 
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    ray indirectRay = ray_array[varyingIndex];
+
+    int varyingIndex2 = int(P[0]*256)%3;
+    ray indirectRay2 = ray_array[varyingIndex2];
+    
+    Cout = color(indirectRay2.pos[0]*indirectRay.dir[2], indirectRay2.pos[1]*indirectRay.dir[1], indirectRay2.pos[2]*indirectRay.dir[0]);
+}

--- a/testsuite/array-reg/test_varying_index_varying_string.osl
+++ b/testsuite/array-reg/test_varying_index_varying_string.osl
@@ -1,0 +1,31 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_varying_string (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    string rarray[3] = { "2", "256", "8" };
+    string garray[3] = { "64", "32", "16" };
+    string barray[3] = { "128", "256", "64" };
+   
+    if (P[1] > 0.5) {
+        rarray[1] = "4";
+        garray[0] = "16";
+        garray[2] = "64";
+        barray[2] = "1";
+    }
+    
+    
+    int varyingIndexR = int(clamp(P[0]*3, 0, 2));
+    int varyingIndexG = int(P[0]*256)%3;
+    int varyingIndexB = int(P[0]*64)%3;
+    string indirectR = rarray[varyingIndexR];
+    string indirectG = garray[varyingIndexG];
+    string indirectB = barray[varyingIndexB];
+    
+    Cout[0] = stoi(indirectR)/256.0;
+    Cout[1] = stoi(indirectG)/256.0;
+    Cout[2] = stoi(indirectB)/256.0;
+}

--- a/testsuite/array-reg/test_varying_index_varying_vector.osl
+++ b/testsuite/array-reg/test_varying_index_varying_vector.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_varying_vector (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    vector varray[3] = { vector(.1,u,.3), P[0]+P[1], vector(.3,.3,v) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    vector indirectV = varray[varyingIndex];
+    
+    Cout = indirectV;
+}

--- a/testsuite/array-reg/test_varying_index_vector.osl
+++ b/testsuite/array-reg/test_varying_index_vector.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_index_vector (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    vector varray[3] = { vector(.1,.2,.3), 0.2, vector(.3,.3,.3) };
+    
+    int varyingIndex = int(clamp(P[0]*3, 0, 2));
+    vector indirectV = varray[varyingIndex];
+    
+    Cout = indirectV;    
+}

--- a/testsuite/array-reg/test_varying_out_of_bounds_index_float.osl
+++ b/testsuite/array-reg/test_varying_out_of_bounds_index_float.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_out_of_bounds_index_float (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    float rarray[3] = { 0.1, 0.2, 0.3 };
+    float garray[3] = { 0.2, 0.4, 0.6 };
+    float barray[3] = { 0.3, 0.5, 0.8 };
+    
+    // out of bounds, should segfault if accessed accidentally
+    int varyingIndex = 2000000000;
+
+    float indirectR = 1;
+    float indirectG = 1;
+    float indirectB = 1;
+    
+    if (int(P[0]*256)%2 == 0) {
+        varyingIndex = int(clamp(P[0]*3, 0, 2));
+    
+        indirectR = rarray[varyingIndex];
+        indirectG = garray[varyingIndex];
+        indirectB = barray[varyingIndex];
+    }
+    
+    Cout = color(indirectR,indirectG,float(varyingIndex));
+}

--- a/testsuite/array-reg/test_varying_out_of_bounds_index_int.osl
+++ b/testsuite/array-reg/test_varying_out_of_bounds_index_int.osl
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_out_of_bounds_index_int (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    int rarray[3] = { 1, 2, 3 };
+    int garray[3] = { 2, 4, 6 };
+    int barray[3] = { 3, 5, 8 };
+    
+    
+    // out of bounds, should segfault if accessed accidentally
+    int varyingIndex = 2000000000;
+
+    int indirectR = 1;
+    int indirectG = 1;
+    int indirectB = 1;
+    
+    if (int(P[0]*256)%2 == 0) {
+        varyingIndex = int(clamp(P[0]*3, 0, 2));
+    
+        indirectR = rarray[varyingIndex];
+        indirectG = garray[varyingIndex];
+        indirectB = barray[varyingIndex];
+    }
+    
+    Cout = color(indirectR/10.0,indirectG/10.0,float(varyingIndex));
+}

--- a/testsuite/array-reg/test_varying_out_of_bounds_index_string.osl
+++ b/testsuite/array-reg/test_varying_out_of_bounds_index_string.osl
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_varying_out_of_bounds_index_string (output color Cout = color(0,0,0))
+{
+    // Test array referencing with varying index
+    string rarray[3] = { "1", "2", "3" };
+    string garray[3] = { "2", "4", "6" };
+    
+    
+    // out of bounds, should segfault if accessed accidentally
+    int varyingIndex = 2000000000;
+
+    string indirectR = "1";
+    string indirectG = "1";
+    string indirectB = "1";
+    
+    if (int(P[0]*256)%2 == 0) {
+        varyingIndex = int(clamp(P[0]*3, 0, 2));
+    
+        indirectR = rarray[varyingIndex];
+        indirectG = garray[varyingIndex];
+    }
+    
+    Cout = color(stoi(indirectR)/10.0,stoi(indirectG)/10.0,float(varyingIndex)/3.0);
+}

--- a/testsuite/matrix-arithmetic-reg/run.py
+++ b/testsuite/matrix-arithmetic-reg/run.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+# multiply float and matrix
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_float_mul_u_matrix.tif test_u_float_mul_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_float_mul_v_matrix.tif test_u_float_mul_v_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_float_mul_u_matrix.tif test_v_float_mul_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_float_mul_v_matrix.tif test_v_float_mul_v_matrix")
+outputs.append ("out_u_float_mul_u_matrix.tif")
+outputs.append ("out_u_float_mul_v_matrix.tif")
+outputs.append ("out_v_float_mul_u_matrix.tif")
+outputs.append ("out_v_float_mul_v_matrix.tif")
+
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_float_mul_u_matrix_masked.tif test_u_float_mul_u_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_float_mul_v_matrix_masked.tif test_u_float_mul_v_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_float_mul_u_matrix_masked.tif test_v_float_mul_u_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_float_mul_v_matrix_masked.tif test_v_float_mul_v_matrix_masked")
+outputs.append ("out_u_float_mul_u_matrix_masked.tif")
+outputs.append ("out_u_float_mul_v_matrix_masked.tif")
+outputs.append ("out_v_float_mul_u_matrix_masked.tif")
+outputs.append ("out_v_float_mul_v_matrix_masked.tif")
+
+# multiply matrix and float 
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_mul_u_float.tif test_u_matrix_mul_u_float")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_mul_v_float.tif test_u_matrix_mul_v_float")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_u_float.tif test_v_matrix_mul_u_float")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_v_float.tif test_v_matrix_mul_v_float")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_v_int.tif test_v_matrix_mul_v_int")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_v_conditional.tif test_v_matrix_mul_v_conditional")
+outputs.append ("out_u_matrix_mul_u_float.tif")
+outputs.append ("out_u_matrix_mul_v_float.tif")
+outputs.append ("out_v_matrix_mul_u_float.tif")
+outputs.append ("out_v_matrix_mul_v_float.tif")
+outputs.append ("out_v_matrix_mul_v_int.tif")
+outputs.append ("out_v_matrix_mul_v_conditional.tif")
+
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_mul_u_float_masked.tif test_u_matrix_mul_u_float_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_mul_v_float_masked.tif test_u_matrix_mul_v_float_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_u_float_masked.tif test_v_matrix_mul_u_float_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_v_float_masked.tif test_v_matrix_mul_v_float_masked")
+outputs.append ("out_u_matrix_mul_u_float_masked.tif")
+outputs.append ("out_u_matrix_mul_v_float_masked.tif")
+outputs.append ("out_v_matrix_mul_u_float_masked.tif")
+outputs.append ("out_v_matrix_mul_v_float_masked.tif")
+
+
+# multiply matrix and matrix 
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_mul_u_matrix.tif test_u_matrix_mul_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_mul_v_matrix.tif test_u_matrix_mul_v_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_u_matrix.tif test_v_matrix_mul_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_v_matrix.tif test_v_matrix_mul_v_matrix")
+outputs.append ("out_u_matrix_mul_u_matrix.tif")
+outputs.append ("out_u_matrix_mul_v_matrix.tif")
+outputs.append ("out_v_matrix_mul_u_matrix.tif")
+outputs.append ("out_v_matrix_mul_v_matrix.tif")
+
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_mul_u_matrix_masked.tif test_u_matrix_mul_u_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_mul_v_matrix_masked.tif test_u_matrix_mul_v_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_u_matrix_masked.tif test_v_matrix_mul_u_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_mul_v_matrix_masked.tif test_v_matrix_mul_v_matrix_masked")
+outputs.append ("out_u_matrix_mul_u_matrix_masked.tif")
+outputs.append ("out_u_matrix_mul_v_matrix_masked.tif")
+outputs.append ("out_v_matrix_mul_u_matrix_masked.tif")
+outputs.append ("out_v_matrix_mul_v_matrix_masked.tif")
+
+
+# divide float by matrix
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_float_div_u_matrix.tif test_u_float_div_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_float_div_v_matrix.tif test_u_float_div_v_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_float_div_u_matrix.tif test_v_float_div_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_float_div_v_matrix.tif test_v_float_div_v_matrix")
+outputs.append ("out_u_float_div_u_matrix.tif")
+outputs.append ("out_u_float_div_v_matrix.tif")
+outputs.append ("out_v_float_div_u_matrix.tif")
+outputs.append ("out_v_float_div_v_matrix.tif")
+
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_float_div_u_matrix_masked.tif test_u_float_div_u_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_float_div_v_matrix_masked.tif test_u_float_div_v_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_float_div_u_matrix_masked.tif test_v_float_div_u_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_float_div_v_matrix_masked.tif test_v_float_div_v_matrix_masked")
+outputs.append ("out_u_float_div_u_matrix_masked.tif")
+outputs.append ("out_u_float_div_v_matrix_masked.tif")
+outputs.append ("out_v_float_div_u_matrix_masked.tif")
+outputs.append ("out_v_float_div_v_matrix_masked.tif")
+
+# divide matrix by float 
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_div_u_float.tif test_u_matrix_div_u_float")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_div_v_float.tif test_u_matrix_div_v_float")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_div_u_float.tif test_v_matrix_div_u_float")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_div_v_float.tif test_v_matrix_div_v_float")
+outputs.append ("out_u_matrix_div_u_float.tif")
+outputs.append ("out_u_matrix_div_v_float.tif")
+outputs.append ("out_v_matrix_div_u_float.tif")
+outputs.append ("out_v_matrix_div_v_float.tif")
+
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_div_u_float_masked.tif test_u_matrix_div_u_float_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_div_v_float_masked.tif test_u_matrix_div_v_float_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_div_u_float_masked.tif test_v_matrix_div_u_float_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_div_v_float_masked.tif test_v_matrix_div_v_float_masked")
+outputs.append ("out_u_matrix_div_u_float_masked.tif")
+outputs.append ("out_u_matrix_div_v_float_masked.tif")
+outputs.append ("out_v_matrix_div_u_float_masked.tif")
+outputs.append ("out_v_matrix_div_v_float_masked.tif")
+
+# divide matrix by matrix 
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_div_u_matrix.tif test_u_matrix_div_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_div_v_matrix.tif test_u_matrix_div_v_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_div_u_matrix.tif test_v_matrix_div_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_div_v_matrix.tif test_v_matrix_div_v_matrix")
+outputs.append ("out_u_matrix_div_u_matrix.tif")
+outputs.append ("out_u_matrix_div_v_matrix.tif")
+outputs.append ("out_v_matrix_div_u_matrix.tif")
+outputs.append ("out_v_matrix_div_v_matrix.tif")
+
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_div_u_matrix_masked.tif test_u_matrix_div_u_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_u_matrix_div_v_matrix_masked.tif test_u_matrix_div_v_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_div_u_matrix_masked.tif test_v_matrix_div_u_matrix_masked")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_v_matrix_div_v_matrix_masked.tif test_v_matrix_div_v_matrix_masked")
+outputs.append ("out_u_matrix_div_u_matrix_masked.tif")
+outputs.append ("out_u_matrix_div_v_matrix_masked.tif")
+outputs.append ("out_v_matrix_div_u_matrix_masked.tif")
+outputs.append ("out_v_matrix_div_v_matrix_masked.tif")
+
+
+# negate matrix
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_neg_u_matrix.tif test_neg_u_matrix")
+command += testshade("-t 1 -g 64 64 -od uint8 -o Cout out_neg_v_matrix.tif test_neg_v_matrix")
+outputs.append ("out_neg_u_matrix.tif")
+outputs.append ("out_neg_v_matrix.tif")
+
+
+# expect a few LSB failures
+failthresh = 0.008
+failpercent = 3
+

--- a/testsuite/matrix-arithmetic-reg/test_neg_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_neg_u_matrix.osl
@@ -1,0 +1,32 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_neg_u_matrix (output color Cout = 0)
+{
+    int u_val = raytype("camera");
+    matrix  val = matrix(
+        -0.8*u_val, -0.5*u_val, -0.25*u_val, -0.1*u_val,
+        -0.2*u_val, -0.4*u_val, -0.65*u_val, -0.9*u_val,
+        -0.7*u_val, -0.85*u_val, -0.55*u_val, -0.85*u_val,
+        -0.33*u_val, -0.66*u_val, -0.77*u_val, -1.0*u_val
+    );
+    matrix  val2 = matrix(
+        -0.7*u_val, -0.85*u_val, -0.55*u_val, -0.85*u_val,
+        -0.2*u_val, -0.4*u_val, -0.65*u_val, -0.9*u_val,
+        -0.8*u_val, -0.5*u_val, -0.25*u_val, -0.1*u_val,
+        -0.77*u_val, -0.33*u_val, -0.66*u_val, -1.0*u_val
+    );
+    matrix d = -val;
+    if (int(P[0]*64)%2==0) {
+        d = -val2;
+    }
+    d*=0.1;
+    
+    Cout = color(
+        d[0][0] + d[0][1] + d[0][2] + d[0][3],
+        d[1][0] + d[1][1] + d[1][2] + d[1][3],
+        d[2][0] + d[2][1] + d[2][2] + d[2][3] +
+        d[3][0] + d[3][1] + d[3][2] + d[3][3]);         
+}

--- a/testsuite/matrix-arithmetic-reg/test_neg_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_neg_v_matrix.osl
@@ -1,0 +1,33 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_neg_v_matrix (output color Cout = 0)
+{
+    float v_val = P[0];
+    matrix  val = matrix(
+        -0.8*v_val, -0.5*v_val, -0.25*v_val, -0.1*v_val,
+        -0.2*v_val, -0.4*v_val, -0.65*v_val, -0.9*v_val,
+        -0.7*v_val, -0.85*v_val, -0.55*v_val, -0.85*v_val,
+        -0.33*v_val, -0.66*v_val, -0.77*v_val, -1.0*v_val
+    );
+    float v_val2 = P[1];
+    matrix  val2 = matrix(
+        -0.7*v_val2, -0.85*v_val2, -0.55*v_val2, -0.85*v_val2,
+        -0.2*v_val2, -0.4*v_val2, -0.65*v_val2, -0.9*v_val2,
+        -0.8*v_val2, -0.5*v_val2, -0.25*v_val2, -0.1*v_val2,
+        -0.77*v_val2, -0.33*v_val2, -0.66*v_val2, -1.0*v_val2
+    );
+    matrix d = -val;
+    if (int(P[0]*64)%2==0) {
+        d = -val2;
+    }
+    d*=0.5;
+    
+    Cout = color(
+        d[0][0] + d[0][1] + d[0][2] + d[0][3],
+        d[1][0] + d[1][1] + d[1][2] + d[1][3],
+        d[2][0] + d[2][1] + d[2][2] + d[2][3] +
+        d[3][0] + d[3][1] + d[3][2] + d[3][3]);         
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_float_div_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_float_div_u_matrix.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_float_div_u_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float numerator = 1.0/3.0;
+    matrix rm = numerator/m1;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_float_div_u_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_float_div_u_matrix_masked.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_float_div_u_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float numerator = 1.0/3.0;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = numerator/m1;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_float_div_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_float_div_v_matrix.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_float_div_v_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float numerator = 1.0/3.0;
+    matrix rm = numerator/m1;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_float_div_v_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_float_div_v_matrix_masked.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_float_div_v_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float numerator = 1.0/3.0;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = numerator/m1;
+    }
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_float_mul_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_float_mul_u_matrix.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_float_mul_u_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float numerator = 1.0/3.0;
+    matrix rm = numerator*m1;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_float_mul_u_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_float_mul_u_matrix_masked.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_float_mul_u_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float numerator = 1.0/3.0;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = numerator*m1;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_float_mul_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_float_mul_v_matrix.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_float_mul_v_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float numerator = 1.0/3.0;
+    matrix rm = numerator*m1;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_float_mul_v_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_float_mul_v_matrix_masked.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_float_mul_v_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float numerator = 1.0/3.0;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = numerator*m1;
+    }
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_div_u_float.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_div_u_float.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_div_u_float (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    matrix rm = m1/2;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_div_u_float_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_div_u_float_masked.osl
@@ -1,0 +1,18 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_div_u_float_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1/2;
+    }
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_div_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_div_u_matrix.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_div_u_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+
+    matrix m2 = matrix(2,0,0,0,
+                       0,2,0,0,
+                       0,0,2,0,
+                       0,0,0,1);
+              
+    matrix rm = m1/m2;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_div_u_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_div_u_matrix_masked.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_div_u_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+
+    matrix divisor = matrix(2,0,0,0,
+                       0,2,0,0,
+                       0,0,2,0,
+                       0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1/divisor;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_div_v_float.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_div_v_float.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_div_v_float (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float divisor = 1 + u;
+    matrix rm = m1/divisor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_div_v_float_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_div_v_float_masked.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_div_v_float_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    
+    float divisor = 1 + u;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1/divisor;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_div_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_div_v_matrix.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_div_v_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    matrix divisor = matrix(
+        1+u,0,0,0,
+        0,2+v,0,0,
+        0,0,6,0,
+        0,0,0,1);
+              
+    matrix rm = m1/divisor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_div_v_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_div_v_matrix_masked.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_div_v_matrix_masked(output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    matrix divisor = matrix(
+        1+u,0,0,0,
+        0,2+v,0,0,
+        0,0,6,0,
+        0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1/divisor;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_u_float.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_u_float.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_mul_u_float (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    matrix rm = m1*0.5;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_u_float_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_u_float_masked.osl
@@ -1,0 +1,18 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_mul_u_float_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1*0.5;
+    }
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_u_matrix.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_mul_u_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+
+    matrix m2 = matrix(0.5,0,0,0,
+                       0,0.5,0,0,
+                       0,0,0.5,0,
+                       0,0,0,1);
+              
+    matrix rm = m1*m2;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_u_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_u_matrix_masked.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_mul_u_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+
+    matrix factor = matrix(0.5,0,0,0,
+                       0,0.5,0,0,
+                       0,0,0.5,0,
+                       0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1*factor;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_v_float.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_v_float.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_mul_v_float (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float factor = u;
+    matrix rm = m1*factor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_v_float_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_v_float_masked.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_mul_v_float_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    
+    float factor = u;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1*factor;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_v_matrix.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_mul_v_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    matrix factor = matrix(
+        1/(1+u),0,0,0,
+        0,1/(2+v),0,0,
+        0,0,6,0,
+        0,0,0,1);
+              
+    matrix rm = m1*factor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_v_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_u_matrix_mul_v_matrix_masked.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_u_matrix_mul_v_matrix_masked(output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    matrix factor = matrix(
+        1/(1+u),0,0,0,
+        0,1/(2+v),0,0,
+        0,0,6,0,
+        0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1*factor;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_float_div_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_float_div_u_matrix.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_float_div_u_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float numerator = 1 - u;
+    matrix rm = numerator/m1;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_float_div_u_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_float_div_u_matrix_masked.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_float_div_u_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float numerator = 1 - u;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = numerator/m1;
+    }
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_float_div_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_float_div_v_matrix.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_float_div_v_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float numerator = 1 - u;              
+    matrix rm = numerator/m1;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_float_div_v_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_float_div_v_matrix_masked.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_float_div_v_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float numerator = 1 - u;              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = numerator/m1;
+    }
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_float_mul_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_float_mul_u_matrix.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_float_mul_u_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float numerator = 1 - u;
+    matrix rm = numerator*m1;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_float_mul_u_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_float_mul_u_matrix_masked.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_float_mul_u_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(raytype("camera"),0,0,0,
+                       0,2*raytype("camera"),0,0,
+                       0,0,3*raytype("camera"),0,
+                       0,0,0,1);
+              
+    float numerator = 1 - u;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = numerator*m1;
+    }
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_float_mul_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_float_mul_v_matrix.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_float_mul_v_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float numerator = 1 - u;              
+    matrix rm = numerator*m1;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_float_mul_v_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_float_mul_v_matrix_masked.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_float_mul_v_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float numerator = 1 - u;              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = numerator*m1;
+    }
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_div_u_float.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_div_u_float.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_div_u_float (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix rm = m1/2;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_div_u_float_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_div_u_float_masked.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_div_u_float_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1/2;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_div_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_div_u_matrix.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_div_u_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix divisor = matrix(2,0,0,0,
+                       0,2,0,0,
+                       0,0,2,0,
+                       0,0,0,1);
+              
+    matrix rm = m1/divisor;
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_div_u_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_div_u_matrix_masked.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_div_u_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix divisor = matrix(2,0,0,0,
+                       0,2,0,0,
+                       0,0,2,0,
+                       0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1/divisor;
+    }    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_div_v_float.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_div_v_float.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_div_v_float (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float divisor = 1 + u;              
+    matrix rm = m1/divisor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_div_v_float_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_div_v_float_masked.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_div_v_float_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float divisor = 1 + u;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1/divisor;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_div_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_div_v_matrix.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_div_v_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix divisor = matrix(v,0,0,0,
+              0,u,0,0,
+              0,0,2,0,
+              0,0,0,1);
+              
+    matrix rm = m1/divisor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_div_v_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_div_v_matrix_masked.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_div_v_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix divisor = matrix(v,0,0,0,
+              0,u,0,0,
+              0,0,2,0,
+              0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1/divisor;
+    }    
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_u_float.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_u_float.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_u_float (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix rm = m1*0.5;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_u_float_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_u_float_masked.osl
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_u_float_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1*0.5;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_u_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_u_matrix.osl
@@ -1,0 +1,17 @@
+shader
+test_v_matrix_mul_u_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix factor = matrix(0.5,0,0,0,
+                       0,0.5,0,0,
+                       0,0,0.5,0,
+                       0,0,0,1);
+              
+    matrix rm = m1*factor;
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_u_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_u_matrix_masked.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_u_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix factor = matrix(0.5,0,0,0,
+                       0,0.5,0,0,
+                       0,0,0.5,0,
+                       0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1*factor;
+    }    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_conditional.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_conditional.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_v_conditional (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    int factor = (P[0] > 0.25);              
+    matrix rm = m1*float(factor);
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_float.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_float.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_v_float (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float factor = u;              
+    matrix rm = m1*factor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_float_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_float_masked.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_v_float_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    float factor = u;
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1*factor;
+    }
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_int.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_int.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_v_int (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    int factor = int(u*10);              
+    matrix rm = m1*factor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_matrix.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_matrix.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_v_matrix (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix factor = matrix(v,0,0,0,
+              0,u,0,0,
+              0,0,0.5,0,
+              0,0,0,1);
+              
+    matrix rm = m1*factor;
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_matrix_masked.osl
+++ b/testsuite/matrix-arithmetic-reg/test_v_matrix_mul_v_matrix_masked.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_v_matrix_mul_v_matrix_masked (output color Cout = 0)
+{
+    matrix m1 = matrix(u,0,0,0,
+              0,v,0,0,
+              0,0,1,0,
+              0,0,0,1);
+              
+    matrix factor = matrix(v,0,0,0,
+              0,u,0,0,
+              0,0,0.5,0,
+              0,0,0,1);
+              
+    matrix rm = m1;              
+    if (int(P[0]*64)%2==0) {
+        rm = m1*factor;
+    }    
+    
+    Cout = color(rm[0][0],rm[1][1],rm[2][2]);
+}

--- a/testsuite/matrix-compref-reg/run.py
+++ b/testsuite/matrix-compref-reg/run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_compref_u_matrix_const_index.tif test_compref_u_matrix_const_index")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_compref_v_matrix_const_index.tif test_compref_v_matrix_const_index")
+outputs.append ("out_compref_u_matrix_const_index.tif")
+outputs.append ("out_compref_v_matrix_const_index.tif")
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_compref_u_matrix_u_index.tif test_compref_u_matrix_u_index")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_compref_v_matrix_u_index.tif test_compref_v_matrix_u_index")
+outputs.append ("out_compref_u_matrix_u_index.tif")
+outputs.append ("out_compref_v_matrix_u_index.tif")
+
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_compref_u_matrix_v_index.tif test_compref_u_matrix_v_index")
+command += testshade("-t 1 -g 256 256 -od uint8 -o Cout out_compref_v_matrix_v_index.tif test_compref_v_matrix_v_index")
+outputs.append ("out_compref_u_matrix_v_index.tif")
+outputs.append ("out_compref_v_matrix_v_index.tif")
+
+# expect a few LSB failures
+failthresh = 0.008
+failpercent = 3
+

--- a/testsuite/matrix-compref-reg/test_compref_u_matrix_const_index.osl
+++ b/testsuite/matrix-compref-reg/test_compref_u_matrix_const_index.osl
@@ -1,0 +1,39 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_compref_u_matrix_const_index (output color Cout = 0)
+{
+    float uval = raytype("camera");
+    matrix m = matrix(
+        0.011*uval, 0.012*uval, 0.013*uval, 0.014*uval,
+        0.021*uval, 0.022*uval, 0.023*uval, 0.024*uval,
+        0.031*uval, 0.032*uval, 0.033*uval, 0.034*uval,
+        0.041*uval, 0.042*uval, 0.043*uval, 0.044*uval
+        );
+    
+    matrix m2  = matrix(
+        m[0][3], m[1][3], m[2][3], m[3][3],
+        m[0][2], m[1][2], m[2][2], m[3][2], 
+        m[0][1], m[1][1], m[2][1], m[3][1],
+        m[0][0], m[1][0], m[2][0], m[3][0]
+    );
+
+    color c =  color(
+        m[0][0] + m[1][0] + m[2][0] + m[3][0],
+        m[0][1] + m[1][1] + m[2][1] + m[3][1],
+        m[0][2] + m[1][2] + m[2][2] + m[3][2] +
+        m[0][3] + m[1][3] + m[2][3] + m[3][3]
+    );
+    if (int(P[0]*64)%2==0) {
+        c =  color(
+            m2[0][0] + m2[1][0] + m2[2][0] + m2[3][0],
+            m2[0][1] + m2[1][1] + m2[2][1] + m2[3][1],
+            m2[0][2] + m2[1][2] + m2[2][2] + m2[3][2] +
+            m2[0][3] + m2[1][3] + m2[2][3] + m2[3][3]
+        );
+    }
+    
+    Cout = c;
+}

--- a/testsuite/matrix-compref-reg/test_compref_u_matrix_u_index.osl
+++ b/testsuite/matrix-compref-reg/test_compref_u_matrix_u_index.osl
@@ -1,0 +1,49 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_compref_u_matrix_u_index (output color Cout = 0)
+{
+    float uval = raytype("camera");
+    matrix m = matrix(
+        0.011*uval, 0.012*uval, 0.013*uval, 0.014*uval,
+        0.021*uval, 0.022*uval, 0.023*uval, 0.024*uval,
+        0.031*uval, 0.032*uval, 0.033*uval, 0.034*uval,
+        0.041*uval, 0.042*uval, 0.043*uval, 0.044*uval
+        );
+    
+    matrix m2; 
+    
+    for(int i=0; i < 4;++i) {
+        for(int j=0; j < 4;++j) {
+            m2[i][j] = m[j][i];
+        }
+    }
+
+    color c = color(0);
+    for(int i=0; i < 4;++i) 
+    {
+        for(int j=0; j < 4;++j) 
+        {
+            int cIndex = min(i,2);
+            c[cIndex] += m[i][j];
+        }
+    }
+    
+    if (int(P[0]*64)%2==0) 
+    {
+        c = color(0);
+        
+        for(int i=0; i < 4;++i) 
+        {
+            for(int j=0; j < 4;++j) 
+            {
+                int cIndex = min(i,2);
+                c[cIndex] += m2[i][j];
+            }
+        }
+    }
+    
+    Cout = c;
+}

--- a/testsuite/matrix-compref-reg/test_compref_u_matrix_v_index.osl
+++ b/testsuite/matrix-compref-reg/test_compref_u_matrix_v_index.osl
@@ -1,0 +1,45 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_compref_u_matrix_v_index (output color Cout = 0)
+{
+    float uval = raytype("camera");
+    matrix m = matrix(
+        0.011*uval, 0.012*uval, 0.013*uval, 0.014*uval,
+        0.021*uval, 0.022*uval, 0.023*uval, 0.024*uval,
+        0.031*uval, 0.032*uval, 0.033*uval, 0.034*uval,
+        0.041*uval, 0.042*uval, 0.043*uval, 0.044*uval
+        );
+    
+    matrix m2 = matrix(0);
+    for(int i=0; i < 4;++i) {
+        int v_i = min(3,int(u+i));
+        for(int j=0; j < 4;++j) {
+            int v_j = min(3,int(j+i));
+            m2[v_i][v_j] = m[v_j][v_i];
+        }
+    }
+
+    color c = color(0);
+    for(int i=0; i < 4;++i) {
+        for(int j=0; j < 4;++j) {
+            int cIndex = min(i,2);
+            c[cIndex] += m[i][j];
+        }
+    }
+    if (int(P[0]*64)%2==0) {
+        c = color(0);
+        for(int i=0; i < 4;++i) {
+            int v_i = int(u*256)%4;
+            for(int j=0; j < 4;++j) {
+                int v_j = int(v*256)%4;
+                int cIndex = min(i,2);
+                c[cIndex] += m2[v_i][v_j];
+            }
+        }
+    }
+    
+    Cout = c;
+}

--- a/testsuite/matrix-compref-reg/test_compref_v_matrix_const_index.osl
+++ b/testsuite/matrix-compref-reg/test_compref_v_matrix_const_index.osl
@@ -1,0 +1,39 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_compref_v_matrix_const_index (output color Cout = 0)
+{
+    float v_val = P[0];
+    matrix m = matrix(
+        0.11*v_val, 0.12*v_val, 0.13*v_val, 0.14*v_val,
+        0.21*v_val, 0.22*v_val, 0.23*v_val, 0.24*v_val,
+        0.31*v_val, 0.32*v_val, 0.33*v_val, 0.34*v_val,
+        0.41*v_val, 0.42*v_val, 0.43*v_val, 0.44*v_val
+        );
+    
+    matrix m2  = matrix(
+        m[0][3], m[1][3], m[2][3], m[3][3],
+        m[0][2], m[1][2], m[2][2], m[3][2], 
+        m[0][1], m[1][1], m[2][1], m[3][1],
+        m[0][0], m[1][0], m[2][0], m[3][0]
+    );
+
+    color c =  color(
+        m[0][0] + m[1][0] + m[2][0] + m[3][0],
+        m[0][1] + m[1][1] + m[2][1] + m[3][1],
+        m[0][2] + m[1][2] + m[2][2] + m[3][2] +
+        m[0][3] + m[1][3] + m[2][3] + m[3][3]
+    );
+    if (int(P[0]*64)%2==0) {
+        c =  color(
+            m2[0][0] + m2[1][0] + m2[2][0] + m2[3][0],
+            m2[0][1] + m2[1][1] + m2[2][1] + m2[3][1],
+            m2[0][2] + m2[1][2] + m2[2][2] + m2[3][2] +
+            m2[0][3] + m2[1][3] + m2[2][3] + m2[3][3]
+        );
+    }
+    
+    Cout = c;
+}

--- a/testsuite/matrix-compref-reg/test_compref_v_matrix_u_index.osl
+++ b/testsuite/matrix-compref-reg/test_compref_v_matrix_u_index.osl
@@ -1,0 +1,49 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_compref_v_matrix_u_index (output color Cout = 0)
+{
+    float v_val = P[0];
+    matrix m = matrix(
+        0.11*v_val, 0.12*v_val, 0.13*v_val, 0.14*v_val,
+        0.21*v_val, 0.22*v_val, 0.23*v_val, 0.24*v_val,
+        0.31*v_val, 0.32*v_val, 0.33*v_val, 0.34*v_val,
+        0.41*v_val, 0.42*v_val, 0.43*v_val, 0.44*v_val
+        );
+    
+    matrix m2; 
+    
+    for(int i=0; i < 4;++i) {
+        for(int j=0; j < 4;++j) {
+            m2[i][j] = m[j][i];
+        }
+    }
+
+    color c = color(0);
+    for(int i=0; i < 4;++i) 
+    {
+        for(int j=0; j < 4;++j) 
+        {
+            int cIndex = min(i,2);
+            c[cIndex] += m[i][j];
+        }
+    }
+    
+    if (int(P[0]*64)%2==0) 
+    {
+        c = color(0);
+        
+        for(int i=0; i < 4;++i) 
+        {
+            for(int j=0; j < 4;++j) 
+            {
+                int cIndex = min(i,2);
+                c[cIndex] += m2[i][j];
+            }
+        }
+    }
+    
+    Cout = c;
+}

--- a/testsuite/matrix-compref-reg/test_compref_v_matrix_v_index.osl
+++ b/testsuite/matrix-compref-reg/test_compref_v_matrix_v_index.osl
@@ -1,0 +1,45 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_compref_v_matrix_v_index (output color Cout = 0)
+{
+    float v_val = P[0];
+    matrix m = matrix(
+        0.11*v_val, 0.12*v_val, 0.13*v_val, 0.14*v_val,
+        0.21*v_val, 0.22*v_val, 0.23*v_val, 0.24*v_val,
+        0.31*v_val, 0.32*v_val, 0.33*v_val, 0.34*v_val,
+        0.41*v_val, 0.42*v_val, 0.43*v_val, 0.44*v_val
+        );
+    
+    matrix m2 = matrix(0);
+    for(int i=0; i < 4;++i) {
+        int v_i = min(3,int(u+i));
+        for(int j=0; j < 4;++j) {
+          int v_j = min(3,int(v+j));
+            m2[v_i][v_j] = m[v_j][v_i];
+        }
+    }
+
+    color c = color(0);
+    for(int i=0; i < 4;++i) {
+        for(int j=0; j < 4;++j) {
+            int cIndex = min(i,2);
+            c[cIndex] += m[i][j];
+        }
+    }
+    if (int(P[0]*64)%2==0) {
+        c = color(0);
+        for(int i=0; i < 4;++i) {
+            int v_i = int(u*256)%4;
+            for(int j=0; j < 4;++j) {
+                int v_j = int(v*256)%4;
+                int cIndex = min(i,2);
+                c[cIndex] += m2[v_i][v_j];
+            }
+        }
+    }
+    
+    Cout = c;
+}

--- a/testsuite/matrix-reg/run.py
+++ b/testsuite/matrix-reg/run.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_u_determinant.tif test_matrix_u_determinant")
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_v_determinant.tif test_matrix_v_determinant")
+outputs.append ("out_matrix_u_determinant.tif")
+outputs.append ("out_matrix_v_determinant.tif")
+
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_u_transpose.tif test_matrix_u_transpose")
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_v_transpose.tif test_matrix_v_transpose")
+outputs.append ("out_matrix_u_transpose.tif")
+outputs.append ("out_matrix_v_transpose.tif")
+
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_16x_u_float.tif test_matrix_16x_u_float")
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_16x_v_float.tif test_matrix_16x_v_float")
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_u_float.tif test_matrix_u_float")
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_v_float.tif test_matrix_v_float")
+outputs.append ("out_matrix_16x_u_float.tif")
+outputs.append ("out_matrix_16x_v_float.tif")
+outputs.append ("out_matrix_u_float.tif")
+outputs.append ("out_matrix_v_float.tif")
+
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_v_fromspace_16x_u_float.tif test_matrix_v_fromspace_16x_u_float")
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_v_fromspace_16x_v_float.tif test_matrix_v_fromspace_16x_v_float")
+outputs.append ("out_matrix_v_fromspace_16x_u_float.tif")
+outputs.append ("out_matrix_v_fromspace_16x_v_float.tif")
+
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_v_fromspace_u_float.tif test_matrix_v_fromspace_u_float")
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_v_fromspace_v_float.tif test_matrix_v_fromspace_v_float")
+outputs.append ("out_matrix_v_fromspace_u_float.tif")
+outputs.append ("out_matrix_v_fromspace_v_float.tif")
+
+
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_matrix_v_fromspace_v_tospace.tif test_matrix_v_fromspace_v_tospace")
+outputs.append ("out_matrix_v_fromspace_v_tospace.tif")
+
+
+def run_space_tests (space) :
+    global command
+    global outputs     
+    
+    command += testshade("-t 1 -g 32 32 -param fromspace "+space+" -od uint8 -o Cout out_matrix_"+space+"_fromspace_u_float.tif test_matrix_u_fromspace_u_float")
+    command += testshade("-t 1 -g 32 32 -param fromspace "+space+" -od uint8 -o Cout out_matrix_"+space+"_fromspace_v_float.tif test_matrix_u_fromspace_v_float")
+    command += testshade("-t 1 -g 32 32 -param fromspace "+space+" -od uint8 -o Cout out_matrix_"+space+"_fromspace_16x_u_float.tif test_matrix_u_fromspace_16x_u_float")
+    command += testshade("-t 1 -g 32 32 -param fromspace "+space+" -od uint8 -o Cout out_matrix_"+space+"_fromspace_16x_v_float.tif test_matrix_u_fromspace_16x_v_float")    
+    outputs.append ("out_matrix_"+space+"_fromspace_u_float.tif")
+    outputs.append ("out_matrix_"+space+"_fromspace_v_float.tif")
+    outputs.append ("out_matrix_"+space+"_fromspace_16x_u_float.tif")
+    outputs.append ("out_matrix_"+space+"_fromspace_16x_v_float.tif")
+    
+    command += testshade("-t 1 -g 32 32 -param tospace "+space+" -od uint8 -o Cout out_matrix_v_fromspace_"+space+"_tospace.tif test_matrix_v_fromspace_u_tospace")
+    command += testshade("-t 1 -g 32 32 -param fromspace "+space+" -od uint8 -o Cout out_matrix_"+space+"_fromspace_v_tospace.tif test_matrix_u_fromspace_v_tospace")    
+    outputs.append ("out_matrix_v_fromspace_"+space+"_tospace.tif")
+    outputs.append ("out_matrix_"+space+"_fromspace_v_tospace.tif")
+    
+    command += testshade("-t 1 -g 32 32 -param fromspace "+space+" -od uint8 -o Cout out_getmatrix_"+space+"_fromspace_v_tospace.tif test_getmatrix_u_fromspace_v_tospace")
+    command += testshade("-t 1 -g 32 32 -param tospace "+space+" -od uint8 -o Cout out_getmatrix_v_fromspace_"+space+"_tospace.tif test_getmatrix_v_fromspace_u_tospace")
+    outputs.append ("out_getmatrix_"+space+"_fromspace_v_tospace.tif")
+    outputs.append ("out_getmatrix_v_fromspace_"+space+"_tospace.tif")
+
+    def run_from_to_test (fromspace, tospace) :
+        global command
+        command += testshade("-t 1 -g 32 32 -param fromspace "+fromspace+" -param tospace "+tospace+" -od uint8 -o Cout out_matrix_"+fromspace+"_fromspace_"+tospace+"_tospace.tif test_matrix_u_fromspace_u_tospace")
+        command += testshade("-t 1 -g 32 32 -param fromspace "+fromspace+" -param tospace "+tospace+" -od uint8 -o Cout out_getmatrix_"+fromspace+"_fromspace_"+tospace+"_tospace.tif test_getmatrix_u_fromspace_u_tospace")
+        
+        global outputs     
+        outputs.append ("out_matrix_"+fromspace+"_fromspace_"+tospace+"_tospace.tif")
+        outputs.append ("out_getmatrix_"+fromspace+"_fromspace_"+tospace+"_tospace.tif")
+        return
+
+    run_from_to_test(space, "common")
+    run_from_to_test(space, "object")
+    run_from_to_test(space, "shader")
+    run_from_to_test(space, "world")
+    run_from_to_test(space, "camera")
+    return
+    
+run_space_tests("common")
+run_space_tests("object")
+run_space_tests("shader")
+run_space_tests("world")
+run_space_tests("camera")
+
+command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_getmatrix_v_fromspace_v_tospace.tif test_getmatrix_v_fromspace_v_tospace")
+outputs.append ("out_getmatrix_v_fromspace_v_tospace.tif")
+
+
+
+# expect a few LSB failures
+failthresh = 0.008
+failpercent = 3
+

--- a/testsuite/matrix-reg/test_getmatrix_u_fromspace_u_tospace.osl
+++ b/testsuite/matrix-reg/test_getmatrix_u_fromspace_u_tospace.osl
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_getmatrix_u_fromspace_u_tospace (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param tospace must_be_provided", 
+    output color Cout = 0)
+{
+    matrix m1 = matrix(0); 
+    getmatrix(fromspace, tospace, m1);
+    
+
+    matrix m2 = m1*0.5;
+    
+    if (int(P[0]*64)%2==0) {
+        int success = getmatrix(fromspace, tospace, m2);
+        if (!success) {
+            m2 = matrix(1);
+        }        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_getmatrix_u_fromspace_v_tospace.osl
+++ b/testsuite/matrix-reg/test_getmatrix_u_fromspace_v_tospace.osl
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_getmatrix_u_fromspace_v_tospace (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = spaces[int(P[0]*64)%5];
+
+    matrix m1 = matrix(0); 
+    getmatrix(fromspace, tospace, m1);
+    
+
+    matrix m2 = m1*0.5;
+    
+    if (int(P[0]*64)%2==0) {
+        int success = getmatrix(fromspace, tospace, m2);
+        if (!success) {
+            m2 = matrix(1);
+        }        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_getmatrix_v_fromspace_u_tospace.osl
+++ b/testsuite/matrix-reg/test_getmatrix_v_fromspace_u_tospace.osl
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_getmatrix_v_fromspace_u_tospace (
+    string tospace = "--param tospace must_be_provided", 
+    output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+
+    matrix m1 = matrix(0); 
+    getmatrix(fromspace, tospace, m1);
+    
+
+    matrix m2 = m1*0.5;
+    
+    if (int(P[0]*64)%2==0) {
+        int success = getmatrix(fromspace, tospace, m2);
+        if (!success) {
+            m2 = matrix(1);
+        }        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_getmatrix_v_fromspace_v_tospace.osl
+++ b/testsuite/matrix-reg/test_getmatrix_v_fromspace_v_tospace.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_getmatrix_v_fromspace_v_tospace (output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+
+    matrix m1 = matrix(0); 
+    getmatrix(fromspace, tospace, m1);
+    
+
+    matrix m2 = m1*0.5;
+    
+    if (int(P[0]*64)%2==0) {
+        int success = getmatrix(fromspace, tospace, m2);
+        if (!success) {
+            m2 = matrix(1);
+        }        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_16x_u_float.osl
+++ b/testsuite/matrix-reg/test_matrix_16x_u_float.osl
@@ -1,0 +1,31 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_16x_u_float (output color Cout = 0)
+{
+    float uval = raytype("camera");
+    matrix m1 = matrix(
+        0.100*uval, 0.125*uval, 0.150*uval, 0.175*uval,
+        0.200*uval, 0.225*uval, 0.250*uval, 0.275*uval,
+        0.300*uval, 0.325*uval, 0.350*uval, 0.375*uval,
+        0.400*uval, 0.425*uval, 0.450*uval, 0.475*uval
+    );
+    
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(
+            0.400*uval, 0.425*uval, 0.450*uval, 0.475*uval,
+            0.300*uval, 0.325*uval, 0.350*uval, 0.375*uval,
+            0.200*uval, 0.225*uval, 0.250*uval, 0.275*uval,
+            0.100*uval, 0.125*uval, 0.150*uval, 0.175*uval
+        );        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_16x_v_float.osl
+++ b/testsuite/matrix-reg/test_matrix_16x_v_float.osl
@@ -1,0 +1,32 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_16x_v_float (output color Cout = 0)
+{
+    float val = u;
+    matrix m1 = matrix(
+        0.100*val, 0.125*val, 0.150*val, 0.175*val,
+        0.200*val, 0.225*val, 0.250*val, 0.275*val,
+        0.300*val, 0.325*val, 0.350*val, 0.375*val,
+        0.400*val, 0.425*val, 0.450*val, 0.475*val
+    );
+    
+
+    val = v;
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(
+            0.400*val, 0.425*val, 0.450*val, 0.475*val,
+            0.300*val, 0.325*val, 0.350*val, 0.375*val,
+            0.200*val, 0.225*val, 0.250*val, 0.275*val,
+            0.100*val, 0.125*val, 0.150*val, 0.175*val
+        );        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_u_determinant.osl
+++ b/testsuite/matrix-reg/test_matrix_u_determinant.osl
@@ -1,0 +1,16 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_determinant (output color Cout = 0)
+{
+    matrix m1 = matrix(2.0/(4*raytype("camera")));
+    
+
+    matrix m2 = matrix(2.0/(2*raytype("camera")));        
+    Cout = color(determinant(m1));
+    if (int(P[0]*64)%2==0) {
+        Cout = color(determinant(m2));
+    } 
+}

--- a/testsuite/matrix-reg/test_matrix_u_float.osl
+++ b/testsuite/matrix-reg/test_matrix_u_float.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_float (output color Cout = 0)
+{
+    matrix m1 = matrix(1.0/(4*raytype("camera")));
+    
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(1.0/(2*raytype("camera")));        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_u_fromspace_16x_u_float.osl
+++ b/testsuite/matrix-reg/test_matrix_u_fromspace_16x_u_float.osl
@@ -1,0 +1,35 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_fromspace_16x_u_float (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float uval = raytype("camera");
+
+    matrix m1 = matrix(fromspace,         
+        0.100*uval, 0.125*uval, 0.150*uval, 0.175*uval,
+        0.200*uval, 0.225*uval, 0.250*uval, 0.275*uval,
+        0.300*uval, 0.325*uval, 0.350*uval, 0.375*uval,
+        0.400*uval, 0.425*uval, 0.450*uval, 0.475*uval
+    );
+
+    
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, 
+            0.400*uval, 0.425*uval, 0.450*uval, 0.475*uval,
+            0.300*uval, 0.325*uval, 0.350*uval, 0.375*uval,
+            0.200*uval, 0.225*uval, 0.250*uval, 0.275*uval,
+            0.100*uval, 0.125*uval, 0.150*uval, 0.175*uval
+        );        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_u_fromspace_16x_v_float.osl
+++ b/testsuite/matrix-reg/test_matrix_u_fromspace_16x_v_float.osl
@@ -1,0 +1,36 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_fromspace_16x_v_float (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = u;
+
+    matrix m1 = matrix(fromspace, 
+        0.100*val, 0.125*val, 0.150*val, 0.175*val,
+        0.200*val, 0.225*val, 0.250*val, 0.275*val,
+        0.300*val, 0.325*val, 0.350*val, 0.375*val,
+        0.400*val, 0.425*val, 0.450*val, 0.475*val
+    );
+
+    val = v;
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, 
+            0.400*val, 0.425*val, 0.450*val, 0.475*val,
+            0.300*val, 0.325*val, 0.350*val, 0.375*val,
+            0.200*val, 0.225*val, 0.250*val, 0.275*val,
+            0.100*val, 0.125*val, 0.150*val, 0.175*val
+        );        
+        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_u_fromspace_u_float.osl
+++ b/testsuite/matrix-reg/test_matrix_u_fromspace_u_float.osl
@@ -1,0 +1,22 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_fromspace_u_float (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    matrix m1 = matrix(fromspace, 1.0/(4*raytype("camera")));
+    
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, 1.0/(2*raytype("camera")));        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_u_fromspace_u_tospace.osl
+++ b/testsuite/matrix-reg/test_matrix_u_fromspace_u_tospace.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_fromspace_u_tospace (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param tospace must_be_provided", 
+    output color Cout = 0)
+{
+    matrix m1 = matrix(fromspace, tospace);
+    
+
+    matrix m2 = m1*0.5;
+    
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, tospace);        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_u_fromspace_v_float.osl
+++ b/testsuite/matrix-reg/test_matrix_u_fromspace_v_float.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_fromspace_v_float (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    matrix m1 = matrix(fromspace, u);
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, v);        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_u_fromspace_v_tospace.osl
+++ b/testsuite/matrix-reg/test_matrix_u_fromspace_v_tospace.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_fromspace_v_tospace (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = spaces[int(P[0]*64)%5];
+
+    matrix m1 = matrix(fromspace, tospace);
+
+    matrix m2 = m1*0.5;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, tospace);        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_u_transpose.osl
+++ b/testsuite/matrix-reg/test_matrix_u_transpose.osl
@@ -1,0 +1,31 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_u_transpose (output color Cout = 0)
+{
+    float uval = raytype("camera");
+    matrix m1 = matrix(
+        0.100*uval, 0.125*uval, 0.150*uval, 0.175*uval,
+        0.200*uval, 0.225*uval, 0.250*uval, 0.275*uval,
+        0.300*uval, 0.325*uval, 0.350*uval, 0.375*uval,
+        0.400*uval, 0.425*uval, 0.450*uval, 0.475*uval
+    );
+    
+    matrix m2 = matrix(
+            0.400*uval, 0.425*uval, 0.450*uval, 0.475*uval,
+            0.300*uval, 0.325*uval, 0.350*uval, 0.375*uval,
+            0.200*uval, 0.225*uval, 0.250*uval, 0.275*uval,
+            0.100*uval, 0.125*uval, 0.150*uval, 0.175*uval
+        );
+    matrix m3 = transpose(m1);        
+    if (int(P[0]*64)%2==0) {
+        m3 = transpose(m2);        
+    }
+    
+    Cout = color(m3[0][0] + m3[0][1] + m3[0][2] + m3[0][3],
+                 m3[1][0] + m3[1][1] + m3[1][2] + m3[1][3],
+                 m3[2][0] + m3[2][1] + m3[2][2] + m3[2][3] +
+                 m3[3][0] + m3[3][1] + m3[3][2] + m3[3][3])/4;
+}

--- a/testsuite/matrix-reg/test_matrix_v_determinant.osl
+++ b/testsuite/matrix-reg/test_matrix_v_determinant.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_determinant (output color Cout = 0)
+{
+    matrix m1 = matrix(u);
+    matrix m2 = matrix(v);
+    Cout = color(determinant(m1));
+    
+    if (int(P[0]*64)%2==0) {
+        Cout = color(determinant(m2));
+    } 
+}

--- a/testsuite/matrix-reg/test_matrix_v_float.osl
+++ b/testsuite/matrix-reg/test_matrix_v_float.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_float (output color Cout = 0)
+{
+    matrix m1 = matrix(u);
+    
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(v);        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_v_fromspace_16x_u_float.osl
+++ b/testsuite/matrix-reg/test_matrix_v_fromspace_16x_u_float.osl
@@ -1,0 +1,35 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_fromspace_16x_u_float (output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+
+    float uval = raytype("camera");
+    matrix m1 = matrix(fromspace, 
+        0.100*uval, 0.125*uval, 0.150*uval, 0.175*uval,
+        0.200*uval, 0.225*uval, 0.250*uval, 0.275*uval,
+        0.300*uval, 0.325*uval, 0.350*uval, 0.375*uval,
+        0.400*uval, 0.425*uval, 0.450*uval, 0.475*uval
+    );
+
+    
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, 
+            0.400*uval, 0.425*uval, 0.450*uval, 0.475*uval,
+            0.300*uval, 0.325*uval, 0.350*uval, 0.375*uval,
+            0.200*uval, 0.225*uval, 0.250*uval, 0.275*uval,
+            0.100*uval, 0.125*uval, 0.150*uval, 0.175*uval
+        );        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_v_fromspace_16x_v_float.osl
+++ b/testsuite/matrix-reg/test_matrix_v_fromspace_16x_v_float.osl
@@ -1,0 +1,36 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_fromspace_16x_v_float (output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+
+    float val = u;
+
+    matrix m1 = matrix(fromspace,
+        0.100*val, 0.125*val, 0.150*val, 0.175*val,
+        0.200*val, 0.225*val, 0.250*val, 0.275*val,
+        0.300*val, 0.325*val, 0.350*val, 0.375*val,
+        0.400*val, 0.425*val, 0.450*val, 0.475*val
+    );
+
+    val = v;
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace,
+            0.400*val, 0.425*val, 0.450*val, 0.475*val,
+            0.300*val, 0.325*val, 0.350*val, 0.375*val,
+            0.200*val, 0.225*val, 0.250*val, 0.275*val,
+            0.100*val, 0.125*val, 0.150*val, 0.175*val
+        );        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_v_fromspace_u_float.osl
+++ b/testsuite/matrix-reg/test_matrix_v_fromspace_u_float.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_fromspace_u_float (output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+
+    matrix m1 = matrix(fromspace, 1.0/(4*raytype("camera")));
+    
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, 1.0/(2*raytype("camera")));        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_v_fromspace_u_tospace.osl
+++ b/testsuite/matrix-reg/test_matrix_v_fromspace_u_tospace.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_fromspace_u_tospace (
+    string tospace = "--param tospace must_be_provided", 
+    output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+
+    matrix m1 = matrix(fromspace, tospace);
+
+    matrix m2 = m1*0.5;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, tospace);        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_v_fromspace_v_float.osl
+++ b/testsuite/matrix-reg/test_matrix_v_fromspace_v_float.osl
@@ -1,0 +1,22 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_fromspace_v_float (output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+
+    matrix m1 = matrix(fromspace, u);
+
+    matrix m2 = m1;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, v);        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_v_fromspace_v_tospace.osl
+++ b/testsuite/matrix-reg/test_matrix_v_fromspace_v_tospace.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_fromspace_v_tospace (output color Cout = 0)
+{
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+
+    matrix m1 = matrix(fromspace, tospace);
+
+    matrix m2 = m1*0.5;
+    if (int(P[0]*64)%2==0) {
+        m2 = matrix(fromspace, tospace);        
+    }
+    
+    Cout = color(m2[0][0] + m2[0][1] + m2[0][2] + m2[0][3],
+                 m2[1][0] + m2[1][1] + m2[1][2] + m2[1][3],
+                 m2[2][0] + m2[2][1] + m2[2][2] + m2[2][3] +
+                 m2[3][0] + m2[3][1] + m2[3][2] + m2[3][3]);
+}

--- a/testsuite/matrix-reg/test_matrix_v_transpose.osl
+++ b/testsuite/matrix-reg/test_matrix_v_transpose.osl
@@ -1,0 +1,33 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_matrix_v_transpose (output color Cout = 0)
+{
+    float val = u;
+    matrix m1 = matrix(
+        0.100*val, 0.125*val, 0.150*val, 0.175*val,
+        0.200*val, 0.225*val, 0.250*val, 0.275*val,
+        0.300*val, 0.325*val, 0.350*val, 0.375*val,
+        0.400*val, 0.425*val, 0.450*val, 0.475*val
+    );
+    
+    val = v;
+    matrix m2 = matrix(
+        0.400*val, 0.425*val, 0.450*val, 0.475*val,
+        0.300*val, 0.325*val, 0.350*val, 0.375*val,
+        0.200*val, 0.225*val, 0.250*val, 0.275*val,
+        0.100*val, 0.125*val, 0.150*val, 0.175*val
+    );
+            
+    matrix m3 = transpose(m1);        
+    if (int(P[0]*64)%2==0) {
+        m3 = transpose(m2);        
+    }
+    
+    Cout = color(m3[0][0] + m3[0][1] + m3[0][2] + m3[0][3],
+                 m3[1][0] + m3[1][1] + m3[1][2] + m3[1][3],
+                 m3[2][0] + m3[2][1] + m3[2][2] + m3[2][3] +
+                 m3[3][0] + m3[3][1] + m3[3][2] + m3[3][3]);
+}

--- a/testsuite/transform-reg/run.py
+++ b/testsuite/transform-reg/run.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
+def run_2space_tests (triptype) :
+    global command
+    command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_transform_v_fromspace_v_tospace_u_"+triptype+".tif test_transform_v_fromspace_v_tospace_u_"+triptype+"")
+    command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_transform_v_fromspace_v_tospace_v_"+triptype+".tif test_transform_v_fromspace_v_tospace_v_"+triptype+"")
+    command += testshade("--vary_udxdy --vary_vdxdy -t 1 -g 32 32 -od uint8 -o Cout out_transform_v_fromspace_v_tospace_v_d"+triptype+".tif test_transform_v_fromspace_v_tospace_v_d"+triptype+"")
+    global outputs     
+    outputs.append ("out_transform_v_fromspace_v_tospace_u_"+triptype+".tif")
+    
+    outputs.append ("out_transform_v_fromspace_v_tospace_v_"+triptype+".tif")
+    outputs.append ("out_transform_v_fromspace_v_tospace_v_d"+triptype+".tif")
+    
+    def run_fromspace_tospace_tests (fromspace, tospace) :
+        global command
+        command += testshade("-t 1 -g 32 32 -param fromspace " + fromspace + " -param tospace " + tospace + " -od uint8 -o Cout out_transform_" + fromspace + "_fromspace_" + tospace + "_tospace_u_"+triptype+".tif test_transform_u_fromspace_u_tospace_u_"+triptype+"")
+        command += testshade("-t 1 -g 32 32 -param fromspace " + fromspace + " -param tospace " + tospace + " -od uint8 -o Cout out_transform_" + fromspace + "_fromspace_" + tospace + "_tospace_v_"+triptype+".tif test_transform_u_fromspace_u_tospace_v_"+triptype+"")
+        command += testshade("--vary_udxdy --vary_vdxdy -t 1 -g 32 32 -param fromspace $1 -param tospace " + tospace + " -od uint8 -o Cout out_transform_" + fromspace + "_fromspace_" + tospace + "_tospace_v_d"+triptype+".tif test_transform_u_fromspace_u_tospace_v_d"+triptype+"")
+    
+        global outputs     
+        outputs.append ("out_transform_" + fromspace + "_fromspace_" + tospace + "_tospace_u_"+triptype+".tif")
+        outputs.append ("out_transform_" + fromspace + "_fromspace_" + tospace + "_tospace_v_"+triptype+".tif")
+        outputs.append ("out_transform_" + fromspace + "_fromspace_" + tospace + "_tospace_v_d"+triptype+".tif")
+        return
+    
+    def run_u_fromspace_tests (space) :
+        run_fromspace_tospace_tests(space, "common")
+        run_fromspace_tospace_tests(space, "object")
+        run_fromspace_tospace_tests(space, "shader")
+        run_fromspace_tospace_tests(space, "world")
+        run_fromspace_tospace_tests(space, "camera")
+    
+        global command
+        command += testshade("-t 1 -g 32 32 -param fromspace " + space + " -od uint8 -o Cout out_transform_" + space + "_fromspace_v_tospace_u_"+triptype+".tif test_transform_u_fromspace_v_tospace_u_"+triptype+"")
+        command += testshade("-t 1 -g 32 32 -param fromspace " + space + " -od uint8 -o Cout out_transform_" + space + "_fromspace_v_tospace_v_"+triptype+".tif test_transform_u_fromspace_v_tospace_v_"+triptype+"")     
+        command += testshade("--vary_udxdy --vary_vdxdy -t 1 -g 32 32 -param fromspace " + space + " -od uint8 -o Cout out_transform_" + space + "_fromspace_v_tospace_v_d"+triptype+".tif test_transform_u_fromspace_v_tospace_v_d"+triptype+"")
+        
+        global outputs     
+        outputs.append ("out_transform_" + space + "_fromspace_v_tospace_u_"+triptype+".tif")
+        outputs.append ("out_transform_" + space + "_fromspace_v_tospace_v_"+triptype+".tif")
+        outputs.append ("out_transform_" + space + "_fromspace_v_tospace_v_d"+triptype+".tif")
+        return
+    
+    run_u_fromspace_tests("common")
+    run_u_fromspace_tests("object")
+    run_u_fromspace_tests("shader")
+    run_u_fromspace_tests("world")
+    run_u_fromspace_tests("camera")
+    
+    def run_v_fromspace_tospace_tests (space) :
+        global command
+        command += testshade("-t 1 -g 32 32 -param tospace " + space + " -od uint8 -o Cout out_transform_v_fromspace_" + space + "_tospace_u_"+triptype+".tif test_transform_v_fromspace_u_tospace_u_"+triptype+"")
+        command += testshade("-t 1 -g 32 32 -param tospace " + space + " -od uint8 -o Cout out_transform_v_fromspace_" + space + "_tospace_v_"+triptype+".tif test_transform_v_fromspace_u_tospace_v_"+triptype+"")     
+        command += testshade("--vary_udxdy --vary_vdxdy -t 1 -g 32 32 -param tospace " + space + " -od uint8 -o Cout out_transform_v_fromspace_" + space + "_tospace_v_d"+triptype+".tif test_transform_v_fromspace_u_tospace_v_d"+triptype+"")
+        
+        global outputs     
+        outputs.append ("out_transform_v_fromspace_" + space + "_tospace_u_"+triptype+".tif")
+        outputs.append ("out_transform_v_fromspace_" + space + "_tospace_v_"+triptype+".tif")
+        outputs.append ("out_transform_v_fromspace_" + space + "_tospace_v_d"+triptype+".tif")
+        return
+    
+    run_v_fromspace_tospace_tests("common")
+    run_v_fromspace_tospace_tests("object")
+    run_v_fromspace_tospace_tests("shader")
+    run_v_fromspace_tospace_tests("world")
+    run_v_fromspace_tospace_tests("camera")
+    return
+
+
+run_2space_tests ("normal")
+run_2space_tests ("point")
+run_2space_tests ("vector")
+
+def run_matrix_tests (triptype) :
+    global command
+    command += testshade("--center -t 1 -g 32 32 -od uint8 -o Cout out_transform_u_matrix_u_"+triptype+".tif test_transform_u_matrix_u_"+triptype+"")
+    command += testshade("--center -t 1 -g 32 32 -od uint8 -o Cout out_transform_u_matrix_v_"+triptype+".tif test_transform_u_matrix_v_"+triptype+"")     
+    command += testshade("--center --vary_udxdy --vary_vdxdy -t 1 -g 32 32 -od uint8 -o Cout out_transform_u_matrix_v_d"+triptype+".tif test_transform_u_matrix_v_d"+triptype+"")
+
+    command += testshade("--center -t 1 -g 32 32 -od uint8 -o Cout out_transform_v_matrix_u_"+triptype+".tif test_transform_v_matrix_u_"+triptype+"")
+    command += testshade("--center -t 1 -g 32 32 -od uint8 -o Cout out_transform_v_matrix_v_"+triptype+".tif test_transform_v_matrix_v_"+triptype+"")
+    command += testshade("--center --vary_udxdy --vary_vdxdy -t 1 -g 32 32 -od uint8 -o Cout out_transform_v_matrix_v_d"+triptype+".tif test_transform_v_matrix_v_d"+triptype+"")
+    
+    command += testshade("--center -t 1 -g 32 32 -od uint8 -o Cout out_transform_u_matrix_affine_u_"+triptype+".tif test_transform_u_matrix_affine_u_"+triptype+"")
+    command += testshade("--center -t 1 -g 32 32 -od uint8 -o Cout out_transform_u_matrix_affine_v_"+triptype+".tif test_transform_u_matrix_affine_v_"+triptype+"")
+    command += testshade("--center --vary_udxdy --vary_vdxdy -t 1 -g 32 32 -od uint8 -o Cout out_transform_u_matrix_affine_v_d"+triptype+".tif test_transform_u_matrix_affine_v_d"+triptype+"")
+    
+    command += testshade("--center -t 1 -g 32 32 -od uint8 -o Cout out_transform_v_matrix_affine_u_"+triptype+".tif test_transform_v_matrix_affine_u_"+triptype+"")
+    command += testshade("--center -t 1 -g 32 32 -od uint8 -o Cout out_transform_v_matrix_affine_v_"+triptype+".tif test_transform_v_matrix_affine_v_"+triptype+"")
+    command += testshade("--center --vary_udxdy --vary_vdxdy -t 1 -g 32 32 -od uint8 -o Cout out_transform_v_matrix_affine_v_d"+triptype+".tif test_transform_v_matrix_affine_v_d"+triptype+"")
+    
+    global outputs     
+    outputs.append ("out_transform_u_matrix_u_"+triptype+".tif")
+    outputs.append ("out_transform_u_matrix_v_"+triptype+".tif")
+    outputs.append ("out_transform_u_matrix_v_d"+triptype+".tif")
+    
+    outputs.append ("out_transform_v_matrix_u_"+triptype+".tif")
+    outputs.append ("out_transform_v_matrix_v_"+triptype+".tif")
+    outputs.append ("out_transform_v_matrix_v_d"+triptype+".tif")
+    
+    outputs.append ("out_transform_u_matrix_affine_u_"+triptype+".tif")
+    outputs.append ("out_transform_u_matrix_affine_v_"+triptype+".tif")
+    outputs.append ("out_transform_u_matrix_affine_v_d"+triptype+".tif")
+
+    outputs.append ("out_transform_v_matrix_affine_u_"+triptype+".tif")
+    outputs.append ("out_transform_v_matrix_affine_v_"+triptype+".tif")
+    outputs.append ("out_transform_v_matrix_affine_v_d"+triptype+".tif")
+    return
+
+run_matrix_tests("normal")
+run_matrix_tests("point")
+run_matrix_tests("vector")
+
+def run_1space_tests (triptype) :
+    def run_tospace_tests (space) :
+        global command
+        command += testshade("-t 1 -g 32 32 -param tospace "+space+" -od uint8 -o Cout out_transform_"+space+"_tospace_u_"+triptype+".tif test_transform_u_tospace_u_"+triptype+"")
+        command += testshade("-t 1 -g 32 32 -param tospace "+space+" -od uint8 -o Cout out_transform_"+space+"_tospace_v_"+triptype+".tif test_transform_u_tospace_v_"+triptype+"")
+        command += testshade("--vary_udxdy --vary_vdxdy -t 1 -g 32 32 -param tospace "+space+" -od uint8 -o Cout out_transform_"+space+"_tospace_v_d"+triptype+".tif test_transform_u_tospace_v_d"+triptype+"")
+        
+        global outputs     
+        outputs.append ("out_transform_"+space+"_tospace_u_"+triptype+".tif")
+        outputs.append ("out_transform_"+space+"_tospace_v_"+triptype+".tif")
+        outputs.append ("out_transform_"+space+"_tospace_v_d"+triptype+".tif")
+        return
+    run_tospace_tests("common")
+    run_tospace_tests("object")
+    run_tospace_tests("shader")
+    run_tospace_tests("world")
+    run_tospace_tests("camera")
+    
+    global command
+    command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_transform_v_tospace_u_"+triptype+".tif test_transform_v_tospace_u_"+triptype+"")
+    command += testshade("-t 1 -g 32 32 -od uint8 -o Cout out_transform_v_tospace_v_"+triptype+".tif test_transform_v_tospace_v_"+triptype+"")
+    command += testshade("--vary_udxdy --vary_vdxdy -t 1 -g 32 32 -od uint8 -o Cout out_transform_v_tospace_v_d"+triptype+".tif test_transform_v_tospace_v_d"+triptype+"")
+    
+    global outputs     
+    outputs.append ("out_transform_v_tospace_u_"+triptype+".tif")
+    outputs.append ("out_transform_v_tospace_v_"+triptype+".tif")
+    outputs.append ("out_transform_v_tospace_v_d"+triptype+".tif")
+    return
+
+run_1space_tests("normal")
+run_1space_tests("point")
+run_1space_tests("vector")
+    
+# expect a few LSB failures
+failthresh = 0.008
+failpercent = 3
+

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_u_normal.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_u_normal (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    normal tv = transform(fromspace, tospace, v1);
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_u_point.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_u_point.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_u_point (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    point tv = transform(fromspace, tospace, v1);
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_u_vector.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_u_vector (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    vector tv = transform(fromspace, tospace, v1);
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_dnormal.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_v_dnormal (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_dpoint.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_v_dpoint (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_dvector.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_v_dvector (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_normal.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_v_normal (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_point.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_point.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_v_point (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_u_tospace_v_vector.osl
@@ -1,0 +1,21 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_u_tospace_v_vector (
+    string fromspace = "--param fromspace must_be_provided", 
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_u_normal.osl
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_u_normal (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_u_point.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_u_point.osl
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_u_point (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_u_vector.osl
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_u_vector (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_dnormal.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_v_dnormal (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_dpoint.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_v_dpoint (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_dvector.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_v_dvector (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_normal.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_v_normal (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[1]*64)%5];
+    
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_point.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_point.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_v_point (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[1]*64)%5];
+    
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_fromspace_v_tospace_v_vector.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_fromspace_v_tospace_v_vector (
+    string fromspace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[1]*64)%5];
+    
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_u_normal.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_u_normal (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_u_point.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_u_point.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_u_point (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_u_vector.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_u_vector (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_v_dnormal.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_v_dnormal (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(u, v, u+v);
+    normal v2 = normal(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_v_dpoint.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_v_dpoint (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(u, v, u+v);
+    point v2 = point(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_v_dvector.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_v_dvector (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(u, v, u+v);
+    vector v2 = vector(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_v_normal.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_v_normal (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(u, v, u+v);
+    normal v2 = normal(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_v_point.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_v_point.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_v_point (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(u, v, u+v);
+    point v2 = point(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_affine_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_affine_v_vector.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_affine_v_vector (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(u, v, u+v);
+    vector v2 = vector(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + val*0.1, val*0.125, val*0.150, 0,
+        val*0.2, 0.1 + val*0.225, val*0.250, 0,
+        val*0.3, val*0.325, 0.1 + val*0.350, 0,
+        val*0.4, val*0.425, val*0.450, 1);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_u_normal.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_u_normal (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_u_point.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_u_point.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_u_point (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_u_vector.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_u_vector (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_v_dnormal.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_v_dnormal (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(u, v, u+v);
+    normal v2 = normal(v, u, v-u);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_v_dpoint.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_v_dpoint (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(u, v, u+v);
+    point v2 = point(v, u, v-u);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_v_dvector.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_v_dvector (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(u, v, u+v);
+    vector v2 = vector(v, u, v-u);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_v_normal.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_v_normal (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(u, v, u+v);
+    normal v2 = normal(v, u, v-u);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_v_point.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_v_point.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_v_point (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(u, v, u+v);
+    point v2 = point(v, u, v-u);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_matrix_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_matrix_v_vector.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_matrix_v_vector (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(u, v, u+v);
+    vector v2 = vector(v, u, v-u);
+    
+    matrix M = matrix(
+        val*0.1, val*0.125, val*0.150, val*0.175,
+        val*0.2, val*0.225, val*0.250, val*0.275,
+        val*0.3, val*0.325, val*0.350, val*0.375,
+        val*0.4, val*0.425, val*0.450, val*0.475);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_u_normal.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_u_normal (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    normal tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_u_point.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_u_point.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_u_point (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    point tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_u_vector.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_u_vector (
+    string tospace = "--param tospace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    vector tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_v_dnormal.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_v_dnormal (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    normal tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_v_dpoint.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_v_dpoint (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    point tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_v_dvector.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_v_dvector (
+    string tospace = "--param tospace must_be_provided", 
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    vector tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_v_normal.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_v_normal (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    normal tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_v_point.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_v_point.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_v_point (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    point tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_u_tospace_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_u_tospace_v_vector.osl
@@ -1,0 +1,20 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_u_tospace_v_vector (
+    string tospace = "--param tospace must_be_provided", 
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    vector tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_u_normal.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_u_normal (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    normal tv = transform(fromspace, tospace, v1);
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_u_point.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_u_point.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_u_point (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    point tv = transform(fromspace, tospace, v1);
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_u_vector.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_u_vector (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    vector tv = transform(fromspace, tospace, v1);
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_dnormal.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_v_dnormal (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_dpoint.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_v_dpoint (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_dvector.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_v_dvector (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_normal.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_v_normal (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_point.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_point.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_v_point (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_u_tospace_v_vector.osl
@@ -1,0 +1,23 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_u_tospace_v_vector (
+    string tospace = "--param fromspace must_be_provided", 
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_u_normal.osl
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_u_normal (
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_u_point.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_u_point.osl
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_u_point (
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_u_vector.osl
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_u_vector (
+    output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_dnormal.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_v_dnormal (
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_dpoint.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_v_dpoint (
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_dvector.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_v_dvector (
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_normal.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_v_normal (
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    normal tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_point.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_point.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_v_point (
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    point tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_fromspace_v_tospace_v_vector.osl
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_fromspace_v_tospace_v_vector (
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    string spaces[5] = { "common", "object", "shader", "world", "camera"};
+    string fromspace = spaces[int(P[0]*64)%5];
+    string tospace = spaces[int(P[1]*64)%5];
+    
+    
+    vector tv = transform(fromspace, tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(fromspace, tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_u_normal.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_u_normal (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_u_point.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_u_point.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_u_point (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_u_vector.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_u_vector (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_v_dnormal.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_v_dnormal (
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u+v);
+    normal v2 = normal(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_v_dpoint.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_v_dpoint (
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u+v);
+    point v2 = point(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_v_dvector.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_v_dvector (
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u+v);
+    vector v2 = vector(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_v_normal.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_v_normal (
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u+v);
+    normal v2 = normal(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_v_point.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_v_point.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_v_point (
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u+v);
+    point v2 = point(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_affine_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_affine_v_vector.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_affine_v_vector (
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u+v);
+    vector v2 = vector(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, 0,
+        u*0.2, 0.1 + u*0.225, u*0.250, 0,
+        v*0.3, v*0.325, 0.1 + v*0.350, 0,
+        v*0.4, v*0.425, v*0.450, 1);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_u_normal.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_u_normal (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, v*0.475);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_u_point.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_u_point.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_u_point (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, v*0.475);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_u_vector.osl
@@ -1,0 +1,29 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_u_vector (
+    output color Cout = 0)
+{
+    float val = raytype("camera");
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, v*0.475);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_v_dnormal.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_v_dnormal (
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u+v);
+    normal v2 = normal(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, v*0.475);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_v_dpoint.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_v_dpoint (
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u+v);
+    point v2 = point(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, 0.1 + v*0.475);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_v_dvector.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_v_dvector (
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u+v);
+    vector v2 = vector(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, 0.1 + v*0.475);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = Dx(tv2) + Dy(tv2);
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_v_normal.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_v_normal (
+    output color Cout = 0)
+{
+    normal v1 = normal(u, v, u+v);
+    normal v2 = normal(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, 0.1 + v*0.475);
+    normal tv = transform(M, v1);
+    normal tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_v_point.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_v_point.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_v_point (
+    output color Cout = 0)
+{
+    point v1 = point(u, v, u+v);
+    point v2 = point(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, v*0.475);
+    point tv = transform(M, v1);
+    point tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_matrix_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_matrix_v_vector.osl
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_matrix_v_vector (
+    output color Cout = 0)
+{
+    vector v1 = vector(u, v, u+v);
+    vector v2 = vector(v, u, v-u);
+    
+    matrix M = matrix(
+        0.1 + u*0.1, u*0.125, u*0.150, u*0.175,
+        u*0.2, 0.1 + u*0.225, u*0.250, u*0.275,
+        v*0.3, v*0.325, 0.1 + v*0.350, v*0.375,
+        v*0.4, v*0.425, v*0.450, v*0.475);
+    vector tv = transform(M, v1);
+    vector tv2 = tv*transform(M*2, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv2 = transform(M, v2);
+    }
+    
+    Cout = tv2;
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_u_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_u_normal.osl
@@ -1,0 +1,26 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_u_normal (output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    normal v1 = normal(val, val2, val3);
+    normal v2 = normal(val3, val, val2);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    normal tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_u_point.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_u_point.osl
@@ -1,0 +1,26 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_u_point (output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    point v1 = point(val, val2, val3);
+    point v2 = point(val3, val, val2);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    point tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_u_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_u_vector.osl
@@ -1,0 +1,26 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_u_vector (output color Cout = 0)
+{
+    float val = 1.0/(2*raytype("camera"));
+    float val2 = val/2;
+    float val3 = val/4;
+
+    vector v1 = vector(val, val2, val3);
+    vector v2 = vector(val3, val, val2);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    vector tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_v_dnormal.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_v_dnormal.osl
@@ -1,0 +1,22 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_v_dnormal (output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    normal tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_v_dpoint.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_v_dpoint.osl
@@ -1,0 +1,22 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_v_dpoint (output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    point tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_v_dvector.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_v_dvector.osl
@@ -1,0 +1,22 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_v_dvector (output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    vector tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = Dx(tv) + Dy(tv);
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_v_normal.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_v_normal.osl
@@ -1,0 +1,22 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_v_normal (output color Cout = 0)
+{
+    normal v1 = normal(u, v, u-v);
+    normal v2 = normal(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    normal tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_v_point.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_v_point.osl
@@ -1,0 +1,22 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_v_point (output color Cout = 0)
+{
+    point v1 = point(u, v, u-v);
+    point v2 = point(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    point tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}

--- a/testsuite/transform-reg/test_transform_v_tospace_v_vector.osl
+++ b/testsuite/transform-reg/test_transform_v_tospace_v_vector.osl
@@ -1,0 +1,22 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test_transform_v_tospace_v_vector (output color Cout = 0)
+{
+    vector v1 = vector(u, v, u-v);
+    vector v2 = vector(v, u, u+v);
+    
+    string tospaces[5] = { "common", "object", "shader", "world", "camera"};
+    string tospace = tospaces[int(P[0]*64)%5];
+    
+    
+    vector tv = transform(tospace, v1);
+
+    if (int(P[0]*64)%2==0) {
+        tv = transform(tospace, v2);
+    }
+    
+    Cout = tv;
+}


### PR DESCRIPTION
## Description

Implement batched matrix ops, including transform, determinant, transpose, and construction and getmatrix with spaces, multiplication, division, negation.

Moved helpers det2x2, det3x3, and det4x4 from opmatrix.cpp to Imathx.h so they could be shared with the wide_opmatrix.cpp.

Added new helper wrapper to pass a single const uniform value to an algorithm designed to work with Wide data.
`template<typename ConstDataT, int WidthT> struct UniformAsWide;`


## Tests

Enabled BATCHED testing for matrix and transform testsuites
Added new BATCHED_REGRESSION testsuites array-reg, matrix-arithmetic-reg, matrix-compref-reg, matrix-reg, transform-reg to more fully exercise combinations of uniform and varying data types and indexing variables.


## Checklist:


- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

