### PR TITLE
Test: don't clobber LD_LIBRARY_PATH for optix tests

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -68,7 +68,7 @@ macro (add_one_testsuite testname testsrcdir)
         set_tests_properties (${testname} PROPERTIES LABELS optix)
         if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "10.0")
             # Make sure libnvrtc-builtins.so is reachable
-            set_property (TEST ${testname} APPEND PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64)
+            set_property (TEST ${testname} APPEND PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64:$ENV{LD_LIBRARY_PATH})
         endif()
     endif ()
 endmacro ()


### PR DESCRIPTION
Well intentioned attempt to ensure that Cuda runtime library was in
the library path when tests were run, but it clobbered the existing
LD_LIBRARY_PATH.
