### PR TITLE
OptiX matrix fixes

### DIFF
--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -5,13 +5,14 @@
 set ($OSL_EXTRA_NVCC_ARGS "" CACHE STRING "Custom args passed to nvcc when compiling CUDA code")
 
 # Compile a CUDA file to PTX using NVCC
-function ( NVCC_COMPILE cuda_src ptx_generated extra_nvcc_args )
+function ( NVCC_COMPILE cuda_src extra_headers ptx_generated extra_nvcc_args )
     get_filename_component ( cuda_src_we ${cuda_src} NAME_WE )
     get_filename_component ( cuda_src_dir ${cuda_src} DIRECTORY )
     set (cuda_ptx "${CMAKE_CURRENT_BINARY_DIR}/${cuda_src_we}.ptx" )
     set (${ptxlist} ${${ptxlist}} ${cuda_ptx} )
     set (${ptx_generated} ${cuda_ptx} PARENT_SCOPE)
     file ( GLOB cuda_headers "${cuda_src_dir}/*.h" )
+    list (APPEND cuda_headers ${extra_headers})
 
     list (TRANSFORM IMATH_INCLUDES PREPEND -I
           OUTPUT_VARIABLE ALL_IMATH_INCLUDES)

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -423,12 +423,12 @@ LLVMGEN (llvm_gen_printf)
         Symbol sym(format_sym.name(), format_sym.typespec(), format_sym.symtype());
         format_ustring = s;
         sym.set_dataptr(SymArena::Absolute, &format_ustring);
-        call_args[new_format_slot] = rop.llvm_load_device_string (sym, /*follow*/ true);
+        call_args[new_format_slot] = rop.ll.int_to_ptr_cast (rop.llvm_load_device_string (sym, /*follow*/ true));
 #else
         // Make sure host has the format string so it can print it
         format_ustring = s;
         rop.shadingsys().renderer()->register_string (format_ustring.string(), "");
-        call_args[new_format_slot] = rop.ll.constant64 (format_ustring.hash());
+        call_args[new_format_slot] = rop.ll.int_to_ptr_cast (rop.ll.constant64 (format_ustring.hash()));
 #endif
         size_t nargs = call_args.size() - (new_format_slot+1);
         // Allocate space to store the arguments to osl_printf().
@@ -444,7 +444,7 @@ LLVMGEN (llvm_gen_printf)
         {
             llvm::Value* args_size = rop.ll.constant64(optix_size);
             llvm::Value* memptr = rop.ll.offset_ptr (voids, 0);
-            llvm::Value* iptr = rop.ll.ptr_cast(memptr, rop.ll.type_int_ptr());
+            llvm::Value* iptr = rop.ll.ptr_cast(memptr, rop.ll.type_longlong_ptr());
             rop.ll.op_store (args_size, iptr);
         }
         optix_size = sizeof(uint64_t);  // first 'args' element is the size of the argument list

--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -26,7 +26,7 @@ if (USE_OPTIX)
 
     # Generate PTX for all of the CUDA files
     foreach (cudasrc ${testrender_cuda_srcs})
-        NVCC_COMPILE ( ${cudasrc} ptx_generated "" )
+        NVCC_COMPILE ( ${cudasrc} "" ptx_generated "" )
         list (APPEND ptx_list ${ptx_generated})
     endforeach ()
 

--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -7,11 +7,20 @@ file(GLOB testrender_srcs *.cpp)
 
 if (USE_OPTIX)
     set (testrender_cuda_srcs
-         cuda/quad.cu
-         cuda/optix_raytracer.cu
-         cuda/sphere.cu
-         cuda/wrapper.cu
-         cuda/rend_lib.cu )
+        cuda/quad.cu
+        cuda/optix_raytracer.cu
+        cuda/sphere.cu
+        cuda/wrapper.cu )
+
+    # We only need to generate the PTX for rend_lib.cu if we are using OptiX 7.0+.
+    # Some of OptiX 6 device functions defined in rend_lib.cu cannot be compiled
+    # with NVCC, they must be compiled with clang using the LLVM_COMPILE_CUDA macro.
+    if (OPTIX_VERSION VERSION_GREATER_EQUAL 7)
+        list (APPEND testshade_cuda_srcs cuda/rend_lib.cu)
+    endif ()
+
+    # We need to make sure that the PTX files are regenerated whenever these
+    # headers change.
     set (testrender_cuda_headers
          cuda/rend_lib.h )
 

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -6,6 +6,7 @@
 #include <optix_device.h>
 #if (OPTIX_VERSION < 70000)
 #include <optix_math.h>
