### PR TITLE
Wean ourselves off of OIIO::string_view::c_str()

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -254,7 +254,8 @@ public:
         return attribute (name, TypeDesc::FLOAT, &f);
     }
     bool attribute (string_view name, string_view val) {
-        const char *s = val.c_str();
+        std::string valstr(val);
+        const char *s = valstr.c_str();
         return attribute (name, TypeDesc::STRING, &s);
     }
 
@@ -284,7 +285,8 @@ public:
         return attribute (group, name, TypeDesc::FLOAT, &f);
     }
     bool attribute (ShaderGroup *group, string_view name, string_view val) {
-        const char *s = val.c_str();
+        std::string valstr(val);
+        const char *s = valstr.c_str();
         return attribute (group, name, TypeDesc::STRING, &s);
     }
 

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -695,12 +695,12 @@ ASTNode::one_default_literal(const Symbol* sym, ASTNode* init, std::string& out,
             float f = lit->intval();
             for (int c = 0; c < 16; ++c)
                 out += Strutil::sprintf("%.9g%s", (c / 4) == (c % 4) ? f : 0.0f,
-                                        c < 15 ? sep.c_str() : "");
+                                        c < 15 ? sep : "");
         } else if (islit && lit->typespec().is_float()) {
             float f = lit->floatval();
             for (int c = 0; c < 16; ++c)
                 out += Strutil::sprintf("%.9g%s", (c / 4) == (c % 4) ? f : 0.0f,
-                                        c < 15 ? sep.c_str() : "");
+                                        c < 15 ? sep : "");
         } else if (init && init->typespec() == type
                    && init->nodetype() == ASTNode::type_constructor_node) {
             ASTtype_constructor* ctr = (ASTtype_constructor*)init;
@@ -730,15 +730,14 @@ ASTNode::one_default_literal(const Symbol* sym, ASTNode* init, std::string& out,
                 for (int c = 0; c < 16; ++c)
                     out += Strutil::sprintf("%.9g%s",
                                             (c / 4) == (c % 4) ? f[0] : 0.0f,
-                                            c < 15 ? sep.c_str() : "");
+                                            c < 15 ? sep : "");
             } else {
                 for (int c = 0; c < 16; ++c)
-                    out += Strutil::sprintf("%.9g%s", f[c],
-                                            c < 15 ? sep.c_str() : "");
+                    out += Strutil::sprintf("%.9g%s", f[c], c < 15 ? sep : "");
             }
         } else {
             for (int c = 0; c < 16; ++c)
-                out += Strutil::sprintf("0%s", c < 15 ? sep.c_str() : "");
+                out += Strutil::sprintf("0%s", c < 15 ? sep : "");
             completed = false;
         }
     } else if (type.is_string()) {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -462,7 +462,8 @@ public:
         return attribute (name, TypeDesc::FLOAT, &val);
     }
     bool attribute (string_view name, string_view val) {
-        const char *s = val.c_str();
+        std::string valstr(val);
+        const char *s = valstr.c_str();
         return attribute (name, TypeDesc::STRING, &s);
     }
     bool attribute (ShaderGroup *group, string_view name,

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3912,7 +3912,7 @@ ClosureRegistry::register_closure (string_view name, int id,
              * because we will be allocating the real struct inside it. */
             OSL_ASSERT_MSG(params[i].field_size <= int(alignof(ClosureComponent)),
                 "Closure %s wants alignment of %d which is larger than that of ClosureComponent",
-                name.c_str(),
+                name.str().c_str(),
                 params[i].field_size);
             break;
         }

--- a/src/testrender/simpleraytracer.h
+++ b/src/testrender/simpleraytracer.h
@@ -61,7 +61,8 @@ public:
         attribute (name, TypeDesc::FLOAT, &value);
     }
     void attribute (string_view name, string_view value) {
-        const char *s = value.c_str();
+        std::string valstr(value);
+        const char *s = valstr.c_str();
         attribute (name, TypeDesc::STRING, &s);
     }
     OIIO::ParamValue * find_attribute (string_view name,

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -79,7 +79,8 @@ public:
         attribute (name, TypeDesc::FLOAT, &value);
     }
     void attribute (string_view name, string_view value) {
-        const char *s = value.c_str();
+        std::string valstr(value);
+        const char *s = valstr.c_str();
         attribute (name, TypeDesc::STRING, &s);
     }
     OIIO::ParamValue * find_attribute (string_view name,

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -497,7 +497,7 @@ add_param (ParamValueList& params, string_view command,
     }
 
     // All remaining cases -- it's a string
-    const char *s = stringval.c_str();
+    const char *s = ustring(stringval).c_str();
     params.emplace_back (paramname, TypeDesc::TypeString, 1, &s);
     if (unlockgeom)
         params.back().interp (ParamValue::INTERP_VERTEX);


### PR DESCRIPTION
OIIO's string_view::c_str() was cute, but it's a little dicey and it's
not present in the C++20 std::string_view. We didn't use it in a ton
of places, so replace with other idioms so that in the future we are
better able to interchange with or switch to std::string_view (when
our minimum supported C++ standard is high enough).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
