### PR TITLE
Use a project-specific var for whether we're running in CI

### DIFF
--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -33,7 +33,7 @@ export PYTHONPATH=$OSL_ROOT/lib/python${PYTHON_VERSION}/site-packages:$PYTHONPAT
 export BUILD_MISSING_DEPS=${BUILD_MISSING_DEPS:=1}
 export COMPILER=${COMPILER:=gcc}
 export CXX=${CXX:=g++}
-export CI=true
+export OSL_CI=true
 export USE_NINJA=${USE_NINJA:=1}
 export CMAKE_GENERATOR=${CMAKE_GENERATOR:=Ninja}
 export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release}

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -80,14 +80,18 @@ endif ()
 ###########################################################################
 # Turn on more detailed warnings and optionally consider warnings as errors
 #
-option (STOP_ON_WARNING "Stop building if there are any compiler warnings" ON)
+if (${PROJECT_NAME}_SUPPORTED_RELEASE)
+    option (STOP_ON_WARNING "Stop building if there are any compiler warnings" OFF)
+else ()
+    option (STOP_ON_WARNING "Stop building if there are any compiler warnings" ON)
+endif()
 option (EXTRA_WARNINGS "Enable lots of extra pedantic warnings" OFF)
 if (NOT MSVC)
     add_compile_options ("-Wall")
     if (EXTRA_WARNINGS)
         add_compile_options ("-Wextra")
     endif ()
-    if (STOP_ON_WARNING OR DEFINED ENV{CI})
+    if (STOP_ON_WARNING OR DEFINED ENV{${PROJECT_NAME}_CI})
         add_compile_options ("-Werror")
         # N.B. Force CI builds to use -Werror, even if STOP_ON_WARNING has
         # been switched off by default, which we may do in release branches.
@@ -563,9 +567,10 @@ endif ()
 
 ###########################################################################
 # Any extra logic to be run only for CI builds goes here.
+# We expect our own CI runs to define env variable ${PROJECT_NAME}_CI
 #
-if (DEFINED ENV{CI} OR DEFINED ENV{GITHUB_ACTIONS})
-    add_definitions ("-D${PROJ_NAME}_CI=1" "-DBUILD_CI=1")
+if (DEFINED ENV{${PROJECT_NAME}_CI})
+    add_definitions (-D${PROJ_NAME}_CI=1 -DBUILD_CI=1)
     if (APPLE)
         # Keep Mono framework from being incorrectly searched for include
         # files on GitHub Actions CI.


### PR DESCRIPTION
Maybe somebody else is building this as a subproject or has a variable
called "CI"?

* For our CI runs, set an env variable "OSL_CI" (not just generic "CI").

* Default STOP_ON_WARNING to be off for supported releases, only on by
  default for main branch where we're actively developing. Because you
  want downstream users who are building supported releases to not get
  tripped up when their compiler upgrades and there's a new warning.

* Make sure STOP_ON_WARNING is true for our CI runs, even for release
  branches -- but now check OSL_CI, not CI, in case somebody else has
  set that.

Fixes #1428

Signed-off-by: Larry Gritz <lg@larrygritz.com>
