### PR TITLE
Build: cmake improvements (ported from OIIO)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
     container:
       image: aswf/ci-osl:2021-clang11
     env:
-      BUILDTARGET: clang-format
+      BUILDTARGET: run-clang-format
       CMAKE_CXX_STANDARD: 17
       PYTHON_VERSION: 3.7
     steps:

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -518,7 +518,7 @@ if (PROJECT_IS_TOP_LEVEL)
         # message (STATUS "clang-format file list: ${FILES_TO_FORMAT}")
         file (COPY ${CMAKE_CURRENT_SOURCE_DIR}/.clang-format
               DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-        add_custom_target (clang-format
+        add_custom_target (run-clang-format
             COMMAND "${CLANG_FORMAT_EXE}" -i -style=file ${FILES_TO_FORMAT} )
     else ()
         message (STATUS "clang-format not found.")

--- a/src/cmake/fancy_add_executable.cmake
+++ b/src/cmake/fancy_add_executable.cmake
@@ -12,6 +12,9 @@
 # The executable may be disabled individually using any of the usual
 # check_is_enabled() conventions (e.g. -DENABLE_<executable>=OFF).
 #
+# If -DENABLE_INSTALL_<executable>=OFF was specified, the target will be built
+# (in the build area) but will not be installed.
+#
 # Usage:
 #
 #   fancy_add_executable ([ NAME targetname ... ]
@@ -42,13 +45,16 @@ macro (fancy_add_executable)
             target_include_directories (${_target_NAME} SYSTEM PRIVATE ${_target_SYSTEM_INCLUDE_DIRS})
         endif ()
         if (_target_DEFINITIONS)
-            target_compile_definitions (${_target_name} PRIVATE ${_target_DEFINITIONS})
+            target_compile_definitions (${_target_NAME} PRIVATE ${_target_DEFINITIONS})
         endif ()
         if (_target_LINK_LIBRARIES)
             target_link_libraries (${_target_NAME} PRIVATE ${_target_LINK_LIBRARIES})
         endif ()
         set_target_properties (${_target_NAME} PROPERTIES FOLDER "Tools")
-        install_targets (${_target_NAME})
+        check_is_enabled (INSTALL_${_target_NAME} _target_NAME_INSTALL_enabled)
+        if (_target_NAME_INSTALL_enabled)
+            install_targets (${_target_NAME})
+        endif ()
     else ()
         message (STATUS "${ColorRed}Disabling ${_target_NAME} ${ColorReset}")
     endif ()


### PR DESCRIPTION
checked_find_package:

* Optional SETVARIABLES gives a list of vars to set to TRUE if the package
  is found.
* Optional DEBUG flag turns on extra debugging information about how the
  package is found.
* Optional PREFER_CONFIG uses a dependency's exported config, if available,
  rather than our Find module.
* Global ALWAYS_PREFER_CONFIG option can be set to ON to always prefer
  config over Find modules for all dependencies.

fancy_add_executable:

* `-DENABLE_INSTALL_<executable>=OFF` lets you turn off the installation
  of an executable.

other:

* Change the target name for doing the clang-format over the code to
  "run-clang-format", because "clang-format" is an imported target name
  of the libclang exported cmake (which we may wish to use soon).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
