### PR TITLE
Some fmt conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,9 @@ if (USE_OPTIX)
     add_definitions ("-DOSL_USE_OPTIX=1")
 endif ()
 
+# Define OSL_INTERNAL symbol only when building OSL itself, will not be
+# defined for downstream projects using OSL.
+add_definitions (-DOSL_INTERNAL=1)
 
 # Set the default namespace. For symbol hiding reasons, it's important that
 # the project name is a subset of the namespace name.

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -39,6 +39,12 @@
 #    endif
 #endif
 
+// For OSL internal compilation only, get deprecation warnings if we call
+// OIIO ErrorHandler methods that use the old printf style interface.
+#if defined(OSL_INTERNAL) && !defined(OIIO_ERRORHANDLER_HIDE_PRINTF)
+#    define OIIO_ERRORHANDLER_HIDE_PRINTF 1
+#endif
+
 // All the things we need from OpenImageIO
 #include <OpenImageIO/oiioversion.h>
 #include <OpenImageIO/errorhandler.h>
@@ -95,6 +101,7 @@ using OIIO::ustringHash;
 using OIIO::string_view;
 using OIIO::span;
 using OIIO::cspan;
+using OIIO::Strutil::print;
 
 using OIIO::TypeDesc;
 using OIIO::TypeUnknown;

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -85,9 +85,9 @@ public:
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
-            m_errhandler->errorf("%s:%d: error: %s", filename, line, msg);
+            m_errhandler->errorfmt("{}:{}: error: {}", filename, line, msg);
         else
-            m_errhandler->errorf("error: %s", msg);
+            m_errhandler->errorfmt("error: {}", msg);
         m_err = true;
     }
 
@@ -103,13 +103,13 @@ public:
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (m_err_on_warning) {
-            errorf(filename, line, "%s", msg);
+            errorfmt(filename, line, "{}", msg);
             return;
         }
         if (filename.size())
-            m_errhandler->warningf("%s:%d: warning: %s", filename, line, msg);
+            m_errhandler->warningfmt("{}:{}: warning: {}", filename, line, msg);
         else
-            m_errhandler->warningf("warning: %s", msg);
+            m_errhandler->warningfmt("warning: {}", msg);
     }
 
     /// Info reporting
@@ -122,9 +122,9 @@ public:
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
-            m_errhandler->infof("%s:%d: info: %s", filename, line, msg);
+            m_errhandler->infofmt("{}:{}: info: {}", filename, line, msg);
         else
-            m_errhandler->infof("info: %s", msg);
+            m_errhandler->infofmt("info: {}", msg);
     }
 
     /// message reporting
@@ -137,9 +137,76 @@ public:
         if (msg.size() && msg.back() == '\n')  // trim extra newline
             msg.pop_back();
         if (filename.size())
-            m_errhandler->messagef("%s:%d: %s", filename, line, msg);
+            m_errhandler->messagefmt("{}:{}: {}", filename, line, msg);
         else
