### PR TITLE
PR/BatchedMessage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,7 @@ jobs:
       PYTHON_VERSION: 3.9
       OSL_BUILD_MATERIALX: 1
       USE_BATCHED: b8_AVX2,b8_AVX512,b16_AVX512
+      CTEST_ARGS: -L message-reg
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,7 +548,7 @@ jobs:
       PYTHON_VERSION: 3.9
       OSL_BUILD_MATERIALX: 1
       USE_BATCHED: b8_AVX2,b8_AVX512,b16_AVX512
-      CTEST_ARGS: -L message-reg
+      CTEST_ARGS: -R message-reg.regress.batched.opt
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,7 +548,6 @@ jobs:
       PYTHON_VERSION: 3.9
       OSL_BUILD_MATERIALX: 1
       USE_BATCHED: b8_AVX2,b8_AVX512,b16_AVX512
-      CTEST_ARGS: -R message-reg.regress.batched.opt
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -215,7 +215,7 @@ macro (osl_add_all_tests)
                 length-reg linearstep
                 logic loop luminance-reg
                 matrix matrix-reg matrix-arithmetic-reg
-                matrix-compref-reg max-reg message
+                matrix-compref-reg max-reg message message-no-closure message-reg
                 mergeinstances-duplicate-entrylayers
                 mergeinstances-nouserdata mergeinstances-vararray
                 metadata-braces min-reg miscmath missing-shader
@@ -282,6 +282,7 @@ macro (osl_add_all_tests)
                 texture-missingalpha texture-missingcolor texture-opts-reg texture-simple
                 texture-smallderivs texture-swirl texture-udim
                 texture-width texture-withderivs texture-wrap
+                trace-reg
                 trailing-commas
                 transcendental-reg
                 transitive-assign

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -373,6 +373,15 @@ public:
         bool shade;       ///< whether to shade what is hit
         ustring traceset; ///< named trace set
         TraceOpt () : mindist(0.0f), maxdist(1.0e30), shade(false) { }
+
+        enum class LLVMMemberIndex
+        {
+            mindist = 0,
+            maxdist,
+            shade,
+            traceset,
+            count
+        };
     };
 
     /// Immediately trace a ray from P in the direction R.  Return true

--- a/src/include/OSL/wide.h
+++ b/src/include/OSL/wide.h
@@ -3206,8 +3206,7 @@ MaskedData<WidthT>::assign_from_type(void* ptr_wide_data)
 
             Masked<DataT, WidthT> wdest(bdst, mask());
 
-            // TODO: renable after issue with bleeding edge CI identified
-            // OSL_OMP_PRAGMA(omp simd simdlen(WidthT))
+            OSL_OMP_PRAGMA(omp simd simdlen(WidthT))
             for (int lane = 0; lane < WidthT; ++lane) {
                 wdest[lane] = unproxy(bsrc[lane]);
             }

--- a/src/include/OSL/wide.h
+++ b/src/include/OSL/wide.h
@@ -3206,7 +3206,8 @@ MaskedData<WidthT>::assign_from_type(void* ptr_wide_data)
 
             Masked<DataT, WidthT> wdest(bdst, mask());
 