+#include <optixu/optixu_matrix_namespace.h>
 #else
 #define OPTIX_COMPATIBILITY 7
 #include <optix_device.h>
@@ -21,6 +22,10 @@ rtDeclareVariable (uint2, launch_index, rtLaunchIndex, );
 rtDeclareVariable (uint2, launch_dim,   rtLaunchDim, );
 rtDeclareVariable (char*, test_str_1, , );
 rtDeclareVariable (char*, test_str_2, , );
+
+// N.B. These will be cast to OSL::Matrix44 variables when used.
+rtDeclareVariable (optix::Matrix4x4, object2common, , );
+rtDeclareVariable (optix::Matrix4x4, shader2common, , );
 
 OSL_NAMESPACE_ENTER
 namespace pvt {
@@ -357,18 +362,20 @@ extern "C" {
     int osl_get_matrix (void *sg_, void *r, const char *from)
     {
         ShaderGlobals *sg = (ShaderGlobals *)sg_;
-        //ShadingContext *ctx = (ShadingContext *)sg->context;
-        if (HDSTR(from) == STRING_PARAMS(common) ||
-            //HDSTR(from) == ctx->shadingsys().commonspace_synonym() ||
-            HDSTR(from) == STRING_PARAMS(shader))
+        if (HDSTR(from) == STRING_PARAMS(common))
         {
-            MAT(r).makeIdentity ();
+            MAT(r).makeIdentity();
             return true;
         }
         if (HDSTR(from) == STRING_PARAMS(object))
         {
-            // TODO: Implement transform
-            return false;
+            MAT(r) = MAT(&object2common);
+            return true;
+        }
+        if (HDSTR(from) == STRING_PARAMS(shader))
+        {
+            MAT(r) = MAT(&shader2common);
+            return true;
         }
         int ok = false; // TODO: Implement transform
         if (!ok)
@@ -383,18 +390,22 @@ extern "C" {
     int osl_get_inverse_matrix (void *sg_, void *r, const char *to)
     {
         ShaderGlobals *sg = (ShaderGlobals *)sg_;
-        //ShadingContext *ctx = (ShadingContext *)sg->context;
-        if (HDSTR(to) == STRING_PARAMS(common) ||
-            //HDSTR(to) == ctx->shadingsys().commonspace_synonym() ||
-            HDSTR(to) == STRING_PARAMS(shader))
+        if (HDSTR(to) == STRING_PARAMS(common))
         {
-            MAT(r).makeIdentity ();
+            MAT(r).makeIdentity();
             return true;
         }
         if (HDSTR(to) == STRING_PARAMS(object))
         {
-            // TODO: Implement transform
-            return false;
+            MAT(r) = MAT(&object2common);
+            MAT(r).invert();
+            return true;
+        }
+        if (HDSTR(to) == STRING_PARAMS(shader))
+        {
+            MAT(r) = MAT(&shader2common);
+            MAT(r).invert();
+            return true;
         }
         int ok = false; // TODO: Implement transform
         if (!ok)
@@ -781,18 +792,20 @@ extern "C" {
     int osl_get_matrix (void *sg_, void *r, const char *from)
     {
         ShaderGlobals *sg = (ShaderGlobals *)sg_;
-        //ShadingContext *ctx = (ShadingContext *)sg->context;
-        if (HDSTR(from) == STRING_PARAMS(common) ||
-            //HDSTR(from) == ctx->shadingsys().commonspace_synonym() ||
-            HDSTR(from) == STRING_PARAMS(shader))
+        if (HDSTR(from) == STRING_PARAMS(common))
         {
-            MAT(r).makeIdentity ();
+            MAT(r).makeIdentity();
             return true;
         }
         if (HDSTR(from) == STRING_PARAMS(object))
         {
-            // TODO: Implement transform
-            return false;
+            MAT(r) = MAT(sg->object2common);
+            return true;
+        }
+        if (HDSTR(from) == STRING_PARAMS(shader))
+        {
+            MAT(r) = MAT(sg->shader2common);
+            return true;
         }
         int ok = false; // TODO: Implement transform
         if (!ok)
@@ -807,17 +820,22 @@ extern "C" {
     int osl_get_inverse_matrix (void *sg_, void *r, const char *to)
     {
         ShaderGlobals *sg = (ShaderGlobals *)sg_;
-        if (HDSTR(to) == STRING_PARAMS(common) ||
-            //HDSTR(to) == ctx->shadingsys().commonspace_synonym() ||
-            HDSTR(to) == STRING_PARAMS(shader))
+        if (HDSTR(to) == STRING_PARAMS(common))
         {
-            MAT(r).makeIdentity ();
+            MAT(r).makeIdentity();
             return true;
         }
         if (HDSTR(to) == STRING_PARAMS(object))
         {
-            // TODO: Implement transform
-            return false;
+            MAT(r) = MAT(sg->object2common);
+            MAT(r).invert();
+            return true;
+        }
+        if (HDSTR(to) == STRING_PARAMS(shader))
+        {
+            MAT(r) = MAT(sg->shader2common);
+            MAT(r).invert();
+            return true;
         }
         int ok = false; // TODO: Implement transform
         if (!ok)

--- a/src/testrender/cuda/rend_lib.h
+++ b/src/testrender/cuda/rend_lib.h
@@ -38,8 +38,11 @@ namespace pvt {
 extern __device__ CUdeviceptr s_color_system;
 extern __device__ CUdeviceptr osl_printf_buffer_start;
 extern __device__ CUdeviceptr osl_printf_buffer_end;
-extern __device__ uint64_t test_str_1;
-extern __device__ uint64_t test_str_2;
+extern __device__ uint64_t    test_str_1;
+extern __device__ uint64_t    test_str_2;
+extern __device__ uint64_t    num_named_xforms;
+extern __device__ CUdeviceptr xform_name_buffer;
+extern __device__ CUdeviceptr xform_buffer;
 }
 #endif
 OSL_NAMESPACE_EXIT

--- a/src/testrender/cuda/wrapper.cu
+++ b/src/testrender/cuda/wrapper.cu
@@ -43,8 +43,8 @@ rtDeclareVariable (float,      t_hit,        rtIntersectionDistance, );
 rtBuffer<float3,2> output_buffer;
 
 // Function pointers for the OSL shader
-rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, void*, int)>, osl_init_func, , );
-rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, void*, int)>, osl_group_func, ,);
+rtDeclareVariable (rtCallableProgramId<void (void*, void*)>, osl_init_func, , );
+rtDeclareVariable (rtCallableProgramId<void (void*, void*)>, osl_group_func, ,);
 
 RT_PROGRAM void any_hit_shadow()
 {

--- a/src/testrender/render_params.h
+++ b/src/testrender/render_params.h
@@ -19,6 +19,14 @@ struct RenderParams
     CUdeviceptr osl_printf_buffer_start;
     CUdeviceptr osl_printf_buffer_end; 
     CUdeviceptr color_system;
+
+    // for transforms
+    CUdeviceptr object2common;
+    CUdeviceptr shader2common;
+    uint64_t    num_named_xforms;
+    CUdeviceptr xform_name_buffer;
+    CUdeviceptr xform_buffer;
+
     // for used-data tests
     uint64_t test_str_1;
     uint64_t test_str_2;

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -18,10 +18,18 @@ endif()
 if (USE_OPTIX)
     set ( testshade_cuda_srcs
         cuda/optix_grid_renderer.cu
-        ../testrender/cuda/wrapper.cu
-        ../testrender/cuda/rend_lib.cu )
+        ../testrender/cuda/wrapper.cu )
+
+    # We only need to generate the PTX for rend_lib.cu if we are using OptiX 7.0+.
+    # Some of OptiX 6 device functions defined in rend_lib.cu cannot be compiled
+    # with NVCC, they must be compiled with clang using the LLVM_COMPILE_CUDA macro.
+    if (OPTIX_VERSION VERSION_GREATER_EQUAL 7)
+        list (APPEND testshade_cuda_srcs ../testrender/cuda/rend_lib.cu)
+    endif ()
+
     set ( testshade_cuda_headers
         ../testrender/cuda/rend_lib.h )
+
     # We need to make sure that the PTX files are regenerated whenever these
     # headers change.
     set ( extra_cuda_headers

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -22,6 +22,10 @@ if (USE_OPTIX)
         ../testrender/cuda/rend_lib.cu )
     set ( testshade_cuda_headers
         ../testrender/cuda/rend_lib.h )
+    # We need to make sure that the PTX files are regenerated whenever these
+    # headers change.
+    set ( extra_cuda_headers
+        render_params.h )
 
     LLVM_COMPILE_CUDA (
         ${CMAKE_CURRENT_SOURCE_DIR}/../testrender/cuda/rend_lib.cu
@@ -34,7 +38,7 @@ if (USE_OPTIX)
 
     # Generate PTX for all of the CUDA files
     foreach (cudasrc ${testshade_cuda_srcs})
-        NVCC_COMPILE ( ${cudasrc} ptx_generated "-I../testrender/cuda" )
+        NVCC_COMPILE ( ${cudasrc} ${extra_cuda_headers} ptx_generated "-I../testrender/cuda" )
         list (APPEND ptx_list ${ptx_generated})
     endforeach ()
 

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -30,8 +30,8 @@ rtDeclareVariable (int,   flipv, , );
 // Buffers
 rtBuffer<float3,2> output_buffer;
 
-rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, void*, int)>, osl_init_func, , );
-rtDeclareVariable (rtCallableProgramId<void (void*, void*, void*, void*, int)>, osl_group_func, ,);
+rtDeclareVariable (rtCallableProgramId<void (void*, void*)>, osl_init_func, , );
+rtDeclareVariable (rtCallableProgramId<void (void*, void*)>, osl_group_func, ,);
 
 RT_PROGRAM void raygen()
 {
@@ -55,7 +55,7 @@ RT_PROGRAM void raygen()
     sg.u           = d.x * invw;
     sg.v           = d.y * invh;
     if (flipv)
-         sg.v      = 1.f - sg.v;
+        sg.v       = 1.f - sg.v;
 
     sg.dudx        = invw;
     sg.dudy        = 0;

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -183,6 +183,9 @@ extern "C" __global__ void __raygen__()
     sg.raytype = CAMERA;
     sg.flipHandedness = 0;
 
+    sg.shader2common = reinterpret_cast<void*>(render_params.shader2common);
+    sg.object2common = reinterpret_cast<void*>(render_params.object2common);
+
     // Pack the "closure pool" into one of the ShaderGlobals pointers
     *(int*) &closure_pool[0] = 0;
     sg.renderstate = &closure_pool[0];

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -117,13 +117,15 @@ extern "C" __global__ void __anyhit__()
 
 extern "C" __global__ void __raygen__setglobals()
 {
-
     // Set global variables
     OSL::pvt::osl_printf_buffer_start    = render_params.osl_printf_buffer_start;
     OSL::pvt::osl_printf_buffer_end      = render_params.osl_printf_buffer_end;
     OSL::pvt::s_color_system             = render_params.color_system;
     OSL::pvt::test_str_1                 = render_params.test_str_1;
     OSL::pvt::test_str_2                 = render_params.test_str_2;
+    OSL::pvt::num_named_xforms           = render_params.num_named_xforms;
+    OSL::pvt::xform_name_buffer          = render_params.xform_name_buffer;
+    OSL::pvt::xform_buffer               = render_params.xform_buffer;
 }
 extern "C" __global__ void __miss__setglobals() { }
 

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -177,6 +177,8 @@ OptixGridRenderer::~OptixGridRenderer ()
     if (m_optix_ctx)
         m_optix_ctx->destroy();
 #else
+    for (void* p : m_ptrs_to_free )
+        cudaFree (p);
     if (m_optix_ctx)
         OPTIX_CHECK (optixDeviceContextDestroy (m_optix_ctx));
 #endif
@@ -241,6 +243,9 @@ OptixGridRenderer::synch_attributes ()
     uint64_t addr2 = register_string ("userdata string", "");
     m_optix_ctx["test_str_1"]->setUserData (sizeof(char*), &addr1);
     m_optix_ctx["test_str_2"]->setUserData (sizeof(char*), &addr2);
+
+    m_optix_ctx["object2common"]->setMatrix4x4fv (/*transpose*/ false, m_object2common.getValue());
+    m_optix_ctx["shader2common"]->setMatrix4x4fv (/*transpose*/ false, m_shader2common.getValue());
 
     {
         const char* name = OSL_NAMESPACE_STRING "::pvt::s_color_system";
@@ -324,7 +329,16 @@ OptixGridRenderer::synch_attributes ()
         CUDA_CHECK (cudaMalloc (reinterpret_cast<void **>(&d_color_system), podDataSize + sizeof(uint64_t)*numStrings));
         CUDA_CHECK (cudaMemcpy (reinterpret_cast<void *>(d_color_system), colorSys, podDataSize, cudaMemcpyHostToDevice));
         CUDA_CHECK (cudaMalloc (reinterpret_cast<void **>(&d_osl_printf_buffer), OSL_PRINTF_BUFFER_SIZE));
-        CUDA_CHECK (cudaMemset(reinterpret_cast<void *>(d_osl_printf_buffer), 0, OSL_PRINTF_BUFFER_SIZE));
+        CUDA_CHECK (cudaMemset (reinterpret_cast<void *>(d_osl_printf_buffer), 0, OSL_PRINTF_BUFFER_SIZE));
+
+        // Transforms
+        CUDA_CHECK (cudaMalloc (reinterpret_cast<void **>(&d_object2common), sizeof(OSL::Matrix44)));
+        CUDA_CHECK (cudaMemcpy (reinterpret_cast<void *>(d_object2common), &m_object2common, sizeof(OSL::Matrix44), cudaMemcpyHostToDevice));
+        CUDA_CHECK (cudaMalloc (reinterpret_cast<void **>(&d_shader2common), sizeof(OSL::Matrix44)));
+        CUDA_CHECK (cudaMemcpy (reinterpret_cast<void *>(d_shader2common), &m_shader2common, sizeof(OSL::Matrix44), cudaMemcpyHostToDevice));
+
+        m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_color_system));
+        m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_osl_printf_buffer));
 
         // then copy the device string to the end, first strings starting at dataPtr - (numStrings)
         // FIXME -- Should probably handle alignment better.
@@ -336,7 +350,6 @@ OptixGridRenderer::synch_attributes ()
             CUDA_CHECK (cudaMemcpy (reinterpret_cast<void *>(gpuStrings), &devStr, sizeof(devStr), cudaMemcpyHostToDevice));
             gpuStrings += sizeof(DeviceString);
         }
-
 #endif
     }
 #endif
