### PR TITLE
Favor our choice of Imath includes over OIIO's.

### DIFF
--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <OSL/platform.h>
 #include <OSL/export.h>
 #include <OSL/oslversion.h>
+#include <OSL/platform.h>
 
 
 // All the things we need from Imath.
@@ -25,6 +25,12 @@
 #   include <OSL/Imathx/ImathColor.h>
 #   include <OSL/matrix22.h>
 #endif
+
+// We included the Imath files we needed, so set the OIIO_IMATH_H_INCLUDED
+// symbol to prevent OpenImageIO/Imath.h from including them again (or
+// before), which is critical if they turn out to be different versions.
+#define OIIO_IMATH_H_INCLUDED 1
+
 
 // The fmt library causes trouble for Cuda. Work around by disabling it from
 // oiio headers (OIIO <= 2.1) or telling fmt not to use the troublesome

--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -9,6 +9,8 @@
 #include <limits>
 #include <type_traits>
 
+#include <OSL/oslconfig.h>
+
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/hash.h>
 #include <OpenImageIO/simd.h>

--- a/src/liboslexec/shadeimage.cpp
+++ b/src/liboslexec/shadeimage.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
+#include <OSL/oslconfig.h>
+
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo_util.h>

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include <OSL/oslconfig.h>
+
 #include <OpenImageIO/imagebufalgo.h>
 #include <OpenImageIO/argparse.h>
 #include <OpenImageIO/strutil.h>

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+#include <OSL/oslconfig.h>
+
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>


### PR DESCRIPTION
New changes in OIIO guards the contents of its Imath.h with the
`OIIO_IMATH_H_INCLUDED` preprocessor symbol. This lets us in OSL
pre-define it to absolutely ensure that OSL headers are including
exactly the Imath headers they want, not accidentally getting the ones
that OIIO includes.

See https://github.com/OpenImageIO/oiio/pull/3322
This present PR is harmless for versions of OIIO prior to that PR being
integrated.

Signed-off-by: Larry Gritz <lg@larrygritz.com>