### PR TITLE
Sanitize filenames when using "archive_groupname"

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2455,10 +2455,12 @@ ShadingSystemImpl::ShaderGroupEnd (ShaderGroup& group)
         std::string filename = m_archive_filename.string();
         if (! filename.size()) {
             filename = OIIO::Filesystem::filename (groupname.string()) + ".tar.gz";
-            // Colons will ruin our day when passed to tar as a filename.
-            // Why, yes, some people name their shader groups with colons.
+            // Transform characters that will ruin our day when passed to
+            // tar as a filename.
             if (OIIO::Strutil::contains(filename, ":"))
                 filename = OIIO::Strutil::replace(filename, ":", "_");
+            if (OIIO::Strutil::contains(filename, "|"))
+                filename = OIIO::Strutil::replace(filename, "|", "_");
         }
         archive_shadergroup (group, filename);
     }
@@ -3822,16 +3824,20 @@ ShadingSystemImpl::archive_shadergroup (ShaderGroup& group, string_view filename
                 entries.insert (osoname);
                 std::string localfile = tmpdir + "/" + osoname;
                 OIIO::Filesystem::copy (osofile, localfile);
-                filename_list += " " + osoname;
+                filename_list += Strutil::fmt::format(" \"{}\"",
+                                                      Strutil::escape_chars(osoname));
             }
         }
     }
 
+    std::string full_filename = Strutil::fmt::format("{}{}",
+                                              Strutil::escape_chars(filename),
+                                              extension);
     if (extension == ".tar" || extension == ".tar.gz" || extension == ".tgz") {
         std::string z = Strutil::ends_with (extension, "gz") ? "-z" : "";
-        std::string cmd = Strutil::sprintf ("tar -c %s -C %s -f %s%s %s",
-                                           z, tmpdir, filename, extension,
-                                           filename_list);
+        std::string cmd = Strutil::sprintf("tar -c %s -C \"%s\" -f \"%s\" %s",
+                                           z, Strutil::escape_chars(tmpdir),
+                                           full_filename, filename_list);
         // std::cout << "Command =\n" << cmd << "\n";
         if (system (cmd.c_str()) != 0) {
             error ("archive_shadergroup: executing tar command failed");
@@ -3839,9 +3845,8 @@ ShadingSystemImpl::archive_shadergroup (ShaderGroup& group, string_view filename
         }
 
     } else if (extension == ".zip") {
-        std::string cmd = Strutil::sprintf ("zip -q %s%s %s",
-                                           filename, extension,
-                                           filename_list);
+        std::string cmd = Strutil::sprintf("zip -q \"%s\" %s",
+                                           full_filename, filename_list);
         // std::cout << "Command =\n" << cmd << "\n";
         if (system (cmd.c_str()) != 0) {
             error ("archive_shadergroup: executing zip command failed");

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2453,8 +2453,13 @@ ShadingSystemImpl::ShaderGroupEnd (ShaderGroup& group)
     ustring groupname = group.name();
     if (groupname.size() && groupname == m_archive_groupname) {
         std::string filename = m_archive_filename.string();
-        if (! filename.size())
+        if (! filename.size()) {
             filename = OIIO::Filesystem::filename (groupname.string()) + ".tar.gz";
+            // Colons will ruin our day when passed to tar as a filename.
+            // Why, yes, some people name their shader groups with colons.
+            if (OIIO::Strutil::contains(filename, ":"))
+                filename = OIIO::Strutil::replace(filename, ":", "_");
+        }
         archive_shadergroup (group, filename);
     }
 


### PR DESCRIPTION
This feature (used, very possibly, only by me, for debugging)
forces OSL to write an archive that contains the oso files and a
serialized version of the shader network.

If no explicit name is given (by the "archive_filename" attribute), it
picks a name based on the shader group name. But that may not be a
safe string for a valid filename. We already eliminated anything
before the last slash, but it turns out that a colon (':') can also
really mess things up. So this small change protects against that.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
