### PR TITLE
CI gcc and llvm testing changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,16 +417,71 @@ jobs:
             build/*/testsuite/*/*.*
             build/*/CMake*.{txt,log}
 
-  linux-bleeding-edge:
+  linux-latest-release:
     # Test against development master for relevant dependencies, latest
     # supported releases of everything else.
-    name: "Linux bleeding edge: gcc10, C++17, llvm11, oiio/ocio/exr/pybind-master, avx2, batch-b16avx512"
+    name: "Linux latest releases: gcc10, C++17, llvm11, avx2, batch-b16avx512"
     runs-on: ubuntu-20.04
     env:
       CXX: g++-10
       USE_CPP: 17
       CMAKE_CXX_STANDARD: 17
       LLVM_VERSION: 11.0.0
+      LLVM_DISTRO_NAME: ubuntu-20.04
+      USE_SIMD: avx2,f16c
+      OPENEXR_VERSION: v3.0.4
+      OPENIMAGEIO_VERSION: master
+      OPENIMAGEIO_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.1.3
+      OPENCOLORIO_VERSION: v2.0.1
+      PYBIND11_VERSION: v2.6.2
+      PUGIXML_VERSION: v1.11.4
+      USE_BATCHED: b8_AVX2,b8_AVX512,b16_AVX512
+      PYTHON_VERSION: 3.8
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare ccache timestamp
+        id: ccache_cache_keys
+        shell: bash
+        run: |
+          echo "::set-output name=date::`date -u +'%Y-%m-%dT%H:%M:%SZ'`"
+      - name: ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/ccache
+          key: ${{ github.job }}-${{ steps.ccache_cache_keys.outputs.date }}
+          restore-keys: |
+            ${{ github.job }}-
+      - name: Build setup
+        run: |
+            src/build-scripts/ci-startup.bash
+      - name: Dependencies
+        run: |
+            src/build-scripts/gh-installdeps.bash
+      - name: Build
+        run: |
+            src/build-scripts/ci-build.bash
+      - name: Testsuite
+        run: |
+            src/build-scripts/ci-test.bash
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: ${{ github.job }}
+          path: |
+            build/*/testsuite/*/*.*
+            build/*/CMake*.{txt,log}
+
+  linux-bleeding-edge:
+    # Test against development master for relevant dependencies, latest
+    # supported releases of everything else.
+    name: "Linux bleeding edge: gcc11, C++17, llvm12, oiio/ocio/exr/pybind-master, avx2, batch-b16avx512"
+    runs-on: ubuntu-20.04
+    env:
+      CXX: g++-11
+      USE_CPP: 17
+      CMAKE_CXX_STANDARD: 17
+      LLVM_VERSION: 12.0.0
       LLVM_DISTRO_NAME: ubuntu-20.04
       USE_SIMD: avx2,f16c
       OPENEXR_VERSION: master

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 * Build system: [CMake](https://cmake.org/) 3.12 or newer (tested through 3.20)
 
 * A suitable **C++14 or C++17** compiler to build OSL itself, which may be any of:
-   - **GCC 6.1 or newer** (tested through gcc 10)
+   - **GCC 6.1 or newer** (tested through gcc 11)
    - Clang 3.4 or newer (tested through clang 12)
    - Microsoft Visual Studio **2017 or newer**
    - Intel C++ compiler icc **version 17 or newer**
@@ -42,7 +42,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 * **[LLVM](http://www.llvm.org) 7, 8, 9, 10, 11, or 12**, including clang
   libraries.
 
-* [Boost](https://www.boost.org) 1.55 or newer (tested through boost 1.73)
+* [Boost](https://www.boost.org) 1.55 or newer (tested through boost 1.75)
 * [Ilmbase or Imath](http://openexr.com/downloads.html) 2.0 or newer (tested through 3.0)
 * [Flex](https://github.com/westes/flex) 2.5.35 or newer and
   [GNU Bison](https://www.gnu.org/software/bison/) 2.7 or newer.

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -29,7 +29,7 @@ if [[ `uname` == "Linux" ]] ; then
     fi
     LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
     echo LLVMTAR = $LLVMTAR
-    if [[ "$LLVM_VERSION" == "10.0.0" ]] || [[ "$LLVM_VERSION" == "11.0.0" ]] ; then
+    if [[ "$LLVM_VERSION" == "10.0.0" ]] || [[ "$LLVM_VERSION" == "11.0.0" ]] || [[ "$LLVM_VERSION" == "11.1.0" ]] || [[ "$LLVM_VERSION" == "12.0.0" ]] ; then
         # new
         curl --location https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
     else

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -55,6 +55,8 @@ else
         time sudo apt-get install -y g++-9
     elif [[ "$CXX" == "g++-10" ]] ; then
         time sudo apt-get install -y g++-10
+    elif [[ "$CXX" == "g++-11" ]] ; then
+        time sudo apt-get install -y g++-11
     fi
 
     source src/build-scripts/build_llvm.bash


### PR DESCRIPTION
* Update the "bleeding edge" CI test to gcc-11, and also LLVM 12,
  which we hadn't tested before (in CI).
* Split out a "latest releases" CI test uses gcc10 and LLVM 11.
* Turns out that nothing else on the OSL side needed to be fixed to
  accommodate gcc 11 (though you need a very up-to-date OIIO if you
  want to compile it with gcc11 unless you turn warnings off).

Signed-off-by: Larry Gritz <lg@larrygritz.com>