@@ -772,6 +785,13 @@ OptixGridRenderer::make_optix_materials ()
     CUDA_CHECK (cudaMalloc (reinterpret_cast<void **> (&d_setglobals_raygenRecord)   ,     sizeof(EmptyRecord)));
     CUDA_CHECK (cudaMalloc (reinterpret_cast<void **> (&d_setglobals_missRecord)     ,     sizeof(EmptyRecord)));
 
+    m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_raygenRecord));
+    m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_missRecord));
+    m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_hitgroupRecord));
+    m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_callablesRecord));
+    m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_setglobals_raygenRecord));
+    m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_setglobals_missRecord));
+
     CUDA_CHECK (cudaMemcpy (reinterpret_cast<void *>( d_raygenRecord)   , &raygenRecord      , sizeof(EmptyRecord), cudaMemcpyHostToDevice));
     CUDA_CHECK (cudaMemcpy (reinterpret_cast<void *>( d_missRecord)     , &missRecord        , sizeof(EmptyRecord), cudaMemcpyHostToDevice));
     CUDA_CHECK (cudaMemcpy (reinterpret_cast<void *>( d_hitgroupRecord) , &hitgroupRecord    , sizeof(EmptyRecord), cudaMemcpyHostToDevice));
@@ -941,6 +961,8 @@ OptixGridRenderer::get_texture_handle (ustring filename OSL_MAYBE_UNUSED,
                                      &channel_desc,
                                      width,height));
 
