### PR TITLE
Hide Matrix22 definition better -- it's not part of any public API

### DIFF
--- a/src/include/OSL/Imathx/Imathx.h
+++ b/src/include/OSL/Imathx/Imathx.h
@@ -16,8 +16,20 @@
 
 #include <OSL/oslconfig.h>
 
+#if OSL_USING_IMATH < 3
+#   include <OSL/matrix22.h>
+#endif
+
 
 OSL_NAMESPACE_ENTER
+
+
+#if OSL_USING_IMATH >= 3
+using Matrix22 = Imath::Matrix22<Float>;
+#else
+using Matrix22 = Imathx::Matrix22<Float>;
+#endif
+
 
 // Choose to treat helper functions as static
 // so their symbols don't escape and possibly collide

--- a/src/include/OSL/matrix22.h
+++ b/src/include/OSL/matrix22.h
@@ -959,7 +959,7 @@ Matrix22<T>::inverse (bool singExc) const
                 {
 #ifndef __CUDA_ARCH__
                     if (singExc)
-                        throw Imath::SingMatrixExc ("Cannot invert "
+                        throw std::invalid_argument ("Cannot invert "
                                              "singular matrix.");
 #endif
                     return Matrix22();

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -23,7 +23,6 @@
 #   include <OSL/Imathx/ImathVec.h>
 #   include <OSL/Imathx/ImathMatrix.h>
 #   include <OSL/Imathx/ImathColor.h>
-#   include <OSL/matrix22.h>
 #endif
 
 // We included the Imath files we needed, so set the OIIO_IMATH_H_INCLUDED
@@ -32,11 +31,9 @@
 #define OIIO_IMATH_H_INCLUDED 1
 
 
-// The fmt library causes trouble for Cuda. Work around by disabling it from
-// oiio headers (OIIO <= 2.1) or telling fmt not to use the troublesome
-// int128 that Cuda doesn't understand (OIIO >= 2.2).
+// The fmt library causes trouble for Cuda. Work around by telling fmt not to
+// use the troublesome int128 that Cuda doesn't understand.
 #ifdef __CUDA_ARCH__
-#    define OIIO_USE_FMT 0
 #    ifndef FMT_USE_INT128
 #        define FMT_USE_INT128 0
 #    endif
@@ -82,11 +79,6 @@ using Color3   = Imath::Color3<Float>;
 using Matrix33 = Imath::Matrix33<Float>;
 using Matrix44 = Imath::Matrix44<Float>;
 
-#if OSL_USING_IMATH >= 3
-using Matrix22 = Imath::Matrix22<Float>;
-#else
-using Matrix22 = Imathx::Matrix22<Float>;
-#endif
 
 
 /// Assume that we are dealing with OpenImageIO's texture system.  It


### PR DESCRIPTION
Also change the one exception mentioned to a std one, matching
Imath 3.x and insulating us from any of the old Iex custom exceptions
from Imath 2.x.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