-            m_errhandler->messagef("%s", msg);
+            m_errhandler->messagefmt("{}", msg);
+    }
+
+    /// Error reporting
+    template<typename... Args>
+    void errorfmt(ustring filename, int line, const char* format,
+                  const Args&... args) const
+    {
+        OSL_DASSERT(format && format[0]);
+        std::string msg = OIIO::Strutil::fmt::format(format, args...);
+        if (msg.size() && msg.back() == '\n')  // trim extra newline
+            msg.pop_back();
+        if (filename.size())
+            m_errhandler->errorfmt("{}:{}: error: {}", filename, line, msg);
+        else
+            m_errhandler->errorfmt("error: {}", msg);
+        m_err = true;
+    }
+
+    /// Warning reporting
+    template<typename... Args>
+    void warningfmt(ustring filename, int line, const char* format,
+                    const Args&... args) const
+    {
+        OSL_DASSERT(format && format[0]);
+        if (nowarn(filename, line))
+            return;  // skip if the filename/line is on the nowarn list
+        std::string msg = OIIO::Strutil::fmt::format(format, args...);
+        if (msg.size() && msg.back() == '\n')  // trim extra newline
+            msg.pop_back();
+        if (m_err_on_warning) {
+            errorfmt(filename, line, "{}", msg);
+            return;
+        }
+        if (filename.size())
+            m_errhandler->warningfmt("{}:{}: warning: {}", filename, line, msg);
+        else
+            m_errhandler->warningfmt("warning: {}", msg);
+    }
+
+    /// Info reporting
+    template<typename... Args>
+    void infofmt(ustring filename, int line, const char* format,
+                 const Args&... args) const
+    {
+        OSL_DASSERT(format && format[0]);
+        std::string msg = OIIO::Strutil::fmt::format(format, args...);
+        if (msg.size() && msg.back() == '\n')  // trim extra newline
+            msg.pop_back();
+        if (filename.size())
+            m_errhandler->infofmt("{}:{}: info: {}", filename, line, msg);
+        else
+            m_errhandler->infofmt("info: {}", msg);
+    }
+
+    /// message reporting
+    template<typename... Args>
+    void messagefmt(ustring filename, int line, const char* format,
+                    const Args&... args) const
+    {
+        OSL_DASSERT(format && format[0]);
+        std::string msg = OIIO::Strutil::fmt::format(format, args...);
+        if (msg.size() && msg.back() == '\n')  // trim extra newline
+            msg.pop_back();
+        if (filename.size())
+            m_errhandler->messagefmt("{}:{}: {}", filename, line, msg);
+        else
+            m_errhandler->messagefmt("{}", msg);
     }
 
     /// Have we hit an error?

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -176,10 +176,10 @@ OSL_NAMESPACE_EXIT
 "protected"|"short"|"signed"|"sizeof"|"static"|"struct" |    \
 "switch"|"template"|"this"|"true"|"typedef"|"uniform" |      \
 "union"|"unsigned"|"varying"|"virtual" {
-                            oslcompiler->errorf(oslcompiler->filename(),
-                                                oslcompiler->lineno(),
-                                                "'%s' is a reserved word",
-                                                yytext);
+                            oslcompiler->errorfmt(oslcompiler->filename(),
+                                                  oslcompiler->lineno(),
+                                                  "'{}' is a reserved word",
+                                                  yytext);
                             SETLINE;
                             return (yylval->i=RESERVED);
                         }
@@ -198,10 +198,10 @@ OSL_NAMESPACE_EXIT
                             // we do not detect overflow when the value is INT_MAX+1,
                             // because negation happens later and -(INT_MAX+1) == INT_MIN
                             if (llval > ((long long)INT_MAX)+1) {
-                                oslcompiler->errorf(oslcompiler->filename(),
-                                                    oslcompiler->lineno(),
-                                                    "integer overflow, value must be between %d and %d.",
-                                                    INT_MIN, INT_MAX);
+                                oslcompiler->errorfmt(oslcompiler->filename(),
+                                                      oslcompiler->lineno(),
+                                                      "integer overflow, value must be between {} and {}.",
+                                                      INT_MIN, INT_MAX);
                             }
                             yylval->i = (int)llval;
                             SETLINE;
@@ -212,10 +212,10 @@ OSL_NAMESPACE_EXIT
                             // we do not detect overflow when the value is INT_MAX+1,
                             // because negation happens later and -(INT_MAX+1) == INT_MIN
                             if (llval > ((long long)UINT_MAX)+1) {
-                                oslcompiler->errorf(oslcompiler->filename(),
-                                                    oslcompiler->lineno(),
-                                                    "integer overflow, value must be between %d and %d.",
-                                                    INT_MIN, INT_MAX);
+                                oslcompiler->errorfmt(oslcompiler->filename(),
+                                                      oslcompiler->lineno(),
+                                                      "integer overflow, value must be between {} and {}.",
+                                                      INT_MIN, INT_MAX);
                             }
                             yylval->i = (int)llval;
                             SETLINE;
@@ -300,8 +300,8 @@ preprocess (const char *str, OSLCompilerImpl* oslcompiler, YYLTYPE* yyloc_param)
     while (*p == ' ' || *p == '\t')
         p++;
     if (*p != '#') {
-        oslcompiler->errorf(oslcompiler->filename(), oslcompiler->lineno(),
-                            "Possible bug in shader preprocess");
+        oslcompiler->errorfmt(oslcompiler->filename(), oslcompiler->lineno(),
+                              "Possible bug in shader preprocess");
         SETLINE;
         return;
     }
