### PR TITLE
Fix oslc missing a write error on function parameter

### DIFF
--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -1003,8 +1003,10 @@ const char* ASTcompound_initializer::childname(size_t /*i*/) const
 
 
 bool
-ASTNode::check_symbol_writeability(ASTNode* var)
+ASTNode::check_symbol_writeability(ASTNode* var, bool quiet, Symbol** dest_sym)
 {
+    if (dest_sym)
+        *dest_sym = nullptr;
     if (var->nodetype() == index_node)
         return check_symbol_writeability(
             static_cast<ASTindex*>(var)->lvalue().get());
@@ -1019,9 +1021,12 @@ ASTNode::check_symbol_writeability(ASTNode* var)
         dest = static_cast<ASTvariable_declaration*>(var)->sym();
 
     if (dest) {
+        if (dest_sym)
+            *dest_sym = dest;
         if (dest->readonly()) {
-            warningf("cannot write to non-output parameter \"%s\"",
-                     dest->name());
+            if (!quiet)
+                warningf("cannot write to non-output parameter \"%s\"",
+                         dest->name());
             // Note: Consider it only a warning to write to a non-output
             // parameter. Users who want it to be a hard error can use
             // -Werror. Writing to any other readonly symbols is a full

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -387,10 +387,14 @@ protected:
     Symbol* codegen_aassign(TypeSpec elemtype, Symbol* src, Symbol* lval,
                             Symbol* index, int i = 0);
 
-    // Check whether the node's symbol destination is ok to write. Return
-    // true if ok, return false and issue error or warning if not. (Used to
-    // check for writing to read-only variables like non-output parameters.)
-    bool check_symbol_writeability(ASTNode* var);
+    // Check whether the node's symbol destination is ok to write. Return true
+    // if ok, return false and issue error or warning if not. If `quiet` is
+    // true, do not actually issue the error/warning, leave it to the caller.
+    // If `dest_sym` is non-null, store in it the `Symbol*` of the destination
+    // symbol designated. This method is used to check for writing to
+    // read-only variables like non-output parameters.
+    bool check_symbol_writeability(ASTNode* var, bool quiet = false,
+                                   Symbol** dest_sym = nullptr);
 
     // Helper for param_default_literals: generate the string that gives
     // the initialization of the literal value (and/or the default, if

--- a/testsuite/oslc-err-write-nonoutput/ref/out.txt
+++ b/testsuite/oslc-err-write-nonoutput/ref/out.txt
@@ -2,5 +2,6 @@ test.osl:8: error: cannot write to non-output parameter "x"
 test.osl:9: error: cannot write to non-output parameter "x"
 test.osl:10: error: cannot write to non-output parameter "i"
 test.osl:11: error: cannot write to non-output parameter "i"
-test.osl:24: error: cannot write to non-output parameter "u"
+test.osl:22: error: cannot write to non-output parameter "a", as passed to function g() as arg 1 (output parameter "b")
+test.osl:35: error: cannot write to non-output parameter "u"
 FAILED test.osl

--- a/testsuite/oslc-err-write-nonoutput/test.osl
+++ b/testsuite/oslc-err-write-nonoutput/test.osl
@@ -13,6 +13,17 @@ float func (float x, int i)
 }
 
 
+
+void g(output float b) {
+    b = 1;  // ok, since b is marked as output
+}
+
+void f(float a) {
+    g(a);  // <--- should be disallowed, a is not output, but the arg of g() is output
+}
+
+
+
 shader test ()
 {
     float y = 1;
@@ -22,4 +33,7 @@ shader test ()
 
     // Try writing to non-writeable global
     u = 0;
+
+    // Try transitive write through f and g -- this used to be a missed error
+    f(y);
 }


### PR DESCRIPTION
Fixes #1416

In OSL, function parameters must be marked as `output` or they are not
supposed to be writable. In issuing errors when a write is performed on
something not writable, we missed an interesting case:

```
void g(output float b) {
    b = 1;  // ok, since b is marked as output
}

void f(float a) {
    g(a);  // <--- should be disallowed, g is writing to f's non-output param
}

float x;
f(x);
```

This patch catches cases like these. The new error looks like this:

`test.osl:22: error: cannot write to non-output parameter "a", as passed to function g() as arg 1 (output parameter "b")`

Signed-off-by: Larry Gritz <lg@larrygritz.com>