-            OSL_OMP_PRAGMA(omp simd simdlen(WidthT))
+            // TODO: renable after issue with bleeding edge CI identified
+            // OSL_OMP_PRAGMA(omp simd simdlen(WidthT))
             for (int lane = 0; lane < WidthT; ++lane) {
                 wdest[lane] = unproxy(bsrc[lane]);
             }

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -9,6 +9,7 @@ set ( liboslexec_target_srcs
     wide/wide_opcolor
     wide/wide_opdictionary
     wide/wide_opmatrix
+    wide/wide_opmessage
     wide/wide_opnoise
     wide/wide_opnoise_cell
     wide/wide_opnoise_gabor_impl

--- a/src/liboslexec/builtindecl_wide_xmacro.h
+++ b/src/liboslexec/builtindecl_wide_xmacro.h
@@ -302,8 +302,6 @@ DECL(__OSL_MASKED_OP3(splineinverse, Wdf, f, Wdf), "xXXXXiii")
 //DECL(__OSL_MASKED_OP3(splineinverse, Wdf, Wf, Wdf), "xXXXXiii")
 
 #ifdef __OSL_TBD
-#if 0  // incomplete
-// setmessage/getmessage involve closures, leave to next iteration
 //DECL (osl_setmessage, "xXsLXisi")
 DECL (osl_pointcloud_search, "iXsXfiiXXii*")
 DECL (osl_pointcloud_get, "iXsXisLX")
@@ -312,11 +310,8 @@ DECL (osl_pointcloud_write_helper, "xXXXisLX")
 #endif
 
 DECL(__OSL_MASKED_OP(getmessage), "xXXssLXiisii")
-//DECL (osl_setmessage_uniform_name_wide_data_masked, "xXXLXisii")
-//DECL (osl_setmessage_varying_name_wide_data_masked, "xXXLXisii")
-DECL(__OSL_MASKED_OP(setmessage_uniform_name_wide_data), "xXXLXisii")
-DECL(__OSL_MASKED_OP(setmessage_varying_name_wide_data), "xXXLXisii")
-#endif
+DECL(__OSL_MASKED_OP2(setmessage, s, WX),  "xXXLXisii")
+DECL(__OSL_MASKED_OP2(setmessage, Ws, WX), "xXXLXisii")
 
 DECL(__OSL_OP(blackbody_vf), "xXXf")
 DECL(__OSL_MASKED_OP2(blackbody, Wv, Wf), "xXXXi")
@@ -624,7 +619,6 @@ DECL(__OSL_OP(resolve_udim_uniform), "XXXXff")
 DECL(__OSL_MASKED_OP(resolve_udim), "xXXXXXXi")
 DECL(__OSL_OP(get_textureinfo_uniform), "iXXXXXX")
 
-#ifdef __OSL_TBD
 // Wide Code generator will set trace options directly in LLVM IR
 // without calling helper functions
 //DECL (osl_trace_set_mindist, "xXf") // unneeded
@@ -632,7 +626,6 @@ DECL(__OSL_OP(get_textureinfo_uniform), "iXXXXXX")
 //DECL (osl_trace_set_shade, "xXi") // unneeded
 //DECL (osl_trace_set_traceset, "xXs") // unneeded
 DECL(__OSL_MASKED_OP(trace), "xXXXXXXXXXi")
-#endif // __OSL_TBD
 
 DECL(__OSL_OP(calculatenormal), "xXXX")
 DECL(__OSL_MASKED_OP(calculatenormal), "xXXXi")

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -288,8 +288,7 @@ ShadingContext::Batched<WidthT>::execute_init
 
     // Clear the message blackboard
     context().m_messages.clear ();
-    // TODO: implement batched_messages
-    //context().batched_messages(WidthOf<WidthT>()).clear ();
+    context().batched_messages_buffer().clear ();
 
     // Clear miscellaneous scratch space
     context().m_scratch_pool.clear ();

--- a/src/liboslexec/wide/wide_opmessage.cpp
+++ b/src/liboslexec/wide/wide_opmessage.cpp
@@ -48,7 +48,7 @@ struct MessageBlock {
         wsourceline;  ///< source code line that contains the call that created this message
     Mask valid_mask;           ///< which lanes of have been set
     Mask get_before_set_mask;  ///< which lanes had get called before a set, track to create errors if set is called later
-    ustring name;  ///< name of this message
+    ustring name;              ///< name of this message
     char* data;  ///< actual data of the message (will never change once the message is created)
     TypeDesc
         type;  ///< what kind of data is stored here? FIXME: should be TypeSpec
@@ -62,8 +62,7 @@ public:
         Masked<int> alayeridx(wlayeridx, lanes_to_populate);
         Masked<ustring> asourcefile(wsourcefile, lanes_to_populate);
         Masked<int> asourceline(wsourceline, lanes_to_populate);
-        // TODO: renable after issue with bleeding edge CI identified
-        // OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             alayeridx[lane]   = layeridx;
             asourcefile[lane] = sourcefile;
@@ -118,10 +117,10 @@ public:
              Mask lanes_to_populate, int layeridx, ustring sourcefile,
              int sourceline)
     {
-        constexpr size_t alignment = sizeof(float)*__OSL_WIDTH;
-        set_list_head(new (m_buffer.message_data.alloc(sizeof(MessageBlock),
-                                                       alignment))
-                          MessageBlock(name, wsrcval.type(), list_head()));
+        constexpr size_t alignment = sizeof(float) * __OSL_WIDTH;
+        set_list_head(
+            new (m_buffer.message_data.alloc(sizeof(MessageBlock), alignment))
+                MessageBlock(name, wsrcval.type(), list_head()));
         list_head()->data
             = m_buffer.message_data.alloc(wsrcval.val_size_in_bytes(),
                                           alignment);
@@ -350,8 +349,7 @@ OSL_BATCHOP void __OSL_MASKED_OP(getmessage)(
         auto missing_lanes = mask & ~m->valid_mask & ~m->get_before_set_mask;
 
         Mask lanes_set_by_deeper_layer(false);
-        // TODO: renable after issue with bleeding edge CI identified
-        // OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             int msg_layerid = msg_wlayeridx[lane];
             // NOTE: using bitwise & to avoid branches
@@ -390,8 +388,7 @@ OSL_BATCHOP void __OSL_MASKED_OP(getmessage)(
                 Masked<int> wlayeridx(m->wlayeridx, missing_lanes);
                 Masked<ustring> wsourcefile(m->wsourcefile, missing_lanes);
                 Masked<int> wsourceline(m->wsourceline, missing_lanes);
-                // TODO: renable after issue with bleeding edge CI identified
-                // OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+                OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
                 for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
                     wlayeridx[lane]   = layeridx;
                     wsourcefile[lane] = sourcefile;

--- a/src/liboslexec/wide/wide_opmessage.cpp
+++ b/src/liboslexec/wide/wide_opmessage.cpp
@@ -59,7 +59,8 @@ public:
         Masked<int> alayeridx(wlayeridx, lanes_to_populate);
         Masked<ustring> asourcefile(wsourcefile, lanes_to_populate);
         Masked<int> asourceline(wsourceline, lanes_to_populate);
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        // TODO: renable after issue with bleeding edge CI identified
+        // OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             alayeridx[lane]   = layeridx;
             asourcefile[lane] = sourcefile;
@@ -345,7 +346,8 @@ OSL_BATCHOP void __OSL_MASKED_OP(getmessage)(
         auto missing_lanes = mask & ~m->valid_mask & ~m->get_before_set_mask;
 
         Mask lanes_set_by_deeper_layer(false);
-        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        // TODO: renable after issue with bleeding edge CI identified
+        // OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
         for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
             int msg_layerid = msg_wlayeridx[lane];
             // NOTE: using bitwise & to avoid branches
@@ -384,7 +386,8 @@ OSL_BATCHOP void __OSL_MASKED_OP(getmessage)(
                 Masked<int> wlayeridx(m->wlayeridx, missing_lanes);
                 Masked<ustring> wsourcefile(m->wsourcefile, missing_lanes);
                 Masked<int> wsourceline(m->wsourceline, missing_lanes);
-                OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+                // TODO: renable after issue with bleeding edge CI identified
+                // OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
                 for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
                     wlayeridx[lane]   = layeridx;
                     wsourcefile[lane] = sourcefile;

--- a/src/liboslexec/wide/wide_opmessage.cpp
+++ b/src/liboslexec/wide/wide_opmessage.cpp
@@ -1,0 +1,441 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#include <OSL/oslconfig.h>
+
+#include <OSL/batched_rendererservices.h>
+#include <OSL/batched_shaderglobals.h>
+
+#include "oslexec_pvt.h"
+
+OSL_NAMESPACE_ENTER
+
+namespace __OSL_WIDE_PVT {
+
+OSL_USING_DATA_WIDTH(__OSL_WIDTH)
+using BatchedRendererServices = OSL::BatchedRendererServices<__OSL_WIDTH>;
+using WidthTag                = OSL::WidthOf<__OSL_WIDTH>;
+
+#include "define_opname_macros.h"
+
+struct MessageBlock {
+    MessageBlock(ustring name, const TypeDesc& type, MessageBlock* next)
+        : name(name)
+        , data(nullptr)
+        , type(type)
+        , valid_mask(false)
+        , get_before_set_mask(false)
+        , next(next)
+    {
+    }
+
+    MessageBlock(const MessageBlock&) = delete;
+    MessageBlock& operator=(const MessageBlock&) = delete;
+
+    /// Some messages don't have data because getmessage() was called before setmessage
+    /// (which is flagged as an error to avoid ambiguities caused by execution order)
+    ///
+    bool has_data() const { return data != nullptr; }
+
+    ustring name;  ///< name of this message
+    char* data;  ///< actual data of the message (will never change once the message is created)
+    TypeDesc
+        type;  ///< what kind of data is stored here? FIXME: should be TypeSpec
+    Mask valid_mask;           ///< which lanes of have been set
+    Mask get_before_set_mask;  ///< which lanes had get called before a set, track to create errors if set is called later
+    Block<int> wlayeridx;  ///< layer index where this was message was created
+    Block<ustring>
+        wsourcefile;  ///< source code file that contains the call that created this message
+    Block<int>
+        wsourceline;  ///< source code line that contains the call that created this message
+    MessageBlock*
+        next;  ///< linked list of messages (managed by MessageList below)
+
+public:
+    void import_data(MaskedData wsrcval, Mask lanes_to_populate, int layeridx,
+                     ustring sourcefile, int sourceline)
+    {
+        Masked<int> alayeridx(wlayeridx, lanes_to_populate);
+        Masked<ustring> asourcefile(wsourcefile, lanes_to_populate);
+        Masked<int> asourceline(wsourceline, lanes_to_populate);
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            alayeridx[lane]   = layeridx;
+            asourcefile[lane] = sourcefile;
+            asourceline[lane] = sourceline;
+        }
+        if (!wsrcval.valid()) {
+            // We always needed to copy the debug info (sourcefile, line, layer)
+            // but we may not have any data to copy
+            get_before_set_mask |= lanes_to_populate;
+            return;
+        }
+        valid_mask |= lanes_to_populate;
+
+        MaskedData dest(wsrcval.type(), /*has_derivs=*/false, lanes_to_populate,
+                        data);
+        dest.assign_from(wsrcval.ptr());
+    }
+
+    void export_data(MaskedData wdestval) { wdestval.assign_from(data); }
+};
+
+struct BatchedMessageList {
+private:
+    BatchedMessageBuffer& m_buffer;
+
+public:
+    BatchedMessageList(BatchedMessageBuffer& buffer) : m_buffer(buffer) {}
+
+    BatchedMessageList(const BatchedMessageList&) = delete;
+    BatchedMessageList& operator=(const BatchedMessageList&) = delete;
+
+    MessageBlock* list_head() const
+    {
+        return reinterpret_cast<MessageBlock*>(m_buffer.list_head);
+    }
+
+    void set_list_head(MessageBlock* new_list_head)
+    {
+        m_buffer.list_head = new_list_head;
+    }
+
+    MessageBlock* find(ustring name) const
+    {
+        for (MessageBlock* m = list_head(); m != nullptr; m = m->next)
+            if (m->name == name)
+                return m;  // name matches
+        return nullptr;    // not found
+    }
+
+
+    void add(ustring name /*varying name*/, MaskedData wsrcval,
+             Mask lanes_to_populate, int layeridx, ustring sourcefile,
+             int sourceline)
+    {
+        set_list_head(new (m_buffer.message_data.alloc(sizeof(MessageBlock)))
+                          MessageBlock(name, wsrcval.type(), list_head()));
+        list_head()->data
+            = m_buffer.message_data.alloc(wsrcval.val_size_in_bytes(),
+                                          /*alignment=*/sizeof(float)
+                                              * __OSL_WIDTH);
+        list_head()->import_data(wsrcval, lanes_to_populate, layeridx,
+                                 sourcefile, sourceline);
+    }
+};
+
+namespace {  // anonymous
+
+OSL_NOINLINE void
+impl_setmessage(BatchedShaderGlobals* bsg, ustring sourcefile, int sourceline,
+                MaskedData wsrcval, int layeridx, ustring name,
+                Mask matching_lanes)
+{
+    TypeDesc type   = wsrcval.type();
+    bool is_closure = (type.basetype
+                       == TypeDesc::UNKNOWN);  // secret code for closure
+    if (is_closure) {
+        OSL_ASSERT(0 && "Incomplete closure support for setmessage");
+    }
+
+    BatchedMessageList messages {
+        bsg->uniform.context->batched_messages_buffer()
+    };
+
+    auto* m = messages.find(name);
+    if (m != nullptr) {
+        OSL_DASSERT(m->name == name);
+        // message already exists?
+        Wide<const ustring> msg_wsourcefile(m->wsourcefile);
+        Wide<const int> msg_wsourceline(m->wsourceline);
+        OSL_ASSERT(m->has_data());
+        {
+            auto lanes_with_data = m->valid_mask & matching_lanes;
+
+            lanes_with_data.foreach ([=](ActiveLane lane) -> void {
+                ustring msg_sourcefile = msg_wsourcefile[lane];
+                int msg_sourceline     = msg_wsourceline[lane];
+
+                bsg->uniform.context->batched<__OSL_WIDTH>().errorf(
+                    lanes_with_data,
+                    "message \"%s\" already exists (created here: %s:%d)"
+                    " cannot set again from %s:%d",
+                    name.c_str(), msg_sourcefile.c_str(), msg_sourceline,
+                    sourcefile.c_str(), sourceline);
+            });
+            auto lanes_to_populate = (~m->valid_mask & matching_lanes)
+                                     & ~m->get_before_set_mask;
+            if (lanes_to_populate.any_on()) {
+                m->import_data(wsrcval, lanes_to_populate, layeridx, sourcefile,
+                               sourceline);
+            }
+        }
+        Mask lanes_that_getmessage_called_on = m->get_before_set_mask
+                                               & matching_lanes;
+        lanes_that_getmessage_called_on.foreach ([=](ActiveLane lane) -> void {
+            ustring msg_sourcefile = msg_wsourcefile[lane];
+            int msg_sourceline     = msg_wsourceline[lane];
+            bsg->uniform.context->batched<__OSL_WIDTH>().errorf(
+                Mask(Lane(lane)),
+                "message \"%s\" was queried before being set (queried here: %s:%d)"
+                " setting it now (%s:%d) would lead to inconsistent results",
+                name.c_str(), msg_sourcefile.c_str(), msg_sourceline,
+                sourcefile.c_str(), sourceline);
+        });
+    } else {
+        // The message didn't exist - create it
+        messages.add(name, wsrcval, matching_lanes, layeridx, sourcefile,
+                     sourceline);
+    }
+}
+
+}  // namespace
+
+
+OSL_BATCHOP void __OSL_MASKED_OP2(setmessage, s,
+                                  WX)(BatchedShaderGlobals* bsg_, void* wname,
+                                      long long type, void* wvalue,
+                                      int layeridx, const char* sourcefile_,
+                                      int sourceline, unsigned int mask_value)
+{
+    Mask mask(mask_value);
+    OSL_ASSERT(mask.any_on());
+
+    ustring name = USTR(wname);
+    MaskedData wsrcval(TYPEDESC(type), false /*has_derivs*/, mask, wvalue);
+
+    const ustring& sourcefile(USTR(sourcefile_));
+
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+
+
+    OSL_DASSERT(wsrcval.type().basetype
+                != TypeDesc::UNKNOWN);  // secret code for closure
+#if 0                                   // TBD closure support
+    // recreate TypeDesc -- we just crammed it into an int!
+    TypeDesc type = TYPEDESC(type_);
+    bool is_closure = (type.basetype == TypeDesc::UNKNOWN); // secret code for closure
+    if (is_closure) {
+        OSL_ASSERT(0 && "Incomplete add closure support to setmessage");
+        type.basetype = TypeDesc::PTR;
+
+    }
+    // for closures, we store a pointer
+#endif
+
+    impl_setmessage(bsg, sourcefile, sourceline, wsrcval, layeridx, name, mask);
+}
+
+
+OSL_BATCHOP void __OSL_MASKED_OP2(setmessage, Ws,
+                                  WX)(BatchedShaderGlobals* bsg_, void* wname,
+                                      long long type, void* wvalue,
+                                      int layeridx, const char* sourcefile_,
+                                      int sourceline, unsigned int mask_value)
+{
+    Mask mask(mask_value);
+    OSL_ASSERT(mask.any_on());
+
+    Wide<const ustring> wName(wname);
+    MaskedData wsrcval(TYPEDESC(type), false /*has_derivs*/, mask, wvalue);
+
+    const ustring& sourcefile(USTR(sourcefile_));
+
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+
+#if 0
+    // recreate TypeDesc -- we just crammed it into an int!
+    TypeDesc type = TYPEDESC(type_);
+    bool is_closure = (type.basetype == TypeDesc::UNKNOWN); // secret code for closure
+    if (is_closure) {
+        OSL_ASSERT(0 && "Incomplete add closure support to setmessage");
+        type.basetype = TypeDesc::PTR;
+
+    }
+    // for closures, we store a pointer
+#else
+    OSL_DASSERT(wsrcval.type().basetype
+                != TypeDesc::UNKNOWN);  // secret code for closure
+#endif
+
+    foreach_unique(wName, mask, [=](ustring name, Mask matching_lanes) -> void {
+        impl_setmessage(bsg, sourcefile, sourceline, wsrcval, layeridx, name,
+                        matching_lanes);
+    });
+}
+
+
+
+OSL_BATCHOP void __OSL_MASKED_OP(getmessage)(
+    void* bsg_, void* result, char* source_, char* name_, long long type_,
+    void* val, int derivs, int layeridx, const char* sourcefile_,
+    int sourceline, unsigned int mask_value)
+{
+    const ustring& source(USTR(source_));
+    const ustring& name(USTR(name_));
+    const ustring& sourcefile(USTR(sourcefile_));
+
+    Mask mask(mask_value);
+
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    Masked<int> wR(result, mask);
+
+    // recreate TypeDesc -- we just crammed it into an int!
+    TypeDesc type   = TYPEDESC(type_);
+    bool is_closure = (type.basetype
+                       == TypeDesc::UNKNOWN);  // secret code for closure
+    if (is_closure) {
+        OSL_ASSERT(0 && "Incomplete add closure support to getmessage");
+        type.basetype = TypeDesc::PTR;  // for closures, we store a pointer
+    }
+
+    static ustring ktrace("trace");
+    OSL_ASSERT(val != nullptr);
+    MaskedData valRef(type, derivs, mask, val);
+    if (USTR(source_) == ktrace) {
+        // Source types where we need to ask the renderer
+        return bsg->uniform.renderer->batched(WidthTag())
+            ->getmessage(bsg, wR, source, name, valRef);
+    }
+
+
+    BatchedMessageList messages {
+        bsg->uniform.context->batched_messages_buffer()
+    };
+
+
+    MessageBlock* m = messages.find(name);
+    if (m != nullptr) {
+        Wide<const ustring> msg_wsourcefile(m->wsourcefile);
+        Wide<const int> msg_wsourceline(m->wsourceline);
+        Wide<const int> msg_wlayeridx(m->wlayeridx);
+
+        if (m->type != type) {
+            // found message, but types don't match
+            mask.foreach ([=](ActiveLane lane) -> void {
+                //int msg_layerid = msg_wlayeridx[lane];
+                ustring msg_sourcefile = msg_wsourcefile[lane];
+                int msg_sourceline     = msg_wsourceline[lane];
+                // found message, but was set by a layer deeper than the one querying the message
+                bool has_data = m->has_data() ? m->valid_mask[lane] : false;
+
+                bsg->uniform.context->batched<__OSL_WIDTH>().errorf(
+                    Mask(lane),
+                    "type mismatch for message \"%s\" (%s as %s here: %s:%d)"
+                    " cannot fetch as %s from %s:%d",
+                    name.c_str(), has_data ? "created" : "queried",
+                    m->type == TypeDesc::PTR ? "closure color"
+                                             : m->type.c_str(),
+                    msg_sourcefile.c_str(), msg_sourceline,
+                    is_closure ? "closure color" : type.c_str(),
+                    sourcefile.c_str(), sourceline);
+            });
+
+            assign_all(wR, 0);
+            return;
+        }
+        OSL_ASSERT(m->has_data());
+        if (!m->has_data()) {
+            // getmessage ran before and found nothing - just return 0
+            assign_all(wR, 0);
+            return;
+        }
+        auto found_lanes   = mask & m->valid_mask;
+        auto missing_lanes = mask & ~m->valid_mask & ~m->get_before_set_mask;
+
+        Mask lanes_set_by_deeper_layer(false);
+        OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+        for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+            int msg_layerid = msg_wlayeridx[lane];
+            // NOTE: using bitwise & to avoid branches
+            if (found_lanes[lane] & (msg_layerid > layeridx)) {
+                lanes_set_by_deeper_layer.set_on(lane);
+            }
+        }
+
+        lanes_set_by_deeper_layer.foreach ([=](ActiveLane lane) -> void {
+            int msg_layerid        = msg_wlayeridx[lane];
+            ustring msg_sourcefile = msg_wsourcefile[lane];
+            int msg_sourceline     = msg_wsourceline[lane];
+
+            // found message, but was set by a layer deeper than the one querying the message
+            bsg->uniform.context->batched<__OSL_WIDTH>().errorf(
+                Mask(lane),
+                "message \"%s\" was set by layer #%d (%s:%d)"
+                " but is being queried by layer #%d (%s:%d)"
+                " - messages may only be transfered from nodes "
+                "that appear earlier in the shading network",
+                name.c_str(), msg_layerid, msg_sourcefile.c_str(),
+                msg_sourceline, layeridx, sourcefile.c_str(), sourceline);
+            wR[lane] = 0;
+        });
+
+        auto lanes_to_copy = found_lanes & ~lanes_set_by_deeper_layer;
+        if (lanes_to_copy.any_on()) {
+            m->export_data(valRef & lanes_to_copy);
+            assign_all(wR & lanes_to_copy, 1);
+        }
+
+        if (missing_lanes.any_on()) {
+            assign_all(wR & missing_lanes, 0);
+            if (bsg->uniform.context->shadingsys().strict_messages()) {
+                m->get_before_set_mask |= missing_lanes;
+                Masked<int> wlayeridx(m->wlayeridx, missing_lanes);
+                Masked<ustring> wsourcefile(m->wsourcefile, missing_lanes);
+                Masked<int> wsourceline(m->wsourceline, missing_lanes);
+                OSL_OMP_PRAGMA(omp simd simdlen(__OSL_WIDTH))
+                for (int lane = 0; lane < __OSL_WIDTH; ++lane) {
+                    wlayeridx[lane]   = layeridx;
+                    wsourcefile[lane] = sourcefile;
+                    wsourceline[lane] = sourceline;
+                }
+            }
+        }
+        return;
+    }
+
+    if (bsg->uniform.context->shadingsys().strict_messages()) {
+        // The message didn't exist - create it
+        MaskedData wsrcval(type, false /*has_derivs*/, mask, nullptr);
+        messages.add(name, wsrcval, mask, layeridx, sourcefile, sourceline);
+    }
+    assign_all(wR, 0);
+    return;
+}
+
+
+
+// Trace
+
+// Utility: retrieve a pointer to the ShadingContext's trace options
+// struct, also re-initialize its contents.
+
+OSL_BATCHOP void __OSL_MASKED_OP(trace)(void* bsg_, void* result, void* opt_,
+                                        void* Pos_, void* dPosdx_,
+                                        void* dPosdy_, void* Dir_,
+                                        void* dDirdx_, void* dDirdy_,
+                                        unsigned int mask_value)
+{
+    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    auto* opt = reinterpret_cast<BatchedRendererServices::TraceOpt*>(opt_);
+
+    Masked<int> wR(result, Mask(mask_value));
+
+    Block<Vec3> zero_block;
+    assign_all(zero_block, Vec3(0.0f));
+
+    Wide<const Vec3> wP(Pos_);
+    Wide<const Vec3> wPdx(dPosdx_ ? dPosdx_ : &zero_block);
+    Wide<const Vec3> wPdy(dPosdy_ ? dPosdy_ : &zero_block);
+
+    Wide<const Vec3> wD(Dir_);
+    Wide<const Vec3> wDdx(dDirdx_ ? dDirdx_ : &zero_block);
+    Wide<const Vec3> wDdy(dDirdy_ ? dDirdy_ : &zero_block);
+
+    bsg->uniform.renderer->batched(WidthTag())
+        ->trace(*opt, bsg, wR, wP, wPdx, wPdy, wD, wDdx, wDdy);
+}
+
+}  // namespace __OSL_WIDE_PVT
+OSL_NAMESPACE_EXIT

--- a/src/testshade/batched_simplerend.cpp
+++ b/src/testshade/batched_simplerend.cpp
@@ -359,7 +359,7 @@ BatchedSimpleRenderer<WidthT>::trace(
 
         float dot_val = point_lane.dot(dir_lane);
 
-        if ((bsg->varying.u[lane] / dot_val) > 0.75) {
+        if ((bsg->varying.u[lane] / dot_val) > 0.5) {
             result[lane] = 1;
         }
 
@@ -375,12 +375,47 @@ BatchedSimpleRenderer<WidthT>::getmessage(BatchedShaderGlobals* bsg,
                                           Masked<int> result, ustring source,
                                           ustring name, MaskedData val)
 {
+    OSL_ASSERT(source == ustring("trace"));
     for (int lane = 0; lane < WidthT; ++lane) {
-        if (bsg->varying.u[lane] > 0.75) {
+        if (bsg->varying.u[lane] > 0.5) {
+            if (name == ustring("hitdist")) {
+                if (Masked<float>::is(val)) {
+                    Masked<float> dest(val);
+                    dest[lane] = 0.5;
+                }
+            }
+            if (name == ustring("hit")) {
+                if (Masked<int>::is(val)) {
+                    Masked<int> dest(val);
+                    dest[lane] = 1;
+                }
+            }
+            if (name == ustring("geom:name")) {
+                if (Masked<ustring>::is(val)) {
+                    Masked<ustring> dest(val);
+                    dest[lane] =  ustring("teapot");
+                }
+            }
+            if (name == ustring("N")) {
+                if (Masked<Vec3>::is(val)) {
+                    Masked<Vec3> dest(val);
+                    dest[lane] = Vec3(1.0 - bsg->varying.v[lane], 0.25, 1.0 - bsg->varying.u[lane]);
+                } else {
+                    OSL_ASSERT(0 && "Oops");
+                }
+            }
+
             result[lane] = 1;
         }
+        else
+        {
+            if (name == ustring("hit")) {
+                if (Masked<int>::is(val)) {
+                    Masked<int> dest(val);
+                    dest[lane] = 0;
+                }
+            }
 
-        else {
             result[lane] = 0;
         }
     }

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -415,6 +415,72 @@ SimpleRenderer::get_userdata (bool derivatives, ustring name, TypeDesc type,
 
 
 bool
+SimpleRenderer::trace (TraceOpt &options, ShaderGlobals *sg,
+                    const OSL::Vec3 &P, const OSL::Vec3 &dPdx,
+                    const OSL::Vec3 &dPdy, const OSL::Vec3 &R,
+                    const OSL::Vec3 &dRdx, const OSL::Vec3 &dRdy)
+{
+    // Don't do real ray tracing, just
+    // use source and direction to alter hit results
+    // so they are repeatable values for testsuite.
+    float dot_val = P.dot(R);
+
+    if((sg->u)/dot_val > 0.5)
+    {
+        return true; //1 in batched
+    } else {
+        return false;
+    }
+}
+
+bool
+SimpleRenderer::getmessage (ShaderGlobals *sg, ustring source, ustring name,
+                         TypeDesc type, void *val, bool derivatives)
+{
+    OSL_ASSERT(source == ustring("trace"));
+    // Don't have any real ray tracing results
+    // so just fill in some repeatable values for testsuite
+    if(sg->u > 0.5)
+    {
+        if (name == ustring("hitdist")) {
+            if (type == TypeFloat) {
+                *reinterpret_cast<float *>(val) = 0.5f;
+            }
+        }
+        if (name == ustring("hit")) {
+            if (type == TypeInt) {
+                *reinterpret_cast<int *>(val) = 1;
+            }
+        }
+        if (name == ustring("geom:name")) {
+            if (type == TypeString) {
+                *reinterpret_cast<ustring *>(val) = ustring("teapot");
+            }
+        }
+        if (name == ustring("N")) {
+            if (type == TypeNormal) {
+                *reinterpret_cast<Vec3 *>(val) = Vec3(1.0 - sg->v, 0.25, 1.0 - sg->u);
+            } else {
+
+                OSL_ASSERT(0 && "Oops");
+            }
+        }
+        return true; //1 in batched
+
+    }
+    else
+    {
+        if (name == ustring("hit")) {
+            if (type == TypeInt) {
+                *reinterpret_cast<int *>(val) = 0;
+            }
+        }
+        return false;
+    }
+}
+
+
+bool
 SimpleRenderer::get_osl_version (ShaderGlobals* /*sg*/, bool /*derivs*/, ustring /*object*/,
                                  TypeDesc type, ustring /*name*/, void *val)
 {

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -61,6 +61,14 @@ public:
     virtual bool get_userdata (bool derivatives, ustring name, TypeDesc type, 
                                ShaderGlobals *sg, void *val);
 
+    virtual bool trace (TraceOpt &options, ShaderGlobals *sg,
+                        const OSL::Vec3 &P, const OSL::Vec3 &dPdx,
+                        const OSL::Vec3 &dPdy, const OSL::Vec3 &R,
+                        const OSL::Vec3 &dRdx, const OSL::Vec3 &dRdy);
+
+    virtual bool getmessage (ShaderGlobals *sg, ustring source, ustring name,
+                             TypeDesc type, void *val, bool derivatives);
+
 
     // Set and get renderer attributes/options
     void attribute (string_view name, TypeDesc type, const void *value);

--- a/testsuite/message-no-closure/a.osl
+++ b/testsuite/message-no-closure/a.osl
@@ -1,0 +1,32 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader a (float Kd = 0.5,
+          output float f_out = 0,
+          output color c_out = 0,
+          output float dummy = u+v  // just to force a real connection when opt is on
+    )
+{
+    f_out = Kd;
+    c_out = color (Kd/2, 1, 1);
+    printf ("a: f_out = %g, c_out = %g\n", f_out, c_out);
+    setmessage ("foo", c_out/2);
+    printf ("a: set message 'foo' to %g\n", c_out/2);
+
+    // Try setting a color message
+    color cc = 0.5*N;
+    setmessage ("cc", cc);
+    printf ("a: set message 'cc' to %g\n", cc);
+
+    // Set an array
+    float array[4] = { 42, 43, 44, 45 };
+    setmessage ("array", array);
+    printf ("a: set message 'array' to { %g %g %g %g }\n",
+            array[0], array[1], array[2], array[3]);
+
+    // Should produce an error when executing backwards (or forward)
+    int c;
+    if (getmessage("wrong_direction_test", c) != 0)
+       error("unexpected result from getmessage - fetched value %d", c);
+}

--- a/testsuite/message-no-closure/b.osl
+++ b/testsuite/message-no-closure/b.osl
@@ -1,0 +1,57 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader b (float f_in = 41,
+          color c_in = 42,
+          float dummy = 0,  // just to force a connection when opt is on
+          output color Cout = 0,
+          )
+{
+    printf ("dummy = %g, force connection with optimization\n", dummy);
+
+    // setup a message that a will try to read -> this should give us an error
+    setmessage("wrong_direction_test", 3);
+
+    printf ("b: f_in = %g, c_in = %g\n", f_in, c_in);
+
+    color foo = 0;
+    int result = getmessage ("foo", foo);
+    printf ("b: retrieved message 'foo', result = %d, foo = %g\n",
+            result, foo);
+
+    float bar = 0;
+    result = getmessage ("bar", bar);
+    printf ("b: retrieved bogus message 'bar', result = %d, bar = %g\n",
+            result, bar);
+
+    result = getmessage ("foo", bar);
+    printf ("b: retrieved message 'foo' with wrong type, result = %d, foo = %g\n",
+            result, bar);
+    result = getmessage ("bar", bar);
+
+    float array[4] = { 0, 0, 0, 0 };
+    result = getmessage ("array", array);
+    printf ("b: retrieved message 'array' to { %g %g %g %g }\n",
+            array[0], array[1], array[2], array[3]);
+
+    // try out a few more error conditions:
+    int c = 0;
+    getmessage("already_queried", c);
+    setmessage("already_queried", 3);     // try to set a message the shader thinks does not exist 
+ 
+    setmessage("message_on_same_layer", 3);
+    getmessage("message_on_same_layer", c);  // try to pass a message within a single layer
+
+    setmessage("set_twice", 3);
+    setmessage("set_twice", 4);           // should fail
+
+    setmessage("set_get_int", N);
+    getmessage("set_get_int", c);          // should be a type mismatch error (source was a normal)
+
+    color diff = 0;
+    setmessage("get_int_set", 3);
+    getmessage("get_int_set", diff);       // should be a type mismatch error (destination was a color)
+
+    Cout = N * float(c) + diff;  // force use of these variables
+}

--- a/testsuite/message-no-closure/ref/out-opt.txt
+++ b/testsuite/message-no-closure/ref/out-opt.txt
@@ -1,0 +1,20 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Connect alayer.f_out to blayer.f_in
+Connect alayer.c_out to blayer.c_in
+Connect alayer.dummy to blayer.dummy
+a: f_out = 0.5, c_out = 0.25 1 1
+a: set message 'foo' to 0.125 0.5 0.5
+a: set message 'cc' to 0 0 0.5
+a: set message 'array' to { 42 43 44 45 }
+dummy = 1, force connection with optimization
+b: f_in = 0.5, c_in = 0.25 1 1
+b: retrieved message 'foo', result = 1, foo = 0.125 0.5 0.5
+b: retrieved bogus message 'bar', result = 0, bar = 0
+ERROR: type mismatch for message "foo" (created as color here: a.osl:14) cannot fetch as float from b.osl:28
+b: retrieved message 'foo' with wrong type, result = 0, foo = 0
+b: retrieved message 'array' to { 42 43 44 45 }
+ERROR: message "set_twice" already exists (created here: b.osl:46) cannot set again from b.osl:47
+ERROR: type mismatch for message "set_get_int" (created as normal here: b.osl:49) cannot fetch as int from b.osl:50
+ERROR: type mismatch for message "get_int_set" (created as int here: b.osl:53) cannot fetch as color from b.osl:54
+

--- a/testsuite/message-no-closure/ref/out.txt
+++ b/testsuite/message-no-closure/ref/out.txt
@@ -1,0 +1,22 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Connect alayer.f_out to blayer.f_in
+Connect alayer.c_out to blayer.c_in
+Connect alayer.dummy to blayer.dummy
+a: f_out = 0.5, c_out = 0.25 1 1
+a: set message 'foo' to 0.125 0.5 0.5
+a: set message 'cc' to 0 0 0.5
+a: set message 'array' to { 42 43 44 45 }
+dummy = 1, force connection with optimization
+ERROR: message "wrong_direction_test" was queried before being set (queried here: a.osl:30) setting it now (b.osl:14) would lead to inconsistent results
+b: f_in = 0.5, c_in = 0.25 1 1
+b: retrieved message 'foo', result = 1, foo = 0.125 0.5 0.5
+b: retrieved bogus message 'bar', result = 0, bar = 0
+ERROR: type mismatch for message "foo" (created as color here: a.osl:14) cannot fetch as float from b.osl:28
+b: retrieved message 'foo' with wrong type, result = 0, foo = 0
+b: retrieved message 'array' to { 42 43 44 45 }
+ERROR: message "already_queried" was queried before being set (queried here: b.osl:40) setting it now (b.osl:41) would lead to inconsistent results
+ERROR: message "set_twice" already exists (created here: b.osl:46) cannot set again from b.osl:47
+ERROR: type mismatch for message "set_get_int" (created as normal here: b.osl:49) cannot fetch as int from b.osl:50
+ERROR: type mismatch for message "get_int_set" (created as int here: b.osl:53) cannot fetch as color from b.osl:54
+

--- a/testsuite/message-no-closure/run.py
+++ b/testsuite/message-no-closure/run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command += testshade ("-layer alayer a --layer blayer b --connect alayer f_out blayer f_in --connect alayer c_out blayer c_in --connect alayer dummy blayer dummy")

--- a/testsuite/message-reg/a_c.osl
+++ b/testsuite/message-reg/a_c.osl
@@ -1,0 +1,7 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#define __OSL_XMACRO_SUFFIX c
+#define CONSTANT_DATA 1
+#include "a_xmacro.h"

--- a/testsuite/message-reg/a_u.osl
+++ b/testsuite/message-reg/a_u.osl
@@ -1,0 +1,7 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#define __OSL_XMACRO_SUFFIX u
+#define UNIFORM_DATA 1
+#include "a_xmacro.h"

--- a/testsuite/message-reg/a_v.osl
+++ b/testsuite/message-reg/a_v.osl
@@ -1,0 +1,7 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#define __OSL_XMACRO_SUFFIX v
+#define VARYING_DATA 1
+#include "a_xmacro.h"

--- a/testsuite/message-reg/a_xmacro.h
+++ b/testsuite/message-reg/a_xmacro.h
@@ -1,0 +1,102 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#ifndef __OSL_XMACRO_SUFFIX
+#    error must define __OSL_XMACRO_SUFFIX to create a unique testname before including this header
+#endif
+
+#if !defined(VARYING_DATA) && !defined(UNIFORM_DATA) && !defined(CONSTANT_DATA)
+#    error Must define either VARYING_DATA, UNIFORM_DATA, CONSTANT_DATA before including this xmacro!
+#endif
+
+#define __OSL_CONCAT_INDIRECT(A, B) A##B
+#define __OSL_CONCAT(A, B)          __OSL_CONCAT_INDIRECT(A, B)
+
+shader __OSL_CONCAT(a_, __OSL_XMACRO_SUFFIX) (
+    int numStripes = 0,
+    output float f_out = 0,
+    output color c_out = 0,
+    output float dummy = u + v  // just to force a real connection when opt is on
+)
+{
+#ifdef CONSTANT_DATA
+    float X = 0.25;
+    float Y = 0.65;
+#endif
+#ifdef UNIFORM_DATA
+    float X = 0.25;
+    float Y = 0.65;
+    // Intended to be unreachable, but
+    // prevent constant folding of result
+    if (raytype("camera") == 0) {
+        X = 0.75;
+        Y = 0.15;
+    }
+#endif
+#ifdef VARYING_DATA
+    float X = u;
+    float Y = v;
+#endif
+
+    f_out = X;
+    c_out = color (Y, X, 1);
+    
+    if ((numStripes != 0) && (int(P[0]*P[0]*P[1]*(2*numStripes))%2==0))
+    {
+        string set_string = "foo";
+        if (X > 0.5)
+            set_string = "bar";
+        setmessage ("foo_string", set_string);
+
+        int set_int = int(256 - (X+Y)*128);
+        setmessage ("foo_int", set_int);
+
+        float set_float = (X+Y)*0.5;
+        setmessage ("foo_float", set_float);
+    
+        color set_color = color(1.0 - Y,X,1);
+        setmessage ("foo_color", set_color);
+    
+        matrix set_matrix = matrix(X/16.0, Y/16.0, X/8.0, Y/8.0,
+                              X/4.0, Y/4.0, X/12.0, Y/12.0,
+                              X/6.0, Y/6.0, X/3.0, Y/3.0,
+                              X/9.0, Y/9.0, X/10.0, Y/10.0);
+        setmessage ("foo_matrix", set_matrix);
+
+
+        string set_strings[3] = {set_string, "foo", "unknown"};
+        setmessage ("foo_strings", set_strings);
+
+        int set_ints[3] = {int(256 - (X+Y)*128), int(X*256), int(Y*256)};
+        setmessage ("foo_ints", set_ints);
+    
+        float set_floats[3] = {(X+Y)*0.5, X, Y};
+        setmessage ("foo_floats", set_floats);
+    
+        color set_colors[3] = {color(1.0 - Y,X,1), color(X,Y,(Y+X)*.05), color(Y,X,2 - (Y+X))};
+        setmessage ("foo_colors", set_colors);
+    
+        matrix set_matrices[3] = {
+            matrix(
+                X/16.0, Y/16.0, X/8.0, Y/8.0,
+                X/4.0, Y/4.0, X/12.0, Y/12.0,
+                X/6.0, Y/6.0, X/3.0, Y/3.0,
+                X/9.0, Y/9.0, X/10.0, Y/10.0
+            ),
+            matrix(
+                X/6.0, Y/6.0, X/3.0, Y/3.0,
+                X/16.0, Y/16.0, X/8.0, Y/8.0,
+                X/4.0, Y/4.0, X/12.0, Y/12.0,
+                X/9.0, Y/9.0, X/10.0, Y/10.0
+            ),
+            matrix(
+                X/9.0, Y/9.0, X/10.0, Y/10.0,
+                X/4.0, Y/4.0, X/12.0, Y/12.0,
+                X/16.0, Y/16.0, X/8.0, Y/8.0,
+                X/6.0, Y/6.0, X/3.0, Y/3.0
+            )
+        };
+        setmessage ("foo_matrices", set_matrices);
+    }
+}

--- a/testsuite/message-reg/b_c.osl
+++ b/testsuite/message-reg/b_c.osl
@@ -1,0 +1,7 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#define __OSL_XMACRO_SUFFIX c
+#define CONSTANT_DATA 1
+#include "b_xmacro.h"

--- a/testsuite/message-reg/b_u.osl
+++ b/testsuite/message-reg/b_u.osl
@@ -1,0 +1,7 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#define __OSL_XMACRO_SUFFIX u
+#define UNIFORM_DATA 1
+#include "b_xmacro.h"

--- a/testsuite/message-reg/b_v.osl
+++ b/testsuite/message-reg/b_v.osl
@@ -1,0 +1,7 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#define __OSL_XMACRO_SUFFIX v
+#define VARYING_DATA 1
+#include "b_xmacro.h"

--- a/testsuite/message-reg/b_xmacro.h
+++ b/testsuite/message-reg/b_xmacro.h
@@ -1,0 +1,149 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#ifndef __OSL_XMACRO_SUFFIX
+#    error must define __OSL_XMACRO_SUFFIX to create a unique testname before including this header
+#endif
+
+#if !defined(VARYING_DATA) && !defined(UNIFORM_DATA) && !defined(CONSTANT_DATA)
+#    error Must define either VARYING_DATA, UNIFORM_DATA, CONSTANT_DATA before including this xmacro!
+#endif
+
+#define __OSL_CONCAT_INDIRECT(A, B) A##B
+#define __OSL_CONCAT(A, B)          __OSL_CONCAT_INDIRECT(A, B)
+
+color string2color(string val)
+{
+    if (val == "foo")
+        return color(1,0,0);
+    if (val == "bar")
+        return color(0,1,0);
+    return color(0,0,1);
+}
+
+float int2float(int val)
+{
+    return float(val)/256.0;
+}
+
+color matrix2color(matrix val)
+{
+    return color(val[0][0] + val[0][1] + val[0][2] + val[0][3] + val[3][0],    
+                 val[1][0] + val[1][1] + val[1][2] + val[1][3] + val[3][1],
+                 val[2][0] + val[2][1] + val[2][2] + val[2][3] + val[3][2]);
+}
+
+shader __OSL_CONCAT(b_, __OSL_XMACRO_SUFFIX) (
+    int numStripes = 0,
+    float f_in = 41,
+    color c_in = 42,
+    float dummy = 0,  // just to force a connection when opt is on
+    output color out_string = 0,
+    output float out_int = 0,
+    output float out_float = 0,
+    output color out_color = 0,
+    output color out_matrix = 0,
+    output color out_strings0 = 0,
+    output color out_strings1 = 0,
+    output color out_strings2 = 0,
+    output float out_ints0 = 0,
+    output float out_ints1 = 0,
+    output float out_ints2 = 0,
+    output float out_floats0 = 0,
+    output float out_floats1 = 0,
+    output float out_floats2 = 0,
+    output color out_colors0 = 0,
+    output color out_colors1 = 0,
+    output color out_colors2 = 0,
+    output color out_matrices0 = 0,
+    output color out_matrices1 = 0,
+    output color out_matrices2 = 0,
+    output float out_result = 0,
+    )
+{
+#ifdef CONSTANT_DATA
+    float X = 0.25;
+    float Y = 0.65;
+#endif
+#ifdef UNIFORM_DATA
+    float X = 0.25;
+    float Y = 0.65;
+    // Intended to be unreachable, but
+    // prevent constant folding of result
+    if (raytype("camera") == 0) {
+        X = 0.75;
+        Y = 0.15;
+    }
+#endif
+#ifdef VARYING_DATA
+    float X = u;
+    float Y = v;
+#endif
+
+    if (dummy < 0) {
+        printf("uneachable, but needed to get connecting layers to particpate and call setmessage");
+    }
+    int result = 0;
+    
+    if ((numStripes != 0) && (int(P[1]*P[1]*(1.0 - P[0])*(2*numStripes))%2==0))
+    {
+        string foo_string = "magic";
+        result += getmessage ("foo_string", foo_string);
+        out_string = string2color(foo_string);
+
+        int foo_int = 0;
+        result += getmessage ("foo_int", foo_int);
+        out_int = int2float(foo_int);
+
+        float foo_float = 0;
+        result += getmessage ("foo_float", foo_float);
+        out_float = foo_float;
+
+        color foo_color = 0;
+        result += getmessage ("foo_color", foo_color);
+        out_color = foo_color;
+
+        matrix foo_matrix = 0;
+        result += getmessage ("foo_matrix", foo_matrix);
+        out_matrix = matrix2color(foo_matrix);
+        
+    
+        string foo_strings[3] = { "unknown", "unknown", "unknown"};
+        result += getmessage ("foo_strings", foo_strings);
+        out_strings0 = string2color(foo_strings[0]);
+        out_strings1 = string2color(foo_strings[1]);
+        out_strings2 = string2color(foo_strings[2]);
+
+
+        int foo_ints[3] = {0, 0, 0};
+        result += getmessage ("foo_ints", foo_ints);
+        out_ints0 = int2float(foo_ints[0]);
+        out_ints1 = int2float(foo_ints[1]);
+        out_ints2 = int2float(foo_ints[2]);
+
+        float foo_floats[3] = {0.0, 0.0, 0.0};
+        result += getmessage ("foo_floats", foo_floats);
+        out_floats0 = foo_floats[0];
+        out_floats1 = foo_floats[1];
+        out_floats2 = foo_floats[2];
+
+        color foo_colors[3] = { color(0,0,0), color(0,0,0), color(0,0,0)};
+        result += getmessage ("foo_colors", foo_colors);
+        out_colors0 = foo_colors[0];
+        out_colors1 = foo_colors[1];
+        out_colors2 = foo_colors[2];
+
+        matrix foo_matrices[3] = {matrix(1), matrix(1), matrix(1)};
+        result += getmessage ("foo_matrices", foo_matrices);
+        out_matrices0 = matrix2color(foo_matrices[0]);
+        out_matrices1 = matrix2color(foo_matrices[1]);
+        out_matrices2 = matrix2color(foo_matrices[2]);
+
+        int not_there = 0;
+        result += getmessage ("not_there", not_there);
+    }
+
+    out_result = float(result)/20;
+    
+}

--- a/testsuite/message-reg/run.py
+++ b/testsuite/message-reg/run.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+def run_test (suffix) :
+    global command
+    tagname = suffix;
+    command += testshade("-t 1 -g 64 64 -od uint8"
+                         +" --param numStripes 16 --layer alayer a_"+suffix
+                         +" --param numStripes 8 --layer blayer b_"+suffix
+                         +" --connect alayer dummy blayer dummy"
+                         +" -o out_string out_string_"+tagname+".tif"
+                         +" -o out_int out_int_"+tagname+".tif"
+                         +" -o out_float out_float_"+tagname+".tif"
+                         +" -o out_color out_color_"+tagname+".tif"
+                         +" -o out_matrix out_matrix_"+tagname+".tif"
+                         +" -o out_strings0 out_strings0_"+tagname+".tif"
+                         +" -o out_strings1 out_strings1_"+tagname+".tif"
+                         +" -o out_strings2 out_strings2_"+tagname+".tif"
+                         +" -o out_ints0 out_ints0_"+tagname+".tif"
+                         +" -o out_ints1 out_ints1_"+tagname+".tif"
+                         +" -o out_ints2 out_ints2_"+tagname+".tif"
+                         +" -o out_floats0 out_floats0_"+tagname+".tif"
+                         +" -o out_floats1 out_floats1_"+tagname+".tif"
+                         +" -o out_floats2 out_floats2_"+tagname+".tif"
+                         +" -o out_colors0 out_colors0_"+tagname+".tif"
+                         +" -o out_colors1 out_colors1_"+tagname+".tif"
+                         +" -o out_colors2 out_colors2_"+tagname+".tif"
+                         +" -o out_matrices0 out_matrices0_"+tagname+".tif"
+                         +" -o out_matrices1 out_matrices1_"+tagname+".tif"
+                         +" -o out_matrices2 out_matrices2_"+tagname+".tif"
+                         +" -o out_result out_result_"+tagname+".tif"
+                         )
+    
+    global outputs     
+    outputs.append ("out_string_"+tagname+".tif")
+    outputs.append ("out_int_"+tagname+".tif")
+    outputs.append ("out_float_"+tagname+".tif")
+    outputs.append ("out_color_"+tagname+".tif")
+    outputs.append ("out_matrix_"+tagname+".tif")
+    outputs.append ("out_strings0_"+tagname+".tif")
+    outputs.append ("out_strings1_"+tagname+".tif")
+    outputs.append ("out_strings2_"+tagname+".tif")
+    outputs.append ("out_ints0_"+tagname+".tif")
+    outputs.append ("out_ints1_"+tagname+".tif")
+    outputs.append ("out_ints2_"+tagname+".tif")
+    outputs.append ("out_floats0_"+tagname+".tif")
+    outputs.append ("out_floats1_"+tagname+".tif")
+    outputs.append ("out_floats2_"+tagname+".tif")
+    outputs.append ("out_colors0_"+tagname+".tif")
+    outputs.append ("out_colors1_"+tagname+".tif")
+    outputs.append ("out_colors2_"+tagname+".tif")
+    outputs.append ("out_matrices0_"+tagname+".tif")
+    outputs.append ("out_matrices1_"+tagname+".tif")
+    outputs.append ("out_matrices2_"+tagname+".tif")
+    outputs.append ("out_result_"+tagname+".tif")    
+    return
+
+run_test ("c")
+run_test ("u")
+run_test ("v")
+
+# expect a few LSB failures
+failthresh = 0.008
+failpercent = 3
+

--- a/testsuite/trace-reg/run.py
+++ b/testsuite/trace-reg/run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+def run_test (suffix) :
+    global command
+    tagname = suffix;
+    command += testshade("-t 1 -g 64 64 --param numStripes 16 -od uint8 -o Cout out.tif test_trace")
+    
+    global outputs     
+    outputs.append ("out.tif")
+    return
+
+run_test ("")
+
+# expect a few LSB failures
+failthresh = 0.008
+failpercent = 3
+

--- a/testsuite/trace-reg/test_trace.osl
+++ b/testsuite/trace-reg/test_trace.osl
@@ -1,0 +1,42 @@
+shader test_trace ( 
+    int numStripes = 0,
+    output vector Cout = 0)
+{
+   
+    point src = P;
+    vector dir = vector (1.0, 1.0, 1.0) - P;
+  
+    int trace_res = 0;
+    float mindist_val = 1;
+    trace_res = trace(src, dir, "mindist", mindist_val, "maxdist", (1000 + (1000*u)), "shade", 2, "traceset", "teapot");
+    
+    if (trace_res) {
+        Cout = vector(1.0, 1.0, 1.0);
+        float hitdist = 1.0;
+        int get_res = getmessage ("trace", "hitdist", hitdist);
+        if (get_res) {
+            Cout = hitdist;
+        }
+    }
+    
+    // Exercise the op masked
+    if ((numStripes != 0) && (int(P[0]*P[0]*P[1]*(2*numStripes))%2==0))
+    {
+        point src2 = vector (1.0, 1.0, 1.0) - P;
+        vector dir2 = P;
+        int trace_res2 = 0;
+        string traceset = "teapot";
+        if (int(64*P[1])%2 == 0) { 
+            traceset = "bunny";
+        }
+        trace_res2 = trace(src2, dir2, "mindist", 1.0, "maxdist", 2000.0, "shade", 2, "traceset", traceset);
+        if (trace_res2) {
+            Cout = vector(1.0, 0.0, 1.0);
+            normal tracedN = normal(0);
+            int get_res = getmessage ("trace", "N", tracedN);
+            if (get_res) {
+                Cout = tracedN;
+            }
+        }
+    }    
+}


### PR DESCRIPTION
## Description

Add batched support for trace, setmessage, and getmessage

Added MaskedData::assign_from(void *ptr_wide_data) to perform a masked copy of wide data at some address.

Added enum class RenderServices::TraceOpt::LLVMMemberIndex to correlate C++ data members with LLVM type generated by BatchedBackendLLVM::llvm_type_batched_trace_options()

Fixed bug in BatchedBackendLLVM::llvm_load_arg where array types where only properly broadcasting uniform to varying arguments for the 0th element of the array.

For batched implemented trace options as a LLVM type with direct code gen to alloca, init default values, and set optional values vs. callbacks.  Same code could be resused for non-batched impl.

Added BatchedMessageBuffer to context and BatchedMessageList to wide_opmessage.cpp to allow a shared buffer to be cleared by the ShadingSystem while allowing target specific compilation of SIMD import/export of message values into the list to compile in wide_opmessage.cpp.

## Tests

Extended testshade's SimpleRenderer and BatchedSimpleRenderer to implement trace and getmessage to allow new tests to exercise some basic functionality.

Added new batched regression tests:
-   message-reg
-   trace-reg


Added new batched test:  

- message-no-closure (which is a simplied version of testsuite/message)

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

