### PR TITLE
Remove last calls to ambiguous OIIO format functions

### DIFF
--- a/src/liboslexec/osogram.y
+++ b/src/liboslexec/osogram.y
@@ -311,8 +311,8 @@ hint
 void
 OSL::pvt::yyerror (YYLTYPE* yylloc_param, void* yyscanner, OSOReader* osoreader, const char* err)
 {
-    osoreader->errhandler().error ("Error, line %d: %s", 
-             osoreader->lineno(), err);
+    osoreader->errhandler().errorf("Error, line %d: %s",
+                                   osoreader->lineno(), err);
 }
 
 

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -290,7 +290,7 @@ public:
         yy_switch_to_buffer(m_buffer, m_scanner);
         int errcode = osoparse(m_scanner, reader); // osoparse returns nonzero if error
         if (errcode) {
-            reader->errhandler().error ("Failed parse of %s (error code %d)", what, errcode);
+            reader->errhandler().errorf("Failed parse of %s (error code %d)", what, errcode);
         }
         return ! errcode;
     }
@@ -313,7 +313,7 @@ OSOReader::parse_file (const std::string &filename)
 
     FILE* osoin = OIIO::Filesystem::fopen (filename, "r");
     if (! osoin) {
-        m_err.error ("File %s not found", filename.c_str());
+        m_err.errorf("File %s not found", filename.c_str());
         return false;
     }
 

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -616,7 +616,7 @@ OSLInput::read_native_scanlines(int subimage, int miplevel, int ybegin,
         return false;
 
     if (!m_group.get()) {
-        error("read_native_scanlines called with missing shading group");
+        errorf("read_native_scanlines called with missing shading group");
         return false;
     }
 
@@ -660,7 +660,7 @@ OSLInput::read_native_tiles(int subimage, int miplevel, int xbegin, int xend,
     if (!seek_subimage(subimage, miplevel))
         return false;
     if (!m_group.get()) {
-        error("read_native_scanlines called with missing shading group");
+        errorf("read_native_scanlines called with missing shading group");
         return false;
     }
 

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -157,7 +157,7 @@ OptixRaytracer::load_ptx_file (string_view filename)
             return ptx_string;
     }
 #endif
-    errhandler().severe ("Unable to load %s", filename);
+    errhandler().severef("Unable to load %s", filename);
     return {};
 }
 
@@ -195,7 +195,7 @@ OptixRaytracer::init_optix_context (int xres OSL_MAYBE_UNUSED,
     std::string progName = "optix_raytracer.ptx";
     std::string renderer_ptx = load_ptx_file(progName);
     if (renderer_ptx.empty()) {
-        errhandler().severe ("Could not find PTX for the raygen program");
+        errhandler().severef("Could not find PTX for the raygen program");
         return false;
     }
 
@@ -371,7 +371,7 @@ OptixRaytracer::load_optix_module (const char*                        filename,
     // Load the renderer CUDA source and generate PTX for it
     std::string program_ptx = load_ptx_file(filename);
     if (program_ptx.empty()) {
-        errhandler().severe ("Could not find PTX file:  %s", filename);
+        errhandler().severef("Could not find PTX file:  %s", filename);
         return false;
     }
 
@@ -1437,7 +1437,7 @@ OptixRaytracer::finalize_pixel_buffer ()
 #if (OPTIX_VERSION < 70000)
     const void* buffer_ptr = m_optix_ctx[buffer_name]->getBuffer()->map();
     if (! buffer_ptr)
-        errhandler().severe ("Unable to map buffer %s", buffer_name);
+        errhandler().severef("Unable to map buffer %s", buffer_name);
     pixelbuf.set_pixels (OIIO::ROI::All(), OIIO::TypeFloat, buffer_ptr);
 #else
     std::vector<float> tmp_buff(m_xres * m_yres * 3);

--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -213,11 +213,11 @@ SimpleRaytracer::parse_scene_xml(const std::string& scenefile)
         parse_result = doc.load_buffer(scenefile.c_str(), scenefile.size());
     }
     if (!parse_result)
-        errhandler().severe ("XML parsed with errors: %s at offset %d",
+        errhandler().severef("XML parsed with errors: %s at offset %d",
                              parse_result.description(), parse_result.offset);
     pugi::xml_node root = doc.child("World");
     if (!root)
-        errhandler().severe ("Error reading scene: Root element <World> is missing");
+        errhandler().severef("Error reading scene: Root element <World> is missing");
 
     // loop over all children of world
     for (auto node = root.first_child(); node; node = node.next_sibling()) {
@@ -347,10 +347,10 @@ SimpleRaytracer::parse_scene_xml(const std::string& scenefile)
         }
     }
     if (root.next_sibling())
-        errhandler().severe ("Error reading %s: Found multiple top-level elements",
+        errhandler().severef("Error reading %s: Found multiple top-level elements",
                              scenefile);
     if (shaders().empty())
-        errhandler().severe ("No shaders in scene");
+        errhandler().severef("No shaders in scene");
     camera.finalize();
 }
 

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -250,7 +250,7 @@ main (int argc, const char *argv[])
         }
         rend->pixelbuf.set_write_format (TypeDesc::HALF);
         if (! rend->pixelbuf.write (imagefile))
-            rend->errhandler().error ("Unable to write output image: %s",
+            rend->errhandler().errorf("Unable to write output image: %s",
                                       rend->pixelbuf.geterror());
         double writetime = timer.lap();
 

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -163,7 +163,7 @@ OptixGridRenderer::load_ptx_file (string_view filename)
             return ptx_string;
     }
 #endif
