### PR TITLE
Removing race condition when compiling for OptiX 7

### DIFF
--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -10,7 +10,8 @@ if (USE_OPTIX)
          cuda/quad.cu
          cuda/optix_raytracer.cu
          cuda/sphere.cu
-         cuda/wrapper.cu )
+         cuda/wrapper.cu
+         cuda/rend_lib.cu )
     set (testrender_cuda_headers
          cuda/rend_lib.h )
 

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -432,6 +432,9 @@ static inline size_t alignment_offset_calc (void* ptr, size_t alignment)
 // These functions are declared extern to prevent name mangling.
 extern "C" {
 
+    // add OptiX entry point to prevent OptiX from discarding the module
+   __global__ void __direct_callable__dummy_rend_lib() { }
+
     __device__
     void* closure_component_allot (void* pool, int id, size_t prim_size, const OSL::Color3& w)
     {

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -32,7 +32,8 @@ endif ()
 if (USE_OPTIX)
     set ( testshade_cuda_srcs
         cuda/optix_grid_renderer.cu
-        ../testrender/cuda/wrapper.cu )
+        ../testrender/cuda/wrapper.cu
+        ../testrender/cuda/rend_lib.cu )
     set ( testshade_cuda_headers
         ../testrender/cuda/rend_lib.h )
 


### PR DESCRIPTION

## Description

This removes a race condition when compiling PTX device code in a multithreaded environment.

The problems stems from OptiX6 requiring the `rend_lib.cu` device bitcode to be linked to each compiled shadergroup whereas we only need to link the `rend_lib.cu` device bitcode to one shadergroup in OptiX7.  When I added OptiX7 support, I put a static/global in OSL to ensure that we don't get multiple definitions from `rend_lib.cu` in the device code for OptiX7.  But that's a poor solution for a couple of reasons:
- it's not thread-safe
- it doesn't support recompiling shaders in an interactive environment.

This removes the requirement to supply the `rend_lib.cu` device code when using OptiX7.  But that also means  the renderer now needs to manually link it in.  Both `testshade` and `testrender` have been updated to reflect this.

## Tests

testsuite runs the same with this fix

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

