### PR TITLE
WIP Refactor common parts of [Batched]BackendLLVM to BackendLLVMCommon

### DIFF
--- a/src/liboslexec/batched_backendllvm.h
+++ b/src/liboslexec/batched_backendllvm.h
@@ -17,6 +17,7 @@ using namespace OSL::pvt;
 
 #include "OSL/llvm_util.h"
 #include "runtimeoptimize.h"
+#include "backendllvm.h"
 
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/SmallVector.h>
@@ -34,8 +35,8 @@ namespace pvt {  // OSL::pvt
 
 
 /// OSOProcessor that generates LLVM IR and JITs it to give machine
-/// code to implement a shader group.
-class BatchedBackendLLVM : public OSOProcessorBase {
+/// code to implement a shader group that shades batches of points.
+class BatchedBackendLLVM : public BackendLLVMCommon {
 public:
     BatchedBackendLLVM(ShadingSystemImpl& shadingsys, ShaderGroup& group,
                        ShadingContext* context, int width);
@@ -44,21 +45,13 @@ public:
     // to allow smart pointers of incomplete types
     virtual ~BatchedBackendLLVM();
 
-    virtual void set_inst(int layer);
-
     /// Create an llvm function for the whole shader group, JIT it,
     /// and store the llvm::Function* handle to it with the ShaderGroup.
-    virtual void run();
-
-
-    /// What LLVM debug level are we at?
-    int llvm_debug() const;
+    virtual void run() override;
 
     /// Set up a bunch of static things we'll need for the whole group.
     ///
     void initialize_llvm_group();
-
-    int layer_remap(int origlayer) const { return m_layer_remap[origlayer]; }
 
     /// Create an llvm function for the current shader instance.
     /// This will end up being the group entry if 'groupentry' is true.
@@ -72,19 +65,16 @@ public:
     /// current basic block if bb==NULL).
     bool build_llvm_code(int beginop, int endop, llvm::BasicBlock* bb = NULL);
 
-    typedef std::map<std::string, llvm::Value*> AllocationMap;
-
     void llvm_assign_initial_value(const Symbol& sym,
                                    llvm::Value* llvm_initial_shader_mask_value,
                                    bool force = false);
-    llvm::LLVMContext& llvm_context() const { return ll.context(); }
-    AllocationMap& named_values() { return m_named_values; }
 
     /// Return an llvm::Value* corresponding to the address of the given
     /// symbol element, with derivative (0=value, 1=dx, 2=dy) and array
     /// index (NULL if it's not an array).
-    llvm::Value* llvm_get_pointer(const Symbol& sym, int deriv = 0,
-                                  llvm::Value* arrayindex = NULL);
+    virtual llvm::Value*
+    llvm_get_pointer(const Symbol& sym, int deriv = 0,
+                     llvm::Value* arrayindex = nullptr) override;
 
     /// Allocate a new memory location to store a wide copy of the value
     /// in sym. Optionally pass in the deriv to create wide copy of the deriv.
@@ -98,12 +88,11 @@ public:
     /// return the scalar -- this allows automatic casting to triples.
     /// Finally, auto-cast int<->float if requested (no conversion is
     /// performed if cast is the default of UNKNOWN).
-    llvm::Value* llvm_load_value(const Symbol& sym, int deriv,
-                                 llvm::Value* arrayindex, int component,
-                                 TypeDesc cast         = TypeDesc::UNKNOWN,
-                                 bool op_is_uniform    = true,
-                                 bool index_is_uniform = true);
-
+    virtual llvm::Value* llvm_load_value(const Symbol& sym, int deriv,
+                                         llvm::Value* arrayindex, int component,
+                                         TypeDesc cast         = TypeUnknown,
+                                         bool op_is_uniform    = true,
+                                         bool index_is_uniform = true) override;
 
     /// Given an llvm::Value* of a pointer (and the type of the data
     /// that it points to), Return the llvm::Value* corresponding to the
@@ -114,22 +103,12 @@ public:
     /// and it's a scalar, return the scalar -- this allows automatic
     /// casting to triples.  Finally, auto-cast int<->float if requested
     /// (no conversion is performed if cast is the default of UNKNOWN).
-    llvm::Value* llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
-                                 int deriv, llvm::Value* arrayindex,
-                                 int component,
-                                 TypeDesc cast              = TypeDesc::UNKNOWN,
-                                 bool op_is_uniform         = true,
-                                 bool index_is_uniform      = true,
-                                 bool symbol_forced_boolean = false);
-
-    /// Just like llvm_load_value, but when both the symbol and the
-    /// array index are known to be constants.  This can even handle
-    /// pulling constant-indexed elements out of constant arrays.  Use
-    /// arrayindex==-1 to indicate that it's not an array dereference.
-    llvm::Value* llvm_load_constant_value(const Symbol& sym, int arrayindex,
-                                          int component,
-                                          TypeDesc cast = TypeDesc::UNKNOWN,
-                                          bool op_is_uniform = true);
+    virtual llvm::Value*
+    llvm_load_value(llvm::Value* ptr, const TypeSpec& type, int deriv,
+                    llvm::Value* arrayindex, int component,
+                    TypeDesc cast = TypeUnknown, bool op_is_uniform = true,
+                    bool index_is_uniform      = true,
+                    bool symbol_forced_boolean = false) override;
 
     /// llvm_load_value with non-constant component designation.  Does
     /// not work with arrays or do type casts!
@@ -144,16 +123,6 @@ public:
                                  int component      = 0,
                                  TypeDesc cast      = TypeDesc::UNKNOWN,
                                  bool op_is_uniform = true)
-    {
-        return llvm_load_value(sym, deriv, NULL, component, cast,
-                               op_is_uniform);
-    }
-
-    /// Legacy version
-    ///
-    llvm::Value* loadLLVMValue(const Symbol& sym, int component = 0,
-                               int deriv = 0, TypeDesc cast = TypeDesc::UNKNOWN,
-                               bool op_is_uniform = true)
     {
         return llvm_load_value(sym, deriv, NULL, component, cast,
                                op_is_uniform);
@@ -298,7 +267,7 @@ public:
 
     inline llvm::Value* getTempMask(const std::string& name = "")
     {
-        ASSERT(
+        OSL_ASSERT(
             !m_temp_scopes.empty()
             && "An instance of BatchedBackendLLVM::TempScope must exist higher up in the call stack");
         return getOrAllocateTemp(TypeSpec(TypeDesc::INT), false /*derivs*/,
@@ -343,12 +312,7 @@ public:
     int ShaderGlobalNameToIndex(ustring name, bool& is_uniform);
 
     /// Return the LLVM type handle for the BatchedShaderGlobals struct.
-    ///
-    llvm::Type* llvm_type_sg();
-
-    /// Return the LLVM type handle for a pointer to a
-    /// BatchedShaderGlobals struct.
-    llvm::Type* llvm_type_sg_ptr();
+    virtual llvm::Type* llvm_type_sg() override;
 
     /// Return the LLVM type handle for the BatchedTextureOptions struct.
     ///
@@ -358,61 +322,12 @@ public:
     ///
     llvm::Type* llvm_type_batched_trace_options();
 
-    /// Return the ShaderGlobals pointer.
-    ///
-    llvm::Value* sg_ptr() const { return m_llvm_shaderglobals_ptr; }
-
     llvm::Type* llvm_type_closure_component();
     llvm::Type* llvm_type_closure_component_ptr();
 
-    /// Return the ShaderGlobals pointer cast as a void*.
-    ///
-    llvm::Value* sg_void_ptr() { return ll.void_ptr(m_llvm_shaderglobals_ptr); }
-
-    llvm::Value* llvm_ptr_cast(llvm::Value* val, const TypeSpec& type)
-    {
-        return ll.ptr_cast(val, type.simpletype());
-    }
-
-    llvm::Value* llvm_wide_ptr_cast(llvm::Value* val, const TypeSpec& type)
-    {
-        return ll.wide_ptr_cast(val, type.simpletype());
-    }
-
-
-    llvm::Value* llvm_void_ptr(const Symbol& sym, int deriv = 0)
-    {
-        return ll.void_ptr(llvm_get_pointer(sym, deriv));
-    }
-
     /// Return the LLVM type handle for a structure of the common group
     /// data that holds all the shader params.
-    llvm::Type* llvm_type_groupdata();
-
-    /// Return the LLVM type handle for a pointer to the common group
-    /// data that holds all the shader params.
-    llvm::Type* llvm_type_groupdata_ptr();
-
-    /// Return the group data pointer.
-    ///
-    llvm::Value* groupdata_ptr() const { return m_llvm_groupdata_ptr; }
-
-    /// Return the group data pointer cast as a void*.
-    ///
-    llvm::Value* groupdata_void_ptr()
-    {
-        return ll.void_ptr(m_llvm_groupdata_ptr);
-    }
-
-    /// Return a reference to the specified field within the group data.
-    llvm::Value* groupdata_field_ref(int fieldnum);
-
-    /// Return a pointer to the specified field within the group data,
-    /// optionally cast to pointer to a particular data type.
-    llvm::Value* groupdata_field_ptr(int fieldnum,
-                                     TypeDesc type   = TypeDesc::UNKNOWN,
-                                     bool is_uniform = true);
-
+    virtual llvm::Type* llvm_type_groupdata() override;
 
     /// Return the pointer to the block of shadeindices.
     llvm::Value *wide_shadeindex_ptr () const { return m_llvm_wide_shadeindex_ptr; }
@@ -480,7 +395,6 @@ public:
     void llvm_run_connected_layers(const Symbol& sym, int symindex,
                                    int opnum                  = -1,
                                    std::set<int>* already_run = NULL);
-
 
 
     // Encapsulate creation of function names that encode parameter types,
@@ -633,57 +547,9 @@ public:
                                     bool functionIsLlvmInlined     = false,
                                     bool ptrToReturnStructIs1stArg = false);
 
-    TypeDesc llvm_typedesc(const TypeSpec& typespec)
-    {
-        return typespec.is_closure_based()
-                   ? TypeDesc(TypeDesc::PTR, typespec.arraylength())
-                   : typespec.simpletype();
-    }
-
-    /// Generate the appropriate llvm type definition for a TypeSpec
-    /// (this is the actual type, for example when we allocate it).
-    /// Allocates ptrs for closures.
-    llvm::Type* llvm_type(const TypeSpec& typespec)
-    {
-        return ll.llvm_type(llvm_typedesc(typespec));
-    }
-
-    llvm::Type* llvm_wide_type(const TypeSpec& typespec)
-    {
-        // We are the "wide" backend, so all types will be vector types
-        return ll.llvm_vector_type(llvm_typedesc(typespec));
-    }
-
     /// Generate the parameter-passing llvm type definition for an OSL
     /// TypeSpec.
-    llvm::Type* llvm_pass_type(const TypeSpec& typespec);
     llvm::Type* llvm_pass_wide_type(const TypeSpec& typespec);
-
-    llvm::PointerType* llvm_type_prepare_closure_func()
-    {
-        return m_llvm_type_prepare_closure_func;
-    }
-    llvm::PointerType* llvm_type_setup_closure_func()
-    {
-        return m_llvm_type_setup_closure_func;
-    }
-
-    /// Return the basic block of the exit for the whole instance.
-    ///
-    bool llvm_has_exit_instance_block() const { return m_exit_instance_block; }
-
-    /// Return the basic block of the exit for the whole instance.
-    ///
-    llvm::BasicBlock* llvm_exit_instance_block()
-    {
-        if (!m_exit_instance_block) {
-            std::string name      = Strutil::sprintf("%s_%d_exit_",
-                                                inst()->layername(),
-                                                inst()->id());
-            m_exit_instance_block = ll.new_basic_block(name);
-        }
-        return m_exit_instance_block;
-    }
 
     /// Check for inf/nan in all written-to arguments of the op
     void llvm_generate_debugnan(const Opcode& op);
@@ -692,27 +558,14 @@ public:
     /// Print debugging line for the op
     void llvm_generate_debug_op_printf(const Opcode& op);
 
-    llvm::Function* layer_func() const { return ll.current_function(); }
-
-    /// Call this when JITing a texture-like call, to track how many.
-    void generated_texture_call(bool handle)
-    {
-        shadingsys().m_stat_tex_calls_codegened += 1;
-        if (handle)
-            shadingsys().m_stat_tex_calls_as_handles += 1;
-    }
-
     void llvm_print_mask(const char* title, llvm::Value* mask = nullptr);
 
-    /// Return the userdata index for the given Symbol.  Return -1 if the Symbol
-    /// is not an input parameter or is constant and therefore doesn't have an
-    /// entry in the groupdata struct.
-    int find_userdata_index(const Symbol& sym);
+    // Return the userdata index for the given Symbol.  Return -1 if the Symbol
+    // is not an input parameter or is constant and therefore doesn't have an
+    // entry in the groupdata struct.
+    // int find_userdata_index(const Symbol& sym);
 
-    LLVM_Util ll;
-
-
-    int vector_width() const { return m_width; }
+    int xvector_width() const { return m_batch_width; }
     int true_mask_value() const { return m_true_mask_value; }
 
 private:
@@ -737,7 +590,6 @@ private:
     void build_offsets_of_BatchedTextureOptions(
         std::vector<unsigned int>& offset_by_index);
 
-    int m_width;
     int m_true_mask_value;
 
     // Interface and Factory method to construct a Concrete TargetLibraryHelper
@@ -763,41 +615,16 @@ private:
     const char* m_wide_arg_prefix;
     llvm::SmallString<512> m_built_op_name;
 
-
-    std::vector<int> m_layer_remap;      ///< Remapping of layer ordering
-    std::set<int> m_layers_already_run;  ///< List of layers run
-    int m_num_used_layers;               ///< Number of layers actually used
-
-    double m_stat_total_llvm_time;  ///<   total time spent on LLVM
-    double m_stat_llvm_setup_time;  ///<     llvm setup time
-    double m_stat_llvm_irgen_time;  ///<     llvm IR generation time
-    double m_stat_llvm_opt_time;    ///<     llvm IR optimization time
-    double m_stat_llvm_jit_time;    ///<     llvm JIT time
-
     // LLVM stuff
-    AllocationMap m_named_values;
-    std::map<const Symbol*, int> m_param_order_map;
-    llvm::Value* m_llvm_shaderglobals_ptr;
-    llvm::Value* m_llvm_groupdata_ptr;
-
     llvm::Value *m_llvm_wide_shadeindex_ptr;
-    llvm::Value *m_llvm_userdata_base_ptr;
-    llvm::Value *m_llvm_output_base_ptr;
 
     // Reused allocas for temps used to pass options or intermediates
     llvm::Value* m_llvm_temp_wide_matrix_ptr;  // for gen_tranform
     llvm::Value* m_llvm_temp_batched_texture_options_ptr;
     llvm::Value* m_llvm_temp_batched_trace_options_ptr;
 
-    llvm::BasicBlock* m_exit_instance_block;  // exit point for the instance
-    llvm::Type* m_llvm_type_sg;         // LLVM type of ShaderGlobals struct
-    llvm::Type* m_llvm_type_groupdata;  // LLVM type of group data
-    llvm::Type* m_llvm_type_closure_component;
     llvm::Type* m_llvm_type_batched_texture_options;
     llvm::Type* m_llvm_type_batched_trace_options;
-    llvm::PointerType* m_llvm_type_prepare_closure_func;
-    llvm::PointerType* m_llvm_type_setup_closure_func;
-    int m_llvm_local_mem;  // Amount of memory we use for locals
 
     friend class ShadingSystemImpl;
 };

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -478,7 +478,7 @@ LLVMGEN (llvm_gen_printf)
         {
             // Condition
             llvm::Value * lane_index = rop.ll.op_load(loc_of_lane_index);
-            llvm::Value * more_lanes_to_process = rop.ll.op_lt(lane_index, rop.ll.constant(rop.vector_width()));
+            llvm::Value * more_lanes_to_process = rop.ll.op_lt(lane_index, rop.ll.constant(rop.batch_width()));
 
             rop.ll.op_branch (more_lanes_to_process, body_block,
                     after_block);

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -224,14 +224,6 @@ BackendLLVM::llvm_type_sg ()
 
 
 llvm::Type *
-BackendLLVM::llvm_type_sg_ptr ()
-{
-    return ll.type_ptr (llvm_type_sg());
-}
-
-
-
-llvm::Type *
 BackendLLVM::llvm_type_groupdata ()
 {
     // If already computed, return it
@@ -346,14 +338,6 @@ BackendLLVM::llvm_type_groupdata ()
     m_llvm_type_groupdata = ll.type_struct (fields, groupdataname);
 
     return m_llvm_type_groupdata;
-}
-
-
-
-llvm::Type *
-BackendLLVM::llvm_type_groupdata_ptr ()
-{
-    return ll.type_ptr (llvm_type_groupdata());
 }
 
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -88,6 +88,7 @@ class ShaderInstance;
 typedef std::shared_ptr<ShaderInstance> ShaderInstanceRef;
 class Dictionary;
 class RuntimeOptimizer;
+class BackendLLVMCommon;
 class BackendLLVM;
 #if OSL_USE_BATCHED
 class BatchedBackendLLVM;
@@ -924,9 +925,8 @@ private:
     friend class ShaderInstance;
     friend class RuntimeOptimizer;
     friend class BackendLLVM;
-#if OSL_USE_BATCHED
+    friend class BackendLLVMCommon;
     friend class BatchedBackendLLVM;
-#endif
 };
 
 
@@ -1726,6 +1726,7 @@ private:
     bool m_complete = false;              ///< Successfully ShaderGroupEnd?
 
     friend class OSL::pvt::ShadingSystemImpl;
+    friend class OSL::pvt::BackendLLVMCommon;
     friend class OSL::pvt::BackendLLVM;
 #if OSL_USE_BATCHED
     friend class OSL::pvt::BatchedBackendLLVM;


### PR DESCRIPTION
I've been thinking about the long-term maintenance burden of the
separate scalar and batched LLVM back ends, and trying to ease the
work burden and tendency to make errors that will result from the
large amount of replicated and nearly-replicated code.

The scalar (single-point) shading back end is more established and
well understood, is much simpler, and is more commonly used (and
probably always will be -- it will be a minority of renderers that are
structured to take advantage of batched execution and that run on
architectures where it makes sense). So I think that looking toward
the future, many contributors and maintainers of this code base will
naturally be more familiar with the single-point internals. I'd like
to make it so that most changes can be made in one place, and by
people who know the single point code well, with the batch code
occupying as small a footprint as practical, to make it more rare to
need to change it, and easier / smaller changes when it does also need
modification.

In this patch, I introduce a BackendLLVMCommon class, derived from OSO
OSOProcessorBase, and inherited by both BackendLLVM and
BatchedBackendLLVM. I try to move a bunch of the replicated code from
those two back ends into the common superclass.

I'm not "done", just did enough to give the gist so you can see where
I'm going with it and enough to see that a bunch of code replication
has been eliminated. I think a lot more can be done in this direction,
ideally with BatchedBackendLLVM eventually containing *ONLY* the parts
that are relevant to batch only or must be significantly different
than the scalar back end. (I don't mind the scalar back end having a
little bit of incidental support for simd types and the like; it's
unobtrusive where it's simple, and it may come in handy for other
things.)

It's possible that the end game is that BackendLLVMCommon and
BackendLLVM simply become one class -- that is, the general/common
llvm back end contains the full implementation of single-point
shading, and and then the batched back end is a derived class that
overloads virtual methods for the things that need to be different for
batched execution. I'm not sure yet. But for now, I'm structuring it
as separate scalar and batched classes, with a parent class that
contains the methods and data that are common to both of them.

While we're at it, I submit that it's probably wise to change
terminology and internal naming so that we talk about "single point"
shading versus "batch" shading, but don't use the term "scalar" to
describe shading one point at a time, because we also, and for quite
some time now, have used "scalar" to describe any single data item
that isn't part of an array or an aggregate. I realized while doing
some of this refactoring that the use of "scalar" for both concepts
made some of the comments a quite confusing. Similarly, we are already
pretty good at saying "batch shading" rather than "SIMD" or "Vector",
both of which are used widely (excuse the pun) elsewhere to have other
meanings. But there are a few places where we use vector to describe
batch shading, and I aim to clean that up over time.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