+        m_ptrs_to_free.push_back (reinterpret_cast<void*>(pixelArray));
+
         CUDA_CHECK (cudaMemcpy2DToArray (pixelArray,
                                          /* offset */0,0,
                                          pixels.data(),
@@ -1026,6 +1048,8 @@ OptixGridRenderer::render(int xres OSL_MAYBE_UNUSED, int yres OSL_MAYBE_UNUSED)
     CUDA_CHECK (cudaMalloc (reinterpret_cast<void **>(&d_output_buffer), xres * yres * 4 * sizeof(float)));
     CUDA_CHECK (cudaMalloc (reinterpret_cast<void **>(&d_launch_params), sizeof(RenderParams)));
 
+    m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_output_buffer));
+    m_ptrs_to_free.push_back (reinterpret_cast<void*>(d_launch_params));
 
     m_xres = xres;
     m_yres = yres;
@@ -1041,6 +1065,8 @@ OptixGridRenderer::render(int xres OSL_MAYBE_UNUSED, int yres OSL_MAYBE_UNUSED)
     params.color_system          = d_color_system;
     params.test_str_1            = test_str_1;
     params.test_str_2            = test_str_2;
+    params.object2common         = d_object2common;
+    params.shader2common         = d_shader2common;
 
     CUDA_CHECK (cudaMemcpy (reinterpret_cast<void *>(d_launch_params), &params, sizeof(RenderParams), cudaMemcpyHostToDevice));
 
