### PR TITLE
Windows build fixes for recent free function render services

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -33,7 +33,7 @@ template<typename DataT, int WidthT> struct Wide;
 /// only exist in the renderer's program space and won't automatically be 
 /// found when referenced in JIT'd code inside OSL.  A renderer may register
 /// the addresses of these global variables to allow valid JIT to occur.
-void register_JIT_Global(const char* global_var_name, void* global_var_addr);
+void OSLEXECPUBLIC register_JIT_Global(const char* global_var_name, void* global_var_addr);
 
 /// Opaque pointer to whatever the renderer uses to represent a
 /// (potentially motion-blurred) coordinate transformation.

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -7,6 +7,11 @@
 /** Lexical scanner for Open Shading Language
  **/
 
+%top{
+/* Include this first to avoid warnings about re-definitions on windows */
+#include <stdint.h>
+}
+
 /************************************************************
  * Definitions section
  ************************************************************/

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -204,13 +204,13 @@ macro ( CUDA_SHADEOPS_COMPILE srclist )
 
     # Link all of the individual LLVM bitcode files
     add_custom_command ( OUTPUT ${linked_shadeops_bc}
-        COMMAND "${LLVM_DIRECTORY}/bin/llvm-link" -internalize ${shadeops_bc_list} -o ${linked_shadeops_bc}
+        COMMAND ${LLVM_LINK_TOOL} -internalize ${shadeops_bc_list} -o ${linked_shadeops_bc}
         DEPENDS ${shadeops_bc_list} ${exec_headers} ${PROJECT_PUBLIC_HEADERS} ${shadeops_srcs}
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 
     # Serialize the linked bitcode into a CPP file and add it to the list of liboslexec soures
     add_custom_command ( OUTPUT ${shadeops_bc_cuda_cpp}
-        COMMAND python "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py"
+        COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py"
             ${linked_shadeops_bc} ${shadeops_bc_cuda_cpp} "osl_llvm_compiled_ops_cuda"
         DEPENDS "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py" ${linked_shadeops_bc}
         ${exec_headers} ${PROJECT_PUBLIC_HEADERS}

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -7,6 +7,10 @@
 /** Lexical scanner for OpenShadingLanguage 'object' files
  **/
 
+%top{
+/* Include this first to avoid warnings about re-definitions on windows */
+#include <stdint.h>
+}
 
 /************************************************************
  * Definitions section


### PR DESCRIPTION
## Description

The latest changes to leverage llvm-bitcode for renderer services did not build properly on windows. This set of patches should fix this along with a few other minor things.


I have a feeling there is probably a more "Cmake native" way of getting the path to the llvm-as and llvm-link binaries. I'm definitely open to suggestions here.