### PR TITLE
PR/NoFMAforNonAffineInverse

### DIFF
--- a/src/include/OSL/Imathx/Imathx.h
+++ b/src/include/OSL/Imathx/Imathx.h
@@ -244,17 +244,14 @@ affineInverse(const Matrix44 &m)
 // match results between LLVM IR based implementation and
 // compiler optimized versions which may have optimized
 // differently than the LLVM IR version.
-// Clang doesn't currently have a way to control fast-math/fp:strict
-// at a per function level, so we will resort to disabling optimization
-// for this function.  Not ideal, but this is already a slow path
-// for exceptional situations.
 // NOTE:  only using "inline" to get ODR (One Definition Rule) behavior
-static inline OSL_HOSTDEVICE Matrix44 OSL_GNUC_ATTRIBUTE(optimize("O0"))
-nonAffineInverse(const Matrix44 &source) OSL_CLANG_ATTRIBUTE(optnone);
+static inline OSL_HOSTDEVICE Matrix44 OSL_GNUC_ATTRIBUTE(optimize("fp-contract=off"))
+nonAffineInverse(const Matrix44 &source);
 
 Matrix44 OSL_HOSTDEVICE nonAffineInverse(const Matrix44 &source)
 {
     OSL_INTEL_PRAGMA(float_control(strict,on,push))
+    OSL_CLANG_PRAGMA(clang fp contract(off))
 
 	using ScalarT = typename Matrix44::BaseType;
     Matrix44 t(source);


### PR DESCRIPTION
## Description

Removed clang and gcc attributes that disabled optimizations for nonAffineInverse.

Added clang pragma and gcc attribute to disable Fused Multiply Add for nonAffineInverse to allow offline compilers to produce results closer to those of LLVM IR compilation (which has FMA disabled by default) which produced the reference images of the testsuite.

## Checklist:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

