### PR TITLE
Add N/I to globals needed list when backfacing() shadeop is used

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -209,6 +209,7 @@ macro (osl_add_all_tests)
                 function-overloads function-redef
                 geomath getattribute-camera getattribute-shader
                 getsymbol-nonheap gettextureinfo gettextureinfo-reg
+                globals-needed
                 group-outputs groupstring
                 hash hashnoise hex hyperb
                 ieee_fp ieee_fp-reg if if-reg incdec initlist initops intbits isconnected

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -40,7 +40,10 @@ static ustring u_nop    ("nop"),
                u_isconnected ("isconnected"),
                u_setmessage ("setmessage"),
                u_getmessage ("getmessage"),
-               u_getattribute ("getattribute");
+               u_getattribute ("getattribute"),
+               u_backfacing ("backfacing"),
+               u_N ("N"),
+               u_I ("I");
 
 
 OSL_NAMESPACE_ENTER
@@ -3224,6 +3227,9 @@ RuntimeOptimizer::run ()
                 } else {
                     m_unknown_closures_needed = true;
                 }
+            } else if (op.opname() == u_backfacing) {
+                m_globals_needed.insert(u_N);
+                m_globals_needed.insert(u_I);
             } else if (op.opname() == u_getattribute) {
                 Symbol *sym1 = opargsym (op, 1);
                 OSL_DASSERT (sym1 && sym1->typespec().is_string());

--- a/testsuite/globals-needed/printbackfacing.osl
+++ b/testsuite/globals-needed/printbackfacing.osl
@@ -1,0 +1,9 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader printbackfacing ()
+{
+    int bf = backfacing();
+    printf ("backfacing = %d", bf);
+}

--- a/testsuite/globals-needed/ref/out.txt
+++ b/testsuite/globals-needed/ref/out.txt
@@ -1,0 +1,1 @@
+Need 2 globals:  I N

--- a/testsuite/globals-needed/run.py
+++ b/testsuite/globals-needed/run.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command += testshade("-g 2 2 -debug printbackfacing")
+
+# debug output is very verbose, use regexp to filter down to
+# only the line we're interested in testing
+filter_re = "Need.*globals.*"


### PR DESCRIPTION
## Description

Fix a bug where utilizing the backfacing() shadeop would not mark the N and I globals as needed.

During the OSL runtime optimizations, if we find a backfacing() shadeop, we now add both N and I
to the list of needed globals, as the underlying implementation of that shadeop relies on them.

## Tests

This is tested by the globals-needed test.  Additionally it adds the ability to filter
out.txt in a test before diff'ing by including a regular expression for the filter in the filter_re variable.
This was so that the output from the debug mode of testshade could be limited to only
the line of interest to this test.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x ] My code follows the prevailing code style of this project.