@@ -1204,6 +1230,14 @@ OptixGridRenderer::clear()
 #endif
 
 #endif
+}
+
+void
+OptixGridRenderer::set_transforms(const OSL::Matrix44& object2common,
+                                  const OSL::Matrix44& shader2common)
+{
+    m_object2common = object2common;
+    m_shader2common = shader2common;
 }
 
 OSL_NAMESPACE_EXIT

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -63,6 +63,9 @@ public:
     virtual void finalize_pixel_buffer ();
     virtual void clear ();
 
+    virtual void set_transforms( const OSL::Matrix44& object2common,
+                                 const OSL::Matrix44& shader2common );
+
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is a valid texture that can be subsequently
     /// read or sampled.
@@ -101,6 +104,8 @@ private:
     CUdeviceptr             d_launch_params = 0;
     CUdeviceptr             d_osl_printf_buffer;
     CUdeviceptr             d_color_system;
+    CUdeviceptr             d_object2common;
+    CUdeviceptr             d_shader2common;
     uint64_t                test_str_1;
     uint64_t                test_str_2;
     const unsigned long     OSL_PRINTF_BUFFER_SIZE = 8 * 1024 * 1024;
@@ -110,6 +115,12 @@ private:
     std::string m_materials_ptx;
     std::unordered_map<OIIO::ustring, optix::TextureSampler, OIIO::ustringHash> m_samplers;
     std::unordered_map<OIIO::ustring, uint64_t, OIIO::ustringHash> m_globals_map;