@@ -315,30 +315,30 @@ preprocess (const char *str, OSLCompilerImpl* oslcompiler, YYLTYPE* yyloc_param)
         if (pragmatype == "error") {
             string_view msg;
             if (OIIO::Strutil::parse_string(line, msg))
-                oslcompiler->errorf(oslcompiler->filename(),
-                                    oslcompiler->lineno(), "%s", msg);
+                oslcompiler->errorfmt(oslcompiler->filename(),
+                                      oslcompiler->lineno(), "{}", msg);
             else
-                oslcompiler->errorf(oslcompiler->filename(),
-                                    oslcompiler->lineno(),
-                                    "<unknown error>");
+                oslcompiler->errorfmt(oslcompiler->filename(),
+                                      oslcompiler->lineno(),
+                                      "<unknown error>");
         }
         else if (pragmatype == "warning") {
             string_view msg;
             if (OIIO::Strutil::parse_string(line, msg))
-                oslcompiler->warningf(oslcompiler->filename(),
-                                      oslcompiler->lineno(), "%s", msg);
+                oslcompiler->warningfmt(oslcompiler->filename(),
+                                      oslcompiler->lineno(), "{}", msg);
             else
-                oslcompiler->warningf(oslcompiler->filename(),
-                                      oslcompiler->lineno(),
-                                      "<unknown warning>");
+                oslcompiler->warningfmt(oslcompiler->filename(),
+                                        oslcompiler->lineno(),
+                                        "<unknown warning>");
         }
         else if (OIIO::Strutil::iequals (pragmatype, "osl")) {
             string_view pragmaname = OIIO::Strutil::parse_word (line);
             if (pragmaname == "nowarn") {
                 oslcompiler->pragma_nowarn ();
             } else {
-                oslcompiler->warningf(oslcompiler->filename(), oslcompiler->lineno(),
-                                      "Unknown pragma '%s'", pragmaname);
+                oslcompiler->warningfmt(oslcompiler->filename(), oslcompiler->lineno(),
+                                        "Unknown pragma '{}'", pragmaname);
             }
         }
         // N.B. Any other pragmas that don't start with "osl" are ignored
@@ -377,8 +377,8 @@ preprocess (const char *str, OSLCompilerImpl* oslcompiler, YYLTYPE* yyloc_param)
             }
             oslcompiler->lineno (line);
         } else {
-            oslcompiler->errorf(oslcompiler->filename(), oslcompiler->lineno(),
-                                "Unrecognized preprocessor command: #%s", p);
+            oslcompiler->errorfmt(oslcompiler->filename(), oslcompiler->lineno(),
+                                  "Unrecognized preprocessor command: #{}", p);
         }
     }
     SETLINE;

--- a/src/liboslexec/osogram.y
+++ b/src/liboslexec/osogram.y
@@ -311,8 +311,8 @@ hint
 void
 OSL::pvt::yyerror (YYLTYPE* yylloc_param, void* yyscanner, OSOReader* osoreader, const char* err)
 {
-    osoreader->errhandler().errorf("Error, line %d: %s",
-                                   osoreader->lineno(), err);
+    osoreader->errhandler().errorfmt("Error, line : ",
+                                     osoreader->lineno(), err);
 }
 
 

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -290,7 +290,8 @@ public:
         yy_switch_to_buffer(m_buffer, m_scanner);
         int errcode = osoparse(m_scanner, reader); // osoparse returns nonzero if error
         if (errcode) {
-            reader->errhandler().errorf("Failed parse of %s (error code %d)", what, errcode);
+            reader->errhandler().errorfmt("Failed parse of {} (error code {})",
+                                          what, errcode);
         }
         return ! errcode;
     }
@@ -313,7 +314,7 @@ OSOReader::parse_file (const std::string &filename)
 
     FILE* osoin = OIIO::Filesystem::fopen (filename, "r");
     if (! osoin) {
-        m_err.errorf("File %s not found", filename.c_str());
+        m_err.errorfmt("File {} not found", filename);
         return false;
     }
 

--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -242,11 +242,11 @@ SimpleRaytracer::parse_scene_xml(const std::string& scenefile)
         parse_result = doc.load_buffer(scenefile.c_str(), scenefile.size());
     }
     if (!parse_result)
-        errhandler().severef("XML parsed with errors: %s at offset %d",
+        errhandler().severefmt("XML parsed with errors: {} at offset {}",
                              parse_result.description(), parse_result.offset);
     pugi::xml_node root = doc.child("World");
     if (!root)
-        errhandler().severef("Error reading scene: Root element <World> is missing");
+        errhandler().severefmt("Error reading scene: Root element <World> is missing");
 
     // loop over all children of world
     for (auto node = root.first_child(); node; node = node.next_sibling()) {
@@ -382,10 +382,10 @@ SimpleRaytracer::parse_scene_xml(const std::string& scenefile)
         }
     }
     if (root.next_sibling())
