### PR TITLE
Fix minor warnings about pointer casts on windows

### DIFF
--- a/src/liboslexec/accum_test.cpp
+++ b/src/liboslexec/accum_test.cpp
@@ -44,7 +44,7 @@ class MyAov final : public Aov
             // our custom argument to write is the rule's number so we
             // can check what. But you normally would pass information
             // about the pixel.
-            long int testno = (long int)flush_data;
+            size_t testno = reinterpret_cast<size_t>(flush_data);
             if (has_color && color.x > 0)
                 // only mrk with true if there is a positive color present
                 m_received[testno] = true;
@@ -64,7 +64,7 @@ class MyAov final : public Aov
 };
 
 // Simulate the tracing of a path with the accumulator
-void simulate(Accumulator &accum, const char **events, int testno)
+void simulate(Accumulator &accum, const char **events, size_t testno)
 {
     accum.begin();
     accum.pushState();
@@ -86,7 +86,7 @@ void simulate(Accumulator &accum, const char **events, int testno)
     accum.accum(Color3(1, 1, 1));
     // Restore state and flush
     accum.popState();
-    accum.end((void *)(long int)testno);
+    accum.end(reinterpret_cast<void*>(testno));
 }
 
 int main()

--- a/src/liboslexec/automata.cpp
+++ b/src/liboslexec/automata.cpp
@@ -113,7 +113,7 @@ NdfAutomata::State::tostr()const
     // and finally the rule if we have it
     if (m_rule) {
         s += " | ";
-        s += Strutil::sprintf("%lx", (long unsigned int)m_rule);
+        s += Strutil::sprintf("%p", m_rule);
     }
     return s;
 }
@@ -362,7 +362,7 @@ DfAutomata::State::tostr()const
         for (RuleSet::const_iterator i = m_rules.begin(); i != m_rules.end(); ++i) {
             if (s[s.size()-1] != '[')
                 s += ", ";
-            s += Strutil::sprintf("%lx", (long unsigned int)*i);
+            s += Strutil::sprintf("%p", *i);
         }
         s += "]";
     }


### PR DESCRIPTION
MSVC defines `long` as a 32-bit type even on 64-bit machines, so switch to `size_t` instead.

For formatting, print pointers as pointers instead of casting to `long`.