+
+    OSL::Matrix44 m_shader2common;  // "shader" space to "common" space matrix
+    OSL::Matrix44 m_object2common;  // "object" space to "common" space matrix
+
+    // CUdeviceptrs that need to be freed after we are done
+    std::vector<void*> m_ptrs_to_free;
 };
 
 #if (OPTIX_VERSION >= 70000)

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -36,7 +36,7 @@ public:
         return addr;
 #else
         m_hash_map[ustr.hash()] = ustr.c_str();
-        return 0;
+        return static_cast<uint64_t>(ustr.hash());
 #endif
     }
 
@@ -65,6 +65,8 @@ public:
 
     virtual void set_transforms( const OSL::Matrix44& object2common,
                                  const OSL::Matrix44& shader2common );
+
+    virtual void register_named_transforms();
 
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is a valid texture that can be subsequently
@@ -106,6 +108,9 @@ private:
     CUdeviceptr             d_color_system;
     CUdeviceptr             d_object2common;
     CUdeviceptr             d_shader2common;
+    uint64_t                m_num_named_xforms;
+    CUdeviceptr             d_xform_name_buffer;
+    CUdeviceptr             d_xform_buffer;
     uint64_t                test_str_1;
     uint64_t                test_str_2;
     const unsigned long     OSL_PRINTF_BUFFER_SIZE = 8 * 1024 * 1024;

