### PR TITLE
Fix compatibility with LLVM 12 and up

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1407,7 +1407,9 @@ LLVM_Util::make_jit_execengine (std::string *err,
 
     options.NoZerosInBSS = false;
     options.GuaranteedTailCallOpt = false;
+#if OSL_LLVM_VERSION < 120
     options.StackAlignmentOverride = 0;
+#endif
     options.FunctionSections = true;
     options.UseInitArray = false;
     options.FloatABIType = llvm::FloatABI::Default;
@@ -5385,7 +5387,7 @@ void
 LLVM_Util::write_bitcode_file (const char *filename, std::string *err)
 {
     std::error_code local_error;
-    llvm::raw_fd_ostream out (filename, local_error, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream out (filename, local_error, llvm::sys::fs::OF_None);
     if (! out.has_error()) {
         llvm::WriteBitcodeToFile (*module(), out);
         if (err && local_error)
@@ -5447,7 +5449,9 @@ LLVM_Util::ptx_compile_group (llvm::Module* lib_module, const std::string& name,
     options.AllowFPOpFusion                        = llvm::FPOpFusion::Fast;
     options.NoZerosInBSS                           = 0;
     options.GuaranteedTailCallOpt                  = 0;
+#if OSL_LLVM_VERSION < 120
     options.StackAlignmentOverride                 = 0;
+#endif
     options.UseInitArray                           = 0;
 
     llvm::TargetMachine* target_machine = llvm_target->createTargetMachine(


### PR DESCRIPTION
## Description
This pull request addresses a compatibility with LLVM 12 due to the change within [LLVM itself](https://reviews.llvm.org/D101650). Additionally, this also fix the merge from release to master on #1402 

## Tests
N/A See https://reviews.llvm.org/D101650


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

