### PR TITLE
Testing: Adjust timeout strategy

### DIFF
--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -13,7 +13,7 @@ $OSL_ROOT/bin/testshade --help
 echo "Parallel test " ${CTEST_PARALLEL_LEVEL}
 pushd build
 time ctest -C ${CMAKE_BUILD_TYPE} -E broken --force-new-ctest-process \
-    --output-on-failure --timeout ${CTEST_TEST_TIMEOUT:=300} ${CTEST_ARGS}
+    --output-on-failure --timeout ${CTEST_TEST_TIMEOUT:=60} ${CTEST_ARGS}
 popd
 
 

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -53,7 +53,8 @@ macro (add_one_testsuite testname testsrcdir)
     # from piling up together, allocate a few cores each.
     if (${testname} MATCHES "^render-")
         set_tests_properties (${testname} PROPERTIES LABELS render
-                              PROCESSORS 4 COST 10)
+                              TIMEOUT 240
+                              PROCESSORS 4 COST 10 TIMEOUT 240)
     endif ()
     # Some labeling for fun
     if (${testname} MATCHES "^texture")
@@ -70,6 +71,12 @@ macro (add_one_testsuite testname testsrcdir)
             # Make sure libnvrtc-builtins.so is reachable
             set_property (TEST ${testname} APPEND PROPERTY ENVIRONMENT LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64:$ENV{LD_LIBRARY_PATH})
         endif()
+    endif ()
+    if (${testname} MATCHES "-reg")
+        # These are batched shading regression tests. Some are quite
+        # long, so give them a higher cost and timeout.
+        set_tests_properties (${testname} PROPERTIES LABELS batchregression
+                              COST 15 TIMEOUT 300)
     endif ()
 endmacro ()
 


### PR DESCRIPTION
I recently bumped the ctest per-test timeout to 300s because one of the
batched shading regression tests was occasionally taking longer than the
prior limit of 240s.

But there is a better way: Individual tests can have their timeouts
set individually via set_tests_properties(TIMEOUT), so I raised the
timeout to 300s for all tests whose names contain "-reg", also kept it
rather long (the old 240s) for the long render tests that are all named
"render-". Then for everything else, we can actually lower the default
to 60s, since no other tests should be long-running.

(For the curious, the reason these batched regression tests are so
expensive is that they test a bunch of combinations, and they first
run the test in the non-batch scalar mode, then again in batched mode,
and compare the results to ensure that the batch code never deviates
from scalar. This makes them take at least twice as long as they
ordinarily would. But also remember that these are only run for the
few CI test matrix entries where we are specifically testing batch
shading.)

Signed-off-by: Larry Gritz <lg@larrygritz.com>
