### PR TITLE
Minor docs changes for changing master branch name to main

### DIFF
--- a/ASWF/Technical-Charter.md
+++ b/ASWF/Technical-Charter.md
@@ -200,7 +200,7 @@ must comply with the terms of this Charter.
 
     - **i.** All new inbound code contributions to the Project must be made
       using the BSD 3-Clause License (available here:
-      https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/master/LICENSE)
+      https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/LICENSE.md)
       (the "Project License").
 
     - **ii.** All new inbound code contributions must:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/master/src/doc/Figures/osl-short.png" width=256 height=128>
+  <img src="https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/src/doc/Figures/osl-short.png" width=256 height=128>
 
   <H1>Open Shading Language</H1>
 </div>
@@ -435,10 +435,10 @@ Contacts, Links, and References
 
 [Read or subscribe to the OSL development mail list](https://lists.aswf.io/g/osl-dev)
 
-[Most recent PDF of the OSL language specification](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/master/src/doc/osl-languagespec.pdf
+[Most recent PDF of the OSL language specification](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/src/doc/osl-languagespec.pdf
 )
 
-[OSL home page at SPI](http://openshadinglanguage.org)
+[OSL home page](http://openshadinglanguage.org)
 
 [Sony Pictures Imageworks main open source page](http://opensource.imageworks.com)
 

--- a/src/cmake/check_is_enabled.cmake
+++ b/src/cmake/check_is_enabled.cmake
@@ -1,6 +1,6 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the Open Shading Language project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 # Is the named package "enabled" via our disabling convention? If either
 # USE_pkgname (or the all-uppercase USE_PKGNAME, or ENABLE_pkgname, or

--- a/src/cmake/colors.cmake
+++ b/src/cmake/colors.cmake
@@ -1,6 +1,6 @@
-# Copyright 2008-present Contributors to the OpenImageIO project.
+# Copyright Contributors to the Open Shading Language project.
 # SPDX-License-Identifier: BSD-3-Clause
-# https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 
 # Define color codes for pretty terminal output


### PR DESCRIPTION
Renaming the master branch to main is imminent. Here are the few
places where we refer directly to branch names that will no longer
exist.

While searching for "master/", I also noticed a couple files that
had the wrong project's copyright boilerplate on it (a lot of the
cmake scripts I write and submit to both projects simultaneously).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
