### PR TITLE
Start switching over from sprintf to fmt

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -105,8 +105,8 @@ endif ()
 
 # OpenImageIO
 checked_find_package (OpenImageIO REQUIRED
-                      VERSION_MIN 2.2.6)
-
+                      VERSION_MIN 2.2.6
+                      DEFINITIONS -DOIIO_HIDE_FORMAT=1)
 
 checked_find_package (pugixml REQUIRED
                       VERSION_MIN 1.8)

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -77,8 +77,8 @@ typedef typename BatchedBackendLLVM::FuncSpec FuncSpec;
 void
 BatchedBackendLLVM::llvm_gen_debug_printf(string_view message)
 {
-    ustring s = ustring::format("(%s %s) %s", inst()->shadername(),
-                                inst()->layername(), message);
+    ustring s = ustring::sprintf("(%s %s) %s", inst()->shadername(),
+                                 inst()->layername(), message);
     ll.call_function(build_name("printf"), sg_void_ptr(), ll.constant("%s\n"),
                      ll.constant(s));
 }

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -607,8 +607,8 @@ OptixGridRenderer::make_optix_materials ()
             // FIXME: This is for cases where testshade is run with 1x1 resolution
             //        Those tests may not have a Cout parameter to write to.
             if (m_xres > 1 && m_yres > 1) {
-                errhandler().warning ("Requested output '%s', which wasn't found",
-                                      outputs[0]);
+                errhandler().warningfmt("Requested output '{}', which wasn't found",
+                                        outputs[0]);
             }
         }
 


### PR DESCRIPTION
Turn on warnings about OIIO::Strutil::format and ustring::format

We should be using Strutil::sprintf / ustring::sprintf, or upgrading
entirely to Strutil::fmt::format / ustring::fmtformat.

Some day, the plain "format" will be deprecated, then disappear, then
reappear as compatible with std::format (as are fmt::format/fmtformat now).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
