### PR TITLE
CI: adjust to upgrading Intel Clang compiler to 2022.1.0

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -68,9 +68,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER MATCHES "[Cc]lan
         endif ()
     elseif (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
         set (CMAKE_COMPILER_IS_INTELCLANG 1)
-        string (REGEX REPLACE ".* version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${clang_full_version_string})
+        string (REGEX MATCH "[0-9]+(\\.[0-9]+)+" INTELCLANG_VERSION_STRING ${clang_full_version_string})
         if (VERBOSE)
-            message (STATUS "The compiler is Intel Clang: ${CMAKE_CXX_COMPILER_ID} version ${CLANG_VERSION_STRING}")
+            message (STATUS "The compiler is Intel Clang: ${CMAKE_CXX_COMPILER_ID} version ${INTELCLANG_VERSION_STRING}")
         endif ()
     else ()
         string (REGEX REPLACE ".* version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${clang_full_version_string})
@@ -164,7 +164,8 @@ if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
     endif ()
     # Suppress warnings about our strategic use of bitwise operations in place
     # of logical operators to produce branchless code in some places.
-    if (CLANG_VERSION_STRING VERSION_GREATER_EQUAL 14.0)
+    if (CLANG_VERSION_STRING VERSION_GREATER_EQUAL 14.0
+        OR INTELCLANG_VERSION_STRING VERSION_GREATER_EQUAL 14.0)
         add_compile_options ("-Wno-bitwise-instead-of-logical")
     endif ()
 
@@ -193,6 +194,11 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
     add_definitions ("-D__STDC_CONSTANT_MACROS")
     # this allows native instructions to be used for sqrtf instead of a function call
     add_compile_options ("-fno-math-errno")
+endif ()
+
+if (INTELCLANG_VERSION_STRING VERSION_GREATER_EQUAL 2022.1.0)
+    # New versions of icx warn about changing certain floating point options
+    add_compile_options ("-Wno-overriding-t-option")
 endif ()
 
 if (MSVC)

--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -102,6 +102,7 @@
 
 // Tests for MSVS versions, always 0 if not MSVS at all.
 #if defined(_MSC_VER)
+#  define OSL_MSVS_VERSION       _MSC_VER
 #  define OSL_MSVS_AT_LEAST_2013 (_MSC_VER >= 1800)
 #  define OSL_MSVS_BEFORE_2013   (_MSC_VER <  1800)
 #  define OSL_MSVS_AT_LEAST_2015 (_MSC_VER >= 1900)
@@ -112,6 +113,7 @@
 #    error "This version of OSL is meant to work only with Visual Studio 2017 or later"
 #  endif
 #else
+#  define OSL_MSVS_VERSION       0
 #  define OSL_MSVS_AT_LEAST_2013 0
 #  define OSL_MSVS_BEFORE_2013   0
 #  define OSL_MSVS_AT_LEAST_2015 0


### PR DESCRIPTION
The Intel OneAPI LLVM-based C++ compiler, as we download it from Intel
for our CI, bumped from 2022.0.0 to 2022.1.0.

New warning popped up -- newest Intel LLVM-based compiler warns about
overriding certain floating point math flags.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
