### PR TITLE
Fix minor CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,7 @@ jobs:
       OPENIMAGEIO_VERSION: master
       PYBIND11_VERSION: v2.6.2
       USE_BATCHED: b8_AVX2,b8_AVX512,b16_AVX512
+      USE_OPENVDB: 0
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp

--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -13,7 +13,7 @@ $OSL_ROOT/bin/testshade --help
 echo "Parallel test " ${CTEST_PARALLEL_LEVEL}
 pushd build
 time ctest -C ${CMAKE_BUILD_TYPE} -E broken --force-new-ctest-process \
-    --output-on-failure --timeout ${CTEST_TEST_TIMEOUT:=240} ${CTEST_ARGS}
+    --output-on-failure --timeout ${CTEST_TEST_TIMEOUT:=300} ${CTEST_ARGS}
 popd
 
 


### PR DESCRIPTION
* Increase testing timeout, some of the batch shading regression tests
  seem to take longer than the prior 240s limit.

* Turn off OpenVDB when using the osl:2021 in combination with OpenEXR
  3.x -- the version of OpenVDB in the 2021 container is too old to
  understand OpenEXR 3.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
