### PR TITLE
oslc: detect using type name as an variable identifier

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -247,6 +247,7 @@ macro (osl_add_all_tests)
                 oslc-err-outputparamvararray oslc-err-paramdefault
                 oslc-err-struct-array-init oslc-err-struct-ctr
                 oslc-err-struct-dup oslc-err-struct-print
+                oslc-err-type-as-variable
                 oslc-err-unknown-ctr
                 oslc-pragma-warnerr
                 oslc-warn-commainit

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -51,7 +51,8 @@ enum SymType {
     SymTypeGlobal,
     SymTypeConst,
     SymTypeFunction,
-    SymTypeType
+    SymTypeType,
+    SymTypeLast
 };
 
 

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -649,6 +649,10 @@ ASTvariable_ref::ASTvariable_ref(OSLCompilerImpl* comp, ustring name)
         errorf("function '%s' can't be used as a variable", name);
         return;
     }
+    if (m_sym->symtype() == SymTypeType) {
+        errorf("type name '%s' can't be used as a variable", name);
+        return;
+    }
     m_typespec = m_sym->typespec();
 }
 

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -43,9 +43,9 @@ Symbol::unmangled() const
 const char*
 Symbol::symtype_shortname(SymType s)
 {
-    OSL_DASSERT((int)s >= 0 && (int)s < (int)SymTypeType);
+    OSL_DASSERT((int)s >= 0 && (int)s < (int)SymTypeLast);
     static const char* names[] = { "param",  "oparam", "local", "temp",
-                                   "global", "const",  "func" };
+                                   "global", "const",  "func",  "typename" };
     return names[(int)s];
 }
 

--- a/testsuite/oslc-err-struct-print/test.osl
+++ b/testsuite/oslc-err-struct-print/test.osl
@@ -15,7 +15,7 @@ test (
     output testStruct out = input
 )
 {
-    printf("testStruct: %g\n", testStruct.c);
-    printf("testStruct: %g\n", testStruct);
-    printf("testStruct: %d\n", testStruct);
+    printf("testStruct: %g\n", input.c);
+    printf("testStruct: %g\n", input);
+    printf("testStruct: %d\n", input);
 }

--- a/testsuite/oslc-err-type-as-variable/NOOPTIMIZE
+++ b/testsuite/oslc-err-type-as-variable/NOOPTIMIZE
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to optimize

--- a/testsuite/oslc-err-type-as-variable/NOOPTIX
+++ b/testsuite/oslc-err-type-as-variable/NOOPTIX
@@ -1,0 +1,1 @@
+Testing oslc error detection, no execution, no need to run with OptiX

--- a/testsuite/oslc-err-type-as-variable/ref/out.txt
+++ b/testsuite/oslc-err-type-as-variable/ref/out.txt
@@ -1,0 +1,3 @@
+test.osl:11: error: type name 'Data' can't be used as a variable
+test.osl:11: error: Cannot return a 'unknown' from 'struct Data foo()'
+FAILED test.osl

--- a/testsuite/oslc-err-type-as-variable/run.py
+++ b/testsuite/oslc-err-type-as-variable/run.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+# command = oslc("test.osl")
+# don't even need that -- it's automatic
+failureok = 1     # this test is expected to have oslc errors

--- a/testsuite/oslc-err-type-as-variable/test.osl
+++ b/testsuite/oslc-err-type-as-variable/test.osl
@@ -1,0 +1,18 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+struct Data {
+    float height;
+};
+
+Data foo(Data a, float b)
+{
+    return Data;   // Error: type name 'Data' can't be used as a variable
+}
+
+shader test ()
+{
+    Data d;
+    d = foo(d, 1.0);
+}


### PR DESCRIPTION
Here was the construct it was confused by:

    struct Data {
        float height;
    };

    Data foo(Data a, float b)
    {
        return Data;   // <----- what's this madness?
    }

Curiously, this revealed a source code error in one of our other tests,
oslc-err-struct-print, which had not been detected previously!

Signed-off-by: Larry Gritz <lg@larrygritz.com>
