### PR TITLE
Add include to prepare for upcoming OIIO change

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -16,6 +16,7 @@
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/imagebufalgo_util.h>
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/sysutil.h>


### PR DESCRIPTION
OIIO 2.3 will rearrange some header files slightly. If you need to use
ImageCache, you must include imagecache.h (duh!). We were accidentally
relying on some leaked definitions in other header files, which will
soon be removed.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
