### PR TITLE
Fix GPU codegen crash

### DIFF
--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -680,8 +680,8 @@ BackendLLVM::llvm_load_device_string (const Symbol& sym, bool follow)
     int userdata_index = find_userdata_index (sym);
 
     llvm::Value* val = NULL;
-    if (sym.symtype() == SymTypeLocal) {
-        // Handle temporary local variables
+    if (sym.symtype() == SymTypeLocal || sym.symtype() == SymTypeTemp) {
+        // Handle temporary and local variables
         val = getOrAllocateLLVMSymbol (sym);
         val = ll.ptr_cast (val, ll.type_longlong_ptr());
     }


### PR DESCRIPTION
llvm_load_device_string wasn't considering temporary string variables,
only declared local variables.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