-    errhandler().severe ("Unable to load %s", filename);
+    errhandler().severef("Unable to load %s", filename);
     return {};
 }
 
@@ -213,7 +213,7 @@ OptixGridRenderer::init_optix_context (int xres OSL_MAYBE_UNUSED,
     std::string progName = "optix_grid_renderer.ptx";
     std::string renderer_ptx = load_ptx_file(progName);
     if (renderer_ptx.empty()) {
-        errhandler().severe ("Could not find PTX for the raygen program");
+        errhandler().severef("Could not find PTX for the raygen program");
         return false;
     }
 
@@ -248,7 +248,7 @@ OptixGridRenderer::synch_attributes ()
         if (!shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys) ||
             !shadingsys->getattribute("colorsystem:sizes", TypeDesc(TypeDesc::LONGLONG,2), (void*)&cpuDataSizes) ||
             !colorSys || !cpuDataSizes[0]) {
-            errhandler().error ("No colorsystem available.");
+            errhandler().errorf("No colorsystem available.");
             return false;
         }
 
@@ -260,7 +260,7 @@ OptixGridRenderer::synch_attributes ()
 
         optix::Buffer buffer = m_optix_ctx->createBuffer(RT_BUFFER_INPUT, RT_FORMAT_USER);
         if (!buffer) {
-            errhandler().error ("Could not create buffer for '%s'.", name);
+            errhandler().errorf("Could not create buffer for '%s'.", name);
             return false;
         }
 
@@ -273,7 +273,7 @@ OptixGridRenderer::synch_attributes ()
         // copy the base data
         char* gpuData = (char*) buffer->map();
         if (!gpuData) {
-            errhandler().error ("Could not map buffer for '%s' (size: %lu).",
+            errhandler().errorf("Could not map buffer for '%s' (size: %lu).",
                                 name, podDataSize + sizeof(DeviceString)*numStrings);
             return false;
         }
@@ -309,7 +309,7 @@ OptixGridRenderer::synch_attributes ()
         if (!shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys) ||
             !shadingsys->getattribute("colorsystem:sizes", TypeDesc(TypeDesc::LONGLONG,2), (void*)&cpuDataSizes) ||
             !colorSys || !cpuDataSizes[0]) {
-            errhandler().error ("No colorsystem available.");
+            errhandler().errorf("No colorsystem available.");
             return false;
         }
 
@@ -385,7 +385,7 @@ OptixGridRenderer::make_optix_materials ()
                                   OSL::TypeDesc::PTR, &osl_ptx);
 
         if (osl_ptx.empty()) {
-            errhandler().error ("Failed to generate PTX for ShaderGroup %s",
+            errhandler().errorf("Failed to generate PTX for ShaderGroup %s",
                                 group_name);
             return false;
         }
@@ -441,7 +441,7 @@ OptixGridRenderer::make_optix_materials ()
     std::string progName = "optix_grid_renderer.ptx";
     std::string program_ptx = load_ptx_file(progName);
     if (program_ptx.empty()) {
-        errhandler().severe ("Could not find PTX for the raygen program");
+        errhandler().severef("Could not find PTX for the raygen program");
         return false;
     }
 
@@ -579,7 +579,7 @@ OptixGridRenderer::make_optix_materials ()
                                   OSL::TypeDesc::PTR, &osl_ptx);
 
         if (osl_ptx.empty()) {
-            errhandler().error ("Failed to generate PTX for ShaderGroup %s",
+            errhandler().errorf("Failed to generate PTX for ShaderGroup %s",
                                 group_name);
             return false;
         }
@@ -838,7 +838,7 @@ OptixGridRenderer::get_texture_handle (ustring filename OSL_MAYBE_UNUSED,
 
         OIIO::ImageBuf image;
         if (!image.init_spec(filename, 0, 0)) {
-            errhandler().error ("Could not load: %s", filename);
+            errhandler().errorf("Could not load: %s", filename);
             return (TextureHandle*)(intptr_t(RT_TEXTURE_ID_NULL));
         }
         int nchan = image.spec().nchannels;
@@ -872,7 +872,7 @@ OptixGridRenderer::get_texture_handle (ustring filename OSL_MAYBE_UNUSED,
         // Open image
         OIIO::ImageBuf image;
         if (!image.init_spec(filename, 0, 0)) {
-            errhandler().error ("Could not load: %s", filename);
+            errhandler().errorf("Could not load: %s", filename);
             return (TextureHandle*)(intptr_t(nullptr));
         }
 
@@ -1125,7 +1125,7 @@ OptixGridRenderer::finalize_pixel_buffer ()
 #if (OPTIX_VERSION < 70000)
     const void* buffer_ptr = m_optix_ctx[buffer_name]->getBuffer()->map();
     if (! buffer_ptr)
-        errhandler().severe ("Unable to map buffer %s", buffer_name);
+        errhandler().severef("Unable to map buffer %s", buffer_name);
     OIIO::ImageBuf* buf = outputbuf(0);
     if (buf)
         buf->set_pixels (OIIO::ROI::All(), OIIO::TypeFloat, buffer_ptr);


### PR DESCRIPTION
Background: OIIO now has errorf that are explicitly printf-like, and
errorfmt that are explicitly std::format-like, and also an old style
error() that is ambiguous.  The ambiguous calls are (at this moment)
aliases to the printf ones, but will be deprecated at some point (and
may, later when it seems safe, get reborn as the std::format compliant
behavior).

This roots out and removes the last few calls to the old ambiguous
ones from the OSL codebase.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
