### PR TITLE
fix problem with unresolved symbols when multiple shaders call certain

### DIFF
--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -563,11 +563,11 @@ ColorSystem::set_colorspace (StringParam colorspace)
 // For Optix, this will be defined by the renderer. Otherwise inline a getter.
 #ifdef __CUDACC__
     extern "C"  __device__
-    void osl_printf (void* sg_, char* fmt_str, void* args) __attribute__((weak));
+    void osl_printf (void* sg_, char* fmt_str, void* args);
 
     extern "C" __device__ int
     rend_get_userdata (StringParam name, void* data, int data_size,
-                       const OSL::TypeDesc& type, int index) __attribute__((weak));
+                       const OSL::TypeDesc& type, int index);
 
     OSL_HOSTDEVICE void
     ColorSystem::error(StringParam src, StringParam dst, Context sg) {


### PR DESCRIPTION
functions on the GPU (ie. osl_printf()).


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