-        errhandler().severef("Error reading %s: Found multiple top-level elements",
-                             scenefile);
+        errhandler().severefmt("Error reading {}: Found multiple top-level elements",
+                               scenefile);
     if (shaders().empty())
-        errhandler().severef("No shaders in scene");
+        errhandler().severefmt("No shaders in scene");
     camera.finalize();
 }
 

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -261,8 +261,8 @@ main (int argc, const char *argv[])
         }
         rend->pixelbuf.set_write_format (TypeDesc::HALF);
         if (! rend->pixelbuf.write (imagefile))
-            rend->errhandler().errorf("Unable to write output image: %s",
-                                      rend->pixelbuf.geterror());
+            rend->errhandler().errorfmt("Unable to write output image: {}",
+                                        rend->pixelbuf.geterror());
         double writetime = timer.lap();
 
         // Print some debugging info
@@ -286,9 +286,9 @@ main (int argc, const char *argv[])
         delete rend;
 #if (OPTIX_VERSION < 70000)
     } catch (const OSL::optix::Exception& e) {
-        printf("Optix Error: %s\n", e.what());
+        OSL::print("Optix Error: {}\n", e.what());
     } catch (const std::exception& e) {
-        printf("Unknown Error: %s\n", e.what());
+        OSL::print("Unknown Error: {}\n", e.what());
     }
 #endif
     return EXIT_SUCCESS;

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -163,7 +163,7 @@ OptixGridRenderer::load_ptx_file (string_view filename)
             return ptx_string;
     }
 #endif
-    errhandler().severef("Unable to load %s", filename);
+    errhandler().severefmt("Unable to load {}", filename);
     return {};
 }
 
@@ -215,7 +215,7 @@ OptixGridRenderer::init_optix_context (int xres OSL_MAYBE_UNUSED,
     std::string progName = "optix_grid_renderer.ptx";
     std::string renderer_ptx = load_ptx_file(progName);
     if (renderer_ptx.empty()) {
-        errhandler().severef("Could not find PTX for the raygen program");
+        errhandler().severefmt("Could not find PTX for the raygen program");
         return false;
     }
 
@@ -250,7 +250,7 @@ OptixGridRenderer::synch_attributes ()
         if (!shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys) ||
             !shadingsys->getattribute("colorsystem:sizes", TypeDesc(TypeDesc::LONGLONG,2), (void*)&cpuDataSizes) ||
             !colorSys || !cpuDataSizes[0]) {
-            errhandler().errorf("No colorsystem available.");
+            errhandler().errorfmt("No colorsystem available.");
             return false;
         }
 
@@ -262,7 +262,7 @@ OptixGridRenderer::synch_attributes ()
 
         optix::Buffer buffer = m_optix_ctx->createBuffer(RT_BUFFER_INPUT, RT_FORMAT_USER);
         if (!buffer) {
-            errhandler().errorf("Could not create buffer for '%s'.", name);
+            errhandler().errorfmt("Could not create buffer for '{}'.", name);
             return false;
         }
 
@@ -275,8 +275,8 @@ OptixGridRenderer::synch_attributes ()
         // copy the base data
         char* gpuData = (char*) buffer->map();
         if (!gpuData) {
-            errhandler().errorf("Could not map buffer for '%s' (size: %lu).",
-                                name, podDataSize + sizeof(DeviceString)*numStrings);
+            errhandler().errorfmt("Could not map buffer for '{}' (size: {}).",
+                                  name, podDataSize + sizeof(DeviceString)*numStrings);
             return false;
         }
         ::memcpy(gpuData, colorSys, podDataSize);
@@ -311,7 +311,7 @@ OptixGridRenderer::synch_attributes ()
         if (!shadingsys->getattribute("colorsystem", TypeDesc::PTR, (void*)&colorSys) ||
             !shadingsys->getattribute("colorsystem:sizes", TypeDesc(TypeDesc::LONGLONG,2), (void*)&cpuDataSizes) ||
             !colorSys || !cpuDataSizes[0]) {
-            errhandler().errorf("No colorsystem available.");
+            errhandler().errorfmt("No colorsystem available.");
             return false;
         }
 
