### PR TITLE
Userdata input placement

### DIFF
--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -92,12 +92,28 @@ using OIIO::TextureOpt;
 
 // And some other things we borrow from OIIO...
 using OIIO::ErrorHandler;
-using OIIO::TypeDesc;
 using OIIO::ustring;
 using OIIO::ustringHash;
 using OIIO::string_view;
 using OIIO::span;
 using OIIO::cspan;
+
+using OIIO::TypeDesc;
+using OIIO::TypeUnknown;
+using OIIO::TypeFloat;
+using OIIO::TypeColor;
+using OIIO::TypePoint;
+using OIIO::TypeVector;
+using OIIO::TypeNormal;
+using OIIO::TypeMatrix;
+using OIIO::TypeFloat4;
+using OIIO::TypeString;
+using OIIO::TypeInt;
+#if OIIO_VERSION >= 20203
+using OIIO::TypeFloat2;
+using OIIO::TypeVector2;
+using OIIO::TypeVector4;
+#endif
 
 
 // N.B. SymArena is not really "configuration", but we cram it here for
@@ -108,9 +124,9 @@ enum class SymArena {
     Unknown = 0,        // Unknown/uninitialized value
     Absolute,           // Absolute address
     Heap,               // Belongs to context heap
-    Outputs             // Belongs to output arena
+    Outputs,            // Belongs to output arena
+    UserData,           // UserData arena
     // ShaderGlobals,   // RESERVED
-    // UserData,        // RESERVED
 };
 
 

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -632,13 +632,13 @@ public:
     /// execute_cleanup. If run==false, just do the binding and setup, don't
     /// actually run the shader.
     bool execute(ShadingContext &ctx, ShaderGroup &group, int shadeindex,
-                 ShaderGlobals& globals, void* output_base_ptr,
-                 bool run = true);
+                 ShaderGlobals& globals, void* userdata_base_ptr,
+                 void* output_base_ptr, bool run = true);
 
     // DEPRECATED(2.0): no shadeindex or base pointers
     bool execute (ShadingContext &ctx, ShaderGroup &group,
                   ShaderGlobals &globals, bool run=true) {
-        return execute(ctx, group, 0, globals, nullptr, run);
+        return execute(ctx, group, 0, globals, nullptr, nullptr, run);
     }
 
     // DEPRECATED(2.0): ctx pointer
@@ -656,12 +656,12 @@ public:
     /// shader executed, false if it did not (including if the shader itself
     /// was empty).
     bool execute_init(ShadingContext &ctx, ShaderGroup &group, int shadeindex,
-                      ShaderGlobals &globals, void* output_base_ptr,
-                      bool run=true);
+                      ShaderGlobals &globals, void* userdata_base_ptr,
+                      void* output_base_ptr, bool run=true);
     // DEPRECATED(2.0): no shadeindex or base pointers
     bool execute_init (ShadingContext &ctx, ShaderGroup &group,
                        ShaderGlobals &globals, bool run=true) {
-        return execute_init(ctx, group, 0, globals, nullptr, run);
+        return execute_init(ctx, group, 0, globals, nullptr, nullptr, run);
     }
 
     /// Execute the layer whose layernumber is specified, in this context.
