### PR TITLE
Fixed an invalid memory access on GPU while trying to access to the attribute TypeDesc in osl_get_attribute

### DIFF
--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -210,7 +210,7 @@ DECL (osl_range_check, "iiiXXXiXiXX")
 DECL (osl_range_check_err, "iiiXXXiXiXX")
 DECL (osl_naninf_check, "xiXiXXiXiiX")
 DECL (osl_uninit_check, "xLXXXiXiXXiXiXii")
-DECL (osl_get_attribute, "iXiXXiiXX")
+DECL (osl_get_attribute, "iXiXXiiLX")
 DECL (osl_bind_interpolated_param, "iXXLiXiXiXi")
 DECL (osl_get_texture_options, "XX");
 DECL (osl_get_noise_options, "XX");

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2976,7 +2976,7 @@ LLVMGEN (llvm_gen_getattribute)
     // We'll pass the destination's attribute type directly to the 
     // RenderServices callback so that the renderer can perform any
     // necessary conversions from its internal format to OSL's.
-    const TypeDesc* dest_type = &Destination.typespec().simpletype();
+    TypeDesc dest_type = Destination.typespec().simpletype();
 
     llvm::Value * args[] = {
             rop.sg_void_ptr(),
@@ -2985,7 +2985,7 @@ LLVMGEN (llvm_gen_getattribute)
             rop.llvm_load_value (Attribute),
             rop.ll.constant ((int)array_lookup),
             rop.llvm_load_value (Index),
-            rop.ll.constant_ptr ((void *) dest_type),
+            rop.ll.constant (dest_type),
             rop.llvm_void_ptr (Destination),
     };
     llvm::Value *r = rop.ll.call_function ("osl_get_attribute", args);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -4189,7 +4189,7 @@ OSL_SHADEOP int osl_get_attribute(void *sg_,
                              void *attr_name_,
                              int   array_lookup,
                              int   index,
-                             const void *attr_type,
+                             long long attr_type,
                              void *attr_dest)
 {
     ShaderGlobals *sg   = (ShaderGlobals *)sg_;
@@ -4199,7 +4199,7 @@ OSL_SHADEOP int osl_get_attribute(void *sg_,
     return sg->context->osl_get_attribute (sg, sg->objdata,
                                            dest_derivs, obj_name, attr_name,
                                            array_lookup, index,
-                                           *(const TypeDesc *)attr_type,
+                                           TYPEDESC(attr_type),
                                            attr_dest);
 }
 


### PR DESCRIPTION
Changed the prototype of osl_get_attribute callback in liboslexec in
order it takes a copy of the attribute TypeDesc casted into a long long
instead of taking a pointer to it. This allows to make it work properly
on GPU else we have an invalid pointer.


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