--- a/src/testshade/render_params.h
+++ b/src/testshade/render_params.h
@@ -9,7 +9,9 @@ struct RenderParams
     bool flipv;
     CUdeviceptr osl_printf_buffer_start;
     CUdeviceptr osl_printf_buffer_end;
-    CUdeviceptr color_system;                                                
+    CUdeviceptr color_system;
+    CUdeviceptr object2common;
+    CUdeviceptr shader2common;
     // for used-data tests
     uint64_t test_str_1;
     uint64_t test_str_2;

--- a/src/testshade/render_params.h
+++ b/src/testshade/render_params.h
@@ -10,8 +10,14 @@ struct RenderParams
     CUdeviceptr osl_printf_buffer_start;
     CUdeviceptr osl_printf_buffer_end;
     CUdeviceptr color_system;
+
+    // for transforms
     CUdeviceptr object2common;
     CUdeviceptr shader2common;
+    uint64_t    num_named_xforms;
+    CUdeviceptr xform_name_buffer;
+    CUdeviceptr xform_buffer;
+
     // for used-data tests
     uint64_t test_str_1;
     uint64_t test_str_2;

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1891,6 +1891,7 @@ test_shade (int argc, const char *argv[])
     if (use_optix)
     {
         reinterpret_cast<OptixGridRenderer *> (rend)->set_transforms(Mobj, Mshad);
+        reinterpret_cast<OptixGridRenderer *> (rend)->register_named_transforms();
 #if (OPTIX_VERSION >= 70000)
         reinterpret_cast<OptixGridRenderer *> (rend)->synch_attributes();
 #endif

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1888,10 +1888,13 @@ test_shade (int argc, const char *argv[])
     setup_transformations (*rend, Mshad, Mobj);
 
 #ifdef OSL_USE_OPTIX
-#if (OPTIX_VERSION >= 70000)
     if (use_optix)
+    {
+        reinterpret_cast<OptixGridRenderer *> (rend)->set_transforms(Mobj, Mshad);
+#if (OPTIX_VERSION >= 70000)
         reinterpret_cast<OptixGridRenderer *> (rend)->synch_attributes();
 #endif
+    }
 #endif
 
     // Set up the image outputs requested on the command line


### PR DESCRIPTION
## Description

This PR adds very basic support for named transforms to testrender and testshade. It's a linear scan through a list of transform names to find the corresponding matrix. Although this is a far-from-ideal solution for real world scenarios with many named transforms, it is sufficient to enable further testing and development.

## Tests

No new tests have been added, but all previously-passing tests still pass. It would be possible to enable the matrix tests in the testsuite if not for some small differences in error reporting:

CPU:
```
Testing getmatrix for unknown space name:
ERROR: Unknown transformation "foobar"
  'foobar' matrix not found, as expected
```
GPU:
```
Testing getmatrix for unknown space name:
  'foobar' matrix not found, as expected
```
## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