@@ -670,27 +670,30 @@ public:
     /// reason why it might have returned false is if the shader group
     /// turned out, after optimization, to do nothing.)
     bool execute_layer(ShadingContext &ctx, int shadeindex, ShaderGlobals &globals,
-                       void* output_base_ptr, int layernumber);
+                       void* userdata_base_ptr, void* output_base_ptr,
+                       int layernumber);
     /// Execute the layer by name.
     bool execute_layer(ShadingContext &ctx, int shadeindex, ShaderGlobals &globals,
-                       void* output_base_ptr, ustring layername);
+                       void* userdata_base_ptr, void* output_base_ptr,
+                       ustring layername);
     /// Execute the layer that has the given ShaderSymbol as an output.
     /// (The symbol is one returned by find_symbol()).
     bool execute_layer(ShadingContext &ctx, int shadeindex, ShaderGlobals &globals,
-                       void* output_base_ptr, const ShaderSymbol *symbol);
+                       void* userdata_base_ptr, void* output_base_ptr,
+                       const ShaderSymbol *symbol);
 
     // DEPRECATED(2.0): no shadeindex or base pointers
     bool execute_layer (ShadingContext &ctx, ShaderGlobals &globals,
                         int layernumber) {
-        return execute_layer(ctx, 0, globals, nullptr, layernumber);
+        return execute_layer(ctx, 0, globals, nullptr, nullptr, layernumber);
     }
     bool execute_layer (ShadingContext &ctx, ShaderGlobals &globals,
                         ustring layername) {
-        return execute_layer(ctx, 0, globals, nullptr, layername);
+        return execute_layer(ctx, 0, globals, nullptr, nullptr, layername);
     }
     bool execute_layer (ShadingContext &ctx, ShaderGlobals &globals,
                         const ShaderSymbol *symbol) {
-        return execute_layer(ctx, 0, globals, nullptr, symbol);
+        return execute_layer(ctx, 0, globals, nullptr, nullptr, symbol);
     }
 
     /// Signify that the context is done with the current execution of the

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -68,8 +68,8 @@ ShadingContext::~ShadingContext ()
 
 bool
 ShadingContext::execute_init(ShaderGroup& sgroup, int shadeindex,
-                             ShaderGlobals& ssg, void* output_base_ptr,
-                             bool run)
+                             ShaderGlobals& ssg, void* userdata_base_ptr,
+                             void* output_base_ptr, bool run)
 {
     if (m_group)
         execute_cleanup ();
@@ -125,7 +125,8 @@ ShadingContext::execute_init(ShaderGroup& sgroup, int shadeindex,
         ssg.context = this;
         ssg.renderer = renderer();
         ssg.Ci = NULL;
-        run_func (&ssg, m_heap.get(), output_base_ptr, shadeindex);
+        run_func (&ssg, m_heap.get(), userdata_base_ptr, output_base_ptr,
+                  shadeindex);
     }
 
     if (profile)
@@ -137,7 +138,8 @@ ShadingContext::execute_init(ShaderGroup& sgroup, int shadeindex,
 
 bool
 ShadingContext::execute_layer(int shadeindex, ShaderGlobals& ssg,
-                              void* output_base_ptr, int layernumber)
+                              void* userdata_base_ptr, void* output_base_ptr,
+                              int layernumber)
 {
     if (!group() || group()->nlayers() == 0 || group()->does_nothing())
         return false;
@@ -150,7 +152,8 @@ ShadingContext::execute_layer(int shadeindex, ShaderGlobals& ssg,
     if (! run_func)
         return false;
 
-    run_func (&ssg, m_heap.get(), output_base_ptr, shadeindex);
+    run_func (&ssg, m_heap.get(), userdata_base_ptr, output_base_ptr,
+              shadeindex);
 
     if (profile)
         m_ticks += timer.ticks();
@@ -187,7 +190,8 @@ ShadingContext::execute_cleanup ()
 
 bool
 ShadingContext::execute (ShaderGroup &sgroup, int shadeindex,
-                         ShaderGlobals &ssg, void* output_base_ptr, bool run)
+                         ShaderGlobals &ssg, void* userdata_base_ptr,
+                         void* output_base_ptr, bool run)
 {
     int n = sgroup.m_exec_repeat;
     Vec3 Psave, Nsave;   // for repeats
@@ -203,10 +207,11 @@ ShadingContext::execute (ShaderGroup &sgroup, int shadeindex,
 
     bool result = true;
     while (1) {
-        if (! execute_init (sgroup, shadeindex, ssg, output_base_ptr, run))
+        if (! execute_init (sgroup, shadeindex, ssg, userdata_base_ptr,
+                            output_base_ptr, run))
             return false;
         if (run && n)
-            execute_layer (shadeindex, ssg, output_base_ptr,
+            execute_layer (shadeindex, ssg, userdata_base_ptr, output_base_ptr,
                            group()->nlayers() - 1);
         result = execute_cleanup ();
         if (--n < 1)

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -115,14 +115,16 @@ BackendLLVM::llvm_call_layer (int layer, bool unconditional)
 {
     // Make code that looks like:
     //     if (! groupdata->run[parentlayer])
-    //         parent_layer (sg, groupdata, output_base_ptr, shadeindex);
+    //         parent_layer (sg, groupdata, userdata_base_ptr,
+    //                       output_base_ptr, shadeindex);
     // if it's a conditional call, or
-    //     parent_layer (sg, groupdata, output_base_ptr, shadeindex);
+    //     parent_layer (sg, groupdata, userdata_base_ptr,
+    //                   output_base_ptr, shadeindex);
     // if it's run unconditionally.
     // The code in the parent layer itself will set its 'executed' flag.
 
-    llvm::Value *args[] = { sg_ptr(), groupdata_ptr(), output_base_ptr(),
-                            shadeindex() };
+    llvm::Value *args[] = { sg_ptr(), groupdata_ptr(), userdata_base_ptr(),
+                            output_base_ptr(), shadeindex() };
 
     ShaderInstance *parent = group()[layer];
     llvm::Value *trueval = ll.constant_bool(true);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -250,10 +250,11 @@ ShadingSystem::release_context (ShadingContext *ctx)
 
 bool
 ShadingSystem::execute(ShadingContext& ctx, ShaderGroup& group, int index,
-                       ShaderGlobals& globals, void* output_base_ptr,
-                       bool run)
+                       ShaderGlobals& globals, void* userdata_base_ptr,
+                       void* output_base_ptr, bool run)
 {
-    return m_impl->execute (ctx, group, index, globals, output_base_ptr, run);
+    return m_impl->execute (ctx, group, index, globals, userdata_base_ptr,
+                            output_base_ptr, run);
 }
 
 
@@ -261,31 +262,35 @@ ShadingSystem::execute(ShadingContext& ctx, ShaderGroup& group, int index,
 bool
 ShadingSystem::execute_init(ShadingContext& ctx, ShaderGroup& group,
                             int index, ShaderGlobals& globals,
-                            void* output_base_ptr, bool run)
+                            void* userdata_base_ptr, void* output_base_ptr,
+                            bool run)
 {
-    return ctx.execute_init(group, index, globals, output_base_ptr, run);
+    return ctx.execute_init(group, index, globals, userdata_base_ptr,
+                            output_base_ptr, run);
 }
 
 
 
 bool
 ShadingSystem::execute_layer(ShadingContext& ctx, int index,
-                             ShaderGlobals& globals,
+                             ShaderGlobals& globals, void* userdata_base_ptr,
                              void* output_base_ptr, int layernumber)
 {
-    return ctx.execute_layer (index, globals, output_base_ptr, layernumber);
+    return ctx.execute_layer (index, globals, userdata_base_ptr,
+                              output_base_ptr, layernumber);
 }
 
 
 
 bool
 ShadingSystem::execute_layer(ShadingContext &ctx, int index,
-                             ShaderGlobals &globals, void* output_base_ptr,
-                             ustring layername)
+                             ShaderGlobals &globals, void* userdata_base_ptr,
+                             void* output_base_ptr, ustring layername)
 {
     int layernumber = find_layer (*ctx.group(), layername);
     return layernumber >= 0
-        ? ctx.execute_layer (index, globals, output_base_ptr, layernumber)
+        ? ctx.execute_layer (index, globals, userdata_base_ptr,
+                             output_base_ptr, layernumber)
         : false;
 }
 
@@ -293,15 +298,16 @@ ShadingSystem::execute_layer(ShadingContext &ctx, int index,
 
 bool
 ShadingSystem::execute_layer(ShadingContext& ctx, int index,
-                             ShaderGlobals& globals, void* output_base_ptr,
-                             const ShaderSymbol* symbol)
+                             ShaderGlobals& globals, void* userdata_base_ptr,
+                             void* output_base_ptr, const ShaderSymbol* symbol)
 {
     if (! symbol)
         return false;
     const Symbol *sym = reinterpret_cast<const Symbol *>(symbol);
     int layernumber = sym->layer();
     return layernumber >= 0
-        ? ctx.execute_layer (index, globals, output_base_ptr, layernumber)
+        ? ctx.execute_layer (index, globals, userdata_base_ptr,
+                             output_base_ptr, layernumber)
         : false;
 }
 
@@ -3041,9 +3047,11 @@ ShadingSystemImpl::release_context (ShadingContext *ctx)
 bool
 ShadingSystemImpl::execute(ShadingContext& ctx, ShaderGroup& group,
                            int index, ShaderGlobals& ssg,
-                           void* output_base_ptr, bool run)
+                           void* userdata_base_ptr, void* output_base_ptr,
+                           bool run)
 {
-    return ctx.execute(group, index, ssg, output_base_ptr, run);
+    return ctx.execute(group, index, ssg, userdata_base_ptr, output_base_ptr,
+                       run);
 }
 
 

--- a/src/testrender/cuda/wrapper.cu
+++ b/src/testrender/cuda/wrapper.cu
@@ -43,8 +43,8 @@ rtDeclareVariable (float,      t_hit,        rtIntersectionDistance, );
 rtBuffer<float3,2> output_buffer;
 
 // Function pointers for the OSL shader
-rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, int)>, osl_init_func, , );
-rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, int)>, osl_group_func, ,);
+rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, void*, int)>, osl_init_func, , );
+rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, void*, int)>, osl_group_func, ,);
 
 RT_PROGRAM void any_hit_shadow()
 {
@@ -373,8 +373,8 @@ extern "C" __global__  void __closesthit__closest_hit_osl()
     // Run the OSL group and init functions
     const unsigned int shaderInitOpIdx = 2u + 2u * sg.shaderID + 0u;
     const unsigned int shaderGroupIdx  = 2u + 2u * sg.shaderID + 1u;
-    optixDirectCall<void, ShaderGlobals*, void *, void*, int>(shaderInitOpIdx, &sg, params, nullptr, 0); // call osl_init_func
-    optixDirectCall<void, ShaderGlobals*, void *, void*, int>(shaderGroupIdx , &sg, params, nullptr, 0); // call osl_group_func
+    optixDirectCall<void, ShaderGlobals*, void *, void*, void*, int>(shaderInitOpIdx, &sg, params, nullptr, nullptr, 0); // call osl_init_func
+    optixDirectCall<void, ShaderGlobals*, void *, void*, void*, int>(shaderGroupIdx , &sg, params, nullptr, nullptr, 0); // call osl_group_func
 
     float3 result = process_closure ((OSL::ClosureColor*) sg.Ci);
     uint3 launch_dims  = optixGetLaunchDimensions();

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -30,8 +30,8 @@ rtDeclareVariable (int,   flipv, , );
 // Buffers
 rtBuffer<float3,2> output_buffer;
 
-rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, int)>, osl_init_func, , );
-rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, int)>, osl_group_func, ,);
+rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, void*, int)>, osl_init_func, , );
+rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, void*, int)>, osl_group_func, ,);
 
 RT_PROGRAM void raygen()
 {
@@ -188,8 +188,8 @@ extern "C" __global__ void __raygen__()
     sg.renderstate = &closure_pool[0];
 
     // Run the OSL group and init functions
-    optixDirectCall<void, ShaderGlobals*, void *, void*, int>(0u, &sg, params, nullptr, 0); // call osl_init_func
-    optixDirectCall<void, ShaderGlobals*, void *, void*, int>(1u, &sg, params, nullptr, 0); // call osl_group_func
+    optixDirectCall<void, ShaderGlobals*, void *, void*, void*, int>(0u, &sg, params, nullptr, nullptr, 0); // call osl_init_func
+    optixDirectCall<void, ShaderGlobals*, void *, void*, void*, int>(1u, &sg, params, nullptr, nullptr, 0); // call osl_group_func
 
     float* f_output = (float*)params;
     int pixel = launch_index.y * launch_dims.x + launch_index.x;

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -105,6 +105,7 @@ static float uoffset = 0, voffset = 0;
 static std::vector<const char*> shader_setup_args;
 static std::string localename = OIIO::Sysutil::getenv("TESTSHADE_LOCALE");
 static OIIO::ParamValueList userdata;
+static char* userdata_base_ptr = nullptr;
 static char* output_base_ptr = nullptr;
 
 
@@ -1362,20 +1363,26 @@ shade_region (SimpleRenderer *rend, ShaderGroup *shadergroup,
             if (entrylayer_index.empty()) {
                 // Sole entry point for whole group, default behavior
                 shadingsys->execute (*ctx, *shadergroup, shadeindex,
-                                     shaderglobals, output_base_ptr);
+                                     shaderglobals, userdata_base_ptr,
+                                     output_base_ptr);
             } else {
                 // Explicit list of entries to call in order
                 shadingsys->execute_init (*ctx, *shadergroup, shadeindex,
-                                          shaderglobals, output_base_ptr);
+                                          shaderglobals, userdata_base_ptr,
+                                          output_base_ptr);
                 if (entrylayer_symbols.size()) {
                     for (size_t i = 0, e = entrylayer_symbols.size(); i < e; ++i)
                         shadingsys->execute_layer (*ctx, shadeindex,
-                                                   shaderglobals, output_base_ptr,
+                                                   shaderglobals,
+                                                   userdata_base_ptr,
+                                                   output_base_ptr,
                                                    entrylayer_symbols[i]);
                 } else {
                     for (size_t i = 0, e = entrylayer_index.size(); i < e; ++i)
                         shadingsys->execute_layer (*ctx, shadeindex,
-                                                   shaderglobals, output_base_ptr,
+                                                   shaderglobals,
+                                                   userdata_base_ptr,
+                                                   output_base_ptr,
                                                    entrylayer_index[i]);
                 }
                 shadingsys->execute_cleanup (*ctx);


### PR DESCRIPTION
This is analogous to the "output placement" that we added recently, but
for input of userdata.

Reminder: "userdata" means shader parameters marked as lockgeom=0 that
are expected to be supplied on a per-shade basis, such as interpolated
vertex data on geometric primitives. The primitive data binds by name to
matching shader parameters.

This patch concerns how the shader gets this per-point data.

Old school: in the middle of the shader, when userdata is needed, the
shader calls osl_bind_interpolated_param(), which makes a callback to
RendererServices::get_userdata(), which... does something magical and
renderer-specific to retrieve the data by name.  This is expensive and
also challenging to implement on the GPU (which is why it remains
unimplemented).

This patch changes the methodology to the following, which is somewhat
analogous to how we did output placement:

0. It is assumed that there is an arena of memory where the userdata
   is going to be, and the pointer to its start is passed down to the
   shader via execute() (just like how the shaderglobals and output
   arena pointers are passed), along with an index of the current
   shade point.

1. The renderer pre-declares SymLocationDesc records for the userdata,
   which specifies the offsets and strides within the arena where the
   data can be found.

2. Prior to launching the shader execute(), the renderer is expected
   fill in those values in the userdata arena for the points to be
   shaded.

3. When JITing the part of the shader that initializes those userdata
   parameter values, we simply JIT a simple data copy directly from
   the computed position within the arena (offsetting the right amount
   for this data, at this shade index) -- just a couple of
   instructions per shade, no function calls, no RendererServices
   callbacks, no name lookups!

4. There is no 4. That's it.

See the changes to osldeformer.cpp for an example of how this looks from
the renderer side. It's really straightforward.

Currently, if there is no SymLocationDesc for a lockgeom=0 parameter
that needs initialization, it will fall back to the old callback. We
may fully deprecate the old way, but not for a while, so this is back
compatible for now.

This seems to work, passes all tests, doesn't break anything, and works
for the osldeformer example!

There is follow-up work to do: I think we can pretty easily do the
same thing for ShaderGlobals ("make your own SG struct"), named marix
retrieval, and other attributes. Will do those in subsequent PRs if
this meets everybody's approval.

Signed-off-by: Larry Gritz <lg@larrygritz.com>