### PR TITLE
Fix generated OSLConfig.cmake -- wrong Imath version

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -8,7 +8,7 @@ include(CMakeFindDependencyMacro)
 
 # add here all the find_dependency() whenever switching to config based dependencies
 if (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 3.0)
-    find_dependency(Imath @OpenEXR_VERSION@)
+    find_dependency(Imath @Imath_VERSION@)
 elseif (@OpenEXR_VERSION@ VERSION_GREATER_EQUAL 2.4 AND @FOUND_OPENEXR_WITH_CONFIG@)
     find_dependency(IlmBase @OpenEXR_VERSION@)
     find_dependency(OpenEXR @OpenEXR_VERSION@)


### PR DESCRIPTION
In our generated OSLConfig.cmake, we inserted a find_dependency(Imath)
that accidentally demanded the OpenEXR_VERSION (should have been
Imath_VERSION). That works fine as long as Imath version is the same
(or higher) than the OpenEXR version. But if the installed OpenEXR
version is somehow ahead of the Imath version, it will fail.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