@@ -387,14 +387,14 @@ OptixGridRenderer::make_optix_materials ()
                                   OSL::TypeDesc::PTR, &osl_ptx);
 
         if (osl_ptx.empty()) {
-            errhandler().errorf("Failed to generate PTX for ShaderGroup %s",
-                                group_name);
+            errhandler().errorfmt("Failed to generate PTX for ShaderGroup {}",
+                                  group_name);
             return false;
         }
 
         if (options.get_int("saveptx")) {
-            std::string filename = OIIO::Strutil::sprintf("%s_%d.ptx",
-                                                          group_name, mtl_id++);
+            std::string filename
+                = OIIO::Strutil::fmt::format("{}_{}.ptx", group_name, mtl_id++);
             OIIO::ofstream out;
             OIIO::Filesystem::open (out, filename);
             out << osl_ptx;
@@ -443,7 +443,7 @@ OptixGridRenderer::make_optix_materials ()
     std::string progName = "optix_grid_renderer.ptx";
     std::string program_ptx = load_ptx_file(progName);
     if (program_ptx.empty()) {
-        errhandler().severef("Could not find PTX for the raygen program");
+        errhandler().severefmt("Could not find PTX for the raygen program");
         return false;
     }
 
@@ -557,7 +557,7 @@ OptixGridRenderer::make_optix_materials ()
     std::string rendlibName = "rend_lib.ptx";
     std::string rend_lib_ptx = load_ptx_file(rendlibName);
     if (rend_lib_ptx.empty()) {
-        errhandler().severef("Could not find PTX for the raygen program");
+        errhandler().severefmt("Could not find PTX for the raygen program");
         return false;
     }
 
@@ -623,14 +623,14 @@ OptixGridRenderer::make_optix_materials ()
                                   OSL::TypeDesc::PTR, &osl_ptx);
 
         if (osl_ptx.empty()) {
-            errhandler().errorf("Failed to generate PTX for ShaderGroup %s",
-                                group_name);
+            errhandler().errorfmt("Failed to generate PTX for ShaderGroup {}",
+                                  group_name);
             return false;
         }
 
         if (options.get_int("saveptx")) {
-            std::string filename = OIIO::Strutil::sprintf("%s_%d.ptx", group_name,
-                                                          mtl_id++);
+            std::string filename
+                = OIIO::Strutil::fmt::format("{}_{}.ptx", group_name, mtl_id++);
             OIIO::ofstream out;
             OIIO::Filesystem::open (out, filename);
             out << osl_ptx;
@@ -883,7 +883,7 @@ OptixGridRenderer::get_texture_handle (ustring filename OSL_MAYBE_UNUSED,
 
         OIIO::ImageBuf image;
         if (!image.init_spec(filename, 0, 0)) {
-            errhandler().errorf("Could not load: %s", filename);
+            errhandler().errorfmt("Could not load: {}", filename);
             return (TextureHandle*)(intptr_t(RT_TEXTURE_ID_NULL));
         }
         int nchan = image.spec().nchannels;
@@ -917,7 +917,7 @@ OptixGridRenderer::get_texture_handle (ustring filename OSL_MAYBE_UNUSED,
         // Open image
         OIIO::ImageBuf image;
         if (!image.init_spec(filename, 0, 0)) {
-            errhandler().errorf("Could not load: %s", filename);
+            errhandler().errorfmt("Could not load: {}", filename);
             return (TextureHandle*)nullptr;
         }
 
@@ -1156,7 +1156,7 @@ OptixGridRenderer::processPrintfBuffer(void *buffer_data, size_t buffer_size)
         total_read += next_args;
 
         buffer[dst++] = '\0';
-        printf("%s", buffer);
+        print("{}", buffer);
     }
 }
 #endif
@@ -1170,7 +1170,7 @@ OptixGridRenderer::finalize_pixel_buffer ()
 #if (OPTIX_VERSION < 70000)
     const void* buffer_ptr = m_optix_ctx[buffer_name]->getBuffer()->map();
     if (! buffer_ptr)
-        errhandler().severef("Unable to map buffer %s", buffer_name);
+        errhandler().severefmt("Unable to map buffer {}", buffer_name);
     OIIO::ImageBuf* buf = outputbuf(0);
     if (buf)
         buf->set_pixels (OIIO::ROI::All(), OIIO::TypeFloat, buffer_ptr);


### PR DESCRIPTION
A small instalment on the long-term shift from printf-style formatting
to std::format style formatting.

Define preprocessor OSL_INTERNAL, which is defined when compiling OSL
itself, but will not be defined for downstream projects using the OSL
headers.

When building OSL, enable the symbol OIIO_ERRORHANDLER_HIDE_PRINTF,
which causes ErrorHandler methods using the old conventions to be
marked as deprecated and generate warnings.

Clean up all the calls revealed by those warnings. (And
opportunistically clean up some other things that happened to be in
the same files.)

Signed-off-by: Larry Gritz <lg@larrygritz.com>
