### PR TITLE
CI: pybind11 adjustments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       CC: gcc
       CMAKE_CXX_STANDARD: 14
       OPENIMAGEIO_VERSION: v2.2.17.0
+      PYBIND11_VERSION: v2.4.2
       PYTHON_VERSION: 2.7
       USE_PYTHON: 0
     steps:
@@ -85,6 +86,7 @@ jobs:
       CMAKE_CXX_STANDARD: 14
       CONAN_LLVM_VERSION: 10.0.1
       OPENIMAGEIO_VERSION: v2.2.17.0
+      PYBIND11_VERSION: v2.5.0
       PYTHON_VERSION: 3.7
       USE_SIMD: sse4.2
     steps:
@@ -131,10 +133,11 @@ jobs:
       CXX: g++
       CC: gcc
       CMAKE_CXX_STANDARD: 17
-      PYTHON_VERSION: 3.7
       USE_SIMD: avx2,f16c
       OPENEXR_VERSION: v2.5.6
       OPENIMAGEIO_VERSION: dev-2.2
+      PYBIND11_VERSION: v2.7.0
+      PYTHON_VERSION: 3.7
       USE_BATCHED: b8_AVX2_noFMA
     steps:
       - uses: actions/checkout@v2
@@ -181,7 +184,7 @@ jobs:
       CC: gcc
       CMAKE_CXX_STANDARD: 17
       OPENIMAGEIO_VERSION: release
-      PYBIND11_VERSION: v2.7.1
+      PYBIND11_VERSION: v2.9.0
       PYTHON_VERSION: 3.9
       USE_BATCHED: b8_AVX2
       USE_SIMD: avx2,f16c
@@ -434,7 +437,7 @@ jobs:
       OPENIMAGEIO_VERSION: release
       OPENIMAGEIO_CMAKE_FLAGS: -DBUILD_FMT_VERSION=7.0.1
       PUGIXML_VERSION: v1.10
-      PYBIND11_VERSION: v2.5.0
+      PYBIND11_VERSION: v2.8.1
     steps:
       - uses: actions/checkout@v2
       - name: Prepare ccache timestamp
@@ -486,7 +489,7 @@ jobs:
       OPENIMAGEIO_VERSION: master
       OPENIMAGEIO_CMAKE_FLAGS: -DBUILD_FMT_VERSION=8.0.1
       OPENCOLORIO_VERSION: v2.1.0
-      PYBIND11_VERSION: v2.8.1
+      PYBIND11_VERSION: v2.9.0
       PUGIXML_VERSION: v1.11.4
       USE_BATCHED: b8_AVX2,b8_AVX512,b16_AVX512
       PYTHON_VERSION: 3.8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     $OpenImageIO_ROOT/lib to be in your LD_LIBRARY_PATH (or
     DYLD_LIBRARY_PATH on OS X).
 
-* **[LLVM](http://www.llvm.org) 7, 8, 9, 10, 11, 12, or 13**, including clang
+* **[LLVM](http://www.llvm.org) 9, 10, 11, 12, or 13**, including clang
   libraries.
 
 * [Boost](https://www.boost.org) 1.55 or newer (tested through boost 1.77)
@@ -55,10 +55,10 @@ NEW or CHANGED dependencies since the last major release are **bold**.
   If it is not found at build time, the OSL `pointcloud` functions will not
   be operative.
 * (optional) Python: If you are building the Python bindings or running the
-   testsuite:
-     * Python >= 2.7 (tested against 2.7, 3.6, 3.7, 3.8, 3.9)
-     * pybind11 >= 2.4.2 (Tested through 2.7)
-     * NumPy
+  testsuite:
+    * Python >= 2.7 (tested against 2.7, 3.7, 3.8, 3.9)
+    * pybind11 >= 2.4.2 (Tested through 2.9)
+    * NumPy
 * (optional) Qt >= 5.6 (tested through 5.15).  If not found at build time,
   the `osltoy` application will be disabled.
 

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -11,7 +11,7 @@ set -ex
 
 # Repo and branch/tag/commit of pybind11 to download if we don't have it yet
 PYBIND11_REPO=${PYBIND11_REPO:=https://github.com/pybind/pybind11.git}
-PYBIND11_VERSION=${PYBIND11_VERSION:=v2.4.3}
+PYBIND11_VERSION=${PYBIND11_VERSION:=v2.8.1}
 
 # Where to put pybind11 repo source (default to the ext area)
 PYBIND11_SRC_DIR=${PYBIND11_SRC_DIR:=${PWD}/ext/pybind11}
@@ -20,7 +20,7 @@ PYBIND11_BUILD_DIR=${PYBIND11_BUILD_DIR:=${PYBIND11_SRC_DIR}/build}
 # Install area for pybind11 (default to ext/dist)
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 PYBIND11_INSTALL_DIR=${PYBIND11_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
-PYBIND11_BUILD_OPTS=${PYBIND11_BUILD_OPTS:=}
+#PYBIND11_BUILD_OPTS=${PYBIND11_BUILD_OPTS:=}
 
 if [[ "${PYTHON_VERSION}" != "" ]] ; then
     PYBIND11_BUILD_OPTS+=" -DPYBIND11_PYTHON_VERSION=${PYTHON_VERSION}"
@@ -38,16 +38,20 @@ if [[ ! -e ${PYBIND11_SRC_DIR} ]] ; then
     git clone ${PYBIND11_REPO} ${PYBIND11_SRC_DIR}
 fi
 cd ${PYBIND11_SRC_DIR}
+
 echo "git checkout ${PYBIND11_VERSION} --force"
 git checkout ${PYBIND11_VERSION} --force
 
 mkdir -p ${PYBIND11_BUILD_DIR}
 cd ${PYBIND11_BUILD_DIR}
-time cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${PYBIND11_INSTALL_DIR} \
-           -DPYBIND11_TEST=OFF \
-           ${PYBIND11_BUILD_OPTS} ..
-time cmake --build . --config Release --target install
+
+if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
+    time cmake -DCMAKE_BUILD_TYPE=Release \
+               -DCMAKE_INSTALL_PREFIX=${PYBIND11_INSTALL_DIR} \
+               -DPYBIND11_TEST=OFF \
+               ${PYBIND11_BUILD_OPTS} ..
+    time cmake --build . --config Release --target install
+fi
 
 # ls -R ${PYBIND11_INSTALL_DIR}
 popd

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -114,7 +114,7 @@ checked_find_package (pugixml REQUIRED
 
 # LLVM library setup
 checked_find_package (LLVM REQUIRED
-                      VERSION_MIN 8.0
+                      VERSION_MIN 9.0
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES)
 # ensure include directory is added (in case of non-standard locations
 include_directories (BEFORE SYSTEM "${LLVM_INCLUDES}")


### PR DESCRIPTION
* pybind11 2.9.0 release -- bump the vfx2022 and "latest" CI tests to
  use it.
* Adjust other CI test pybind11 versions to get good coverage across all
  the pybind11 releases, and to synchronize the vfx platfom tests with
  the pybind11 release that was current for its respective year.
* Sync build_scripts/build_pybind11.bash with the latest in OIIO, including
  bumping the default pybind11 version we download to 2.8.1.
* Opportunistic touch-up of warnings about llvm version to bring
  into sync with our actual current requirements.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
