### PR TITLE
RuntimeOptimizer: Fix messages & unknown_message_sent initialization

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3053,6 +3053,11 @@ RuntimeOptimizer::run ()
         old_nops += inst()->ops().size();
     }
 
+    // Clear messages sent for the group, they will be filled in by
+    // optimize_instance().
+    m_messages_sent.clear();
+    m_unknown_message_sent = false;
+
     if (shadingsys().m_opt_merge_instances == 1)
         shadingsys().merge_instances (group());
 


### PR DESCRIPTION
Alex Wells pointed out that they were never explicitly initialized.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

