### PR TITLE
PR/ICX_Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,10 @@ ifneq (${USE_BATCHED},)
 MY_CMAKE_FLAGS += -DUSE_BATCHED:STRING="${USE_BATCHED}"
 endif
 
+ifneq (${VEC_REPORT},)
+MY_CMAKE_FLAGS += -DVEC_REPORT:BOOL="${VEC_REPORT}"
+endif
+
 ifneq (${TEST},)
 TEST_FLAGS += -R ${TEST}
 endif
@@ -398,6 +402,7 @@ help:
 	@echo "                                  0, b8_AVX, b8_AVX2, b8_AVX2_noFMA,"
 	@echo "                                  b8_AVX512, b8_AVX512_noFMA,"
 	@echo "                                  b16_AVX512, b16_AVX512_noFMA)"
+	@echo "      VEC_REPORT=0             Generate compiler vectorization reports"
 	@echo "  make test, extra options:"
 	@echo "      TEST=regex               Run only tests matching the regex"
 	@echo ""

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -327,6 +327,7 @@ endif ()
 # The USE_BATCHED option may be set to indicate that support for batched
 # SIMD shader execution be compiled along with targe specific libraries
 set (USE_BATCHED "" CACHE STRING "Build batched SIMD shader execution for (0, b8_AVX, b8_AVX2, b8_AVX2_noFMA, b8_AVX512, b8_AVX512_noFMA, b16_AVX512, b16_AVX512_noFMA)")
+option (VEC_REPORT "Enable compiler's reporting system for vectorization" OFF)
 set (BATCHED_SUPPORT_DEFINES "")
 set (BATCHED_TARGET_LIBS "")
 set (BUILD_BATCHED False)

--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -640,7 +640,7 @@ OSL_FORCEINLINE OSL_HOSTDEVICE Dual2<float> select(const bool b, const Dual2<flo
     // versus requiring a stack location.
     // Without this work per component, gathers & scatters were being emitted
     // when used inside SIMD loops.
-#if OSL_ANY_CLANG && !OSL_INTEL_CLASSIC_COMPILER_VERSION
+#if OSL_ANY_CLANG && !OSL_INTEL_CLASSIC_COMPILER_VERSION && !OSL_INTEL_LLVM_COMPILER_VERSION
     // Clang's vectorizor was really insistent that a select operation could not be replaced
     // with control flow, so had to re-introduce the ? operator to make it happy
     return Dual2<float> (

--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -263,7 +263,7 @@
 #endif
 
 #define OSL_OMP_SIMD_LOOP(...) OSL_OMP_PRAGMA(omp simd __VA_ARGS__)
-#if (OSL_GCCVERSION || OSL_INTEL_CLASSIC_COMPILER_VERSION)
+#if (OSL_GCCVERSION || OSL_INTEL_CLASSIC_COMPILER_VERSION || OSL_INTEL_LLVM_COMPILER_VERSION)
 #   define OSL_OMP_COMPLEX_SIMD_LOOP(...) OSL_OMP_SIMD_LOOP(__VA_ARGS__)
 #else
     // Ignore requests to vectorize complex/nested SIMD loops for certain

--- a/src/include/OSL/sfmath.h
+++ b/src/include/OSL/sfmath.h
@@ -263,7 +263,7 @@ namespace sfm
         }
     }
 
-#if OSL_ANY_CLANG && !OSL_INTEL_CLASSIC_COMPILER_VERSION
+#if OSL_ANY_CLANG && !OSL_INTEL_CLASSIC_COMPILER_VERSION && !OSL_INTEL_LLVM_COMPILER_VERSION
 
     // To make clang's loop vectorizor happy
     // we need to make sure result of min and max

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -161,8 +161,12 @@ macro ( REQUIRE_INF_NAN SRC )
         else ()
             #set_property(SOURCE $SRC} APPEND PROPERTY COMPILE_OPTIONS "-fp-model=precise")
             # Disabling fast-math should be enough to enable proper support of INF and NaN
-            set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS "-fno-fast-math")
-            #message (STATUS "SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS -fno-fast-math")
+            #set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS "-fno-fast-math")
+            # We can explicitly honor inf, nans, and signed 0's
+            set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS 
+                "-fhonor-infinities" 
+                "-fhonor-nans" 
+                "-fsigned-zeros")
         endif()
     endif()
 endmacro ( )
@@ -383,9 +387,12 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
             
             list (APPEND TARGET_CXX_OPTS 
                 "/Qprec-div" 
-                "/Qopt-report:5"
                 "/Qopenmp-simd"
                 )
+            if (VEC_REPORT)
+                list (APPEND TARGET_CXX_OPTS "/Qopt-report:5")
+            endif ()
+                
                 
         else ()
             if (${TARGET_OPT_ISA} STREQUAL "AVX512")
@@ -409,10 +416,13 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
             
             list (APPEND TARGET_CXX_OPTS 
                 "-prec-div" 
-                "-qopt-report=5" 
                 "-qopenmp-simd"
                 "-qno-opt-multiple-gather-scatter-by-shuffles"
                 )
+                
+            if (VEC_REPORT)
+                list (APPEND TARGET_CXX_OPTS "-qopt-report=5")
+            endif ()
                 
         endif ()
     endif ()
@@ -459,12 +469,20 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
             list (APPEND TARGET_CXX_OPTS "-fopenmp")
         endif ()
         
-        # Uncomment next section to investigate failures in vectorization
-        #list (APPEND TARGET_CXX_OPTS 
-        #    "-Rpass=loop-vectorize" 
-        #    "-Rpass-analysis=loop-vectorize" 
-        #    "-Rpass-missed=loop-vectorize"
-        #    )
+        if (VEC_REPORT)
+            if (CMAKE_COMPILER_IS_INTELCLANG)
+                list (APPEND TARGET_CXX_OPTS 
+                    "-qopt-report=3"
+                    )
+            else ()
+                list (APPEND TARGET_CXX_OPTS 
+                    "-Rpass=loop-vectorize" 
+                    "-Rpass-analysis=loop-vectorize" 
+                    # Uncomment next section to investigate failures in vectorization
+                    #"-Rpass-missed=loop-vectorize"
+                    )
+            endif ()
+        endif ()
     endif ()
     
     

--- a/src/liboslexec/opcolor_impl.h
+++ b/src/liboslexec/opcolor_impl.h
@@ -243,7 +243,7 @@ hsv_to_rgb (const COLOR3& hsv)
         // Avoid switch statement vectorizor doesn't like
         // Also avoid if/else nest which some optimizers might
         // convert back into a switch statement
-#   if OSL_ANY_CLANG && !OSL_INTEL_CLASSIC_COMPILER_VERSION
+#   if OSL_ANY_CLANG && !OSL_INTEL_CLASSIC_COMPILER_VERSION && !OSL_INTEL_LLVM_COMPILER_VERSION
         // Clang was still transforming series of if's back into a switch.
         // Alternate between == and <= comparisons to avoid
 #       define __OSL_ASC_EQ <=


### PR DESCRIPTION
## Description

Enable icx compiler to vectorize OSL_OMP_COMPLEX_SIMD_LOOP
Avoid many clang vectorization workarounds for OSL_INTEL_LLVM_COMPILER_VERSION
Added Makefile option VEC_REPORT to turn on generation of optimization reports
Reduce impact of REQUIRE_INF_NAN for icx by explicitly honoring inf, nan, and signed zeros vs. disabling fast-math

## Tests

Existing tests with CI plan will exercise everything

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

