### PR TITLE
CI: bump 'latest' openexr and pybind11 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,9 +249,9 @@ jobs:
             cxx_compiler: g++-11
             cxx_std: 17
             fmt_ver: 8.1.1
-            openexr_ver: v3.1.4
+            openexr_ver: v3.1.5
             openimageio_ver: master
-            pybind11_ver: v2.9.1
+            pybind11_ver: v2.9.2
             python_ver: 3.8
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>

