### PR TITLE
Make exported cmake configs relocatable by using relative paths

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -19,9 +19,16 @@ endif ()
 
 find_dependency(OpenImageIO @OpenImageIO_VERSION@ REQUIRED)
 
-set_and_check (@PROJECT_NAME@_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
-set_and_check (@PROJECT_NAME@_INCLUDES    "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
-set_and_check (@PROJECT_NAME@_LIB_DIR     "@CMAKE_INSTALL_FULL_LIBDIR@")
+# Compute the installation prefix relative to this file
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+
+# There's no guarantee that CMAKE_INSTALL_XXXDIR is a relative path so we extract the final component to handle asbolute paths
+get_filename_component(_INCLUDE_DIR_NAME "@CMAKE_INSTALL_INCLUDEDIR@" NAME)
+get_filename_component(_LIB_DIR_NAME "@CMAKE_INSTALL_LIBDIR@" NAME)
+
+set_and_check (@PROJECT_NAME@_INCLUDE_DIR "${_IMPORT_PREFIX}/${_INCLUDE_DIR_NAME}")
+set_and_check (@PROJECT_NAME@_INCLUDES    "${_IMPORT_PREFIX}/${_INCLUDE_DIR_NAME}")
+set_and_check (@PROJECT_NAME@_LIB_DIR     "${_IMPORT_PREFIX}/${_LIB_DIR_NAME}")
 
 #...logic to determine installedPrefix from the own location...
 #set (@PROJECT_NAME@_CONFIG_DIR  "${installedPrefix}/@CONFIG_INSTALL_DIR@")


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>
