### PR TITLE
More printf -> fmt conversion

### DIFF
--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -136,8 +136,8 @@ BatchedBackendLLVM::llvm_call_layer(int layer, bool unconditional)
     args[5] = lanes_requiring_execution_value;
 
     // Before the merge, keeping in case we broke it
-    //std::string name = Strutil::format ("%s_%s_%d", m_library_selector,  parent->layername().c_str(),
-    //                                  parent->id());
+    //std::string name = fmtformat("{}_{}_{}", m_library_selector,  parent->layername().c_str(),
+    //                             parent->id());
     std::string name
         = Strutil::fmt::format("{}_{}", m_library_selector,
                                layer_function_name(group(), *parent));
@@ -436,10 +436,8 @@ LLVMGEN (llvm_gen_printf)
 
     // Some ops prepend things
     if (op.opname() == op_error || op.opname() == op_warning) {
-        std::string prefix = Strutil::sprintf ("Shader %s [%s]: ",
-                                               op.opname(),
-                                               rop.inst()->shadername());
-        s = prefix + s;
+        s = fmtformat("Shader {} [{}]: {}", op.opname(),
+                      rop.inst()->shadername(), s);
     }
 
     // Now go back and put the new format string in its place
@@ -6398,7 +6396,7 @@ LLVMGEN (llvm_gen_spline)
 
     FuncSpec func_spec(op.opname().c_str());
 
-    //std::string name = Strutil::sprintf("osl_%s_", op.opname());
+    //std::string name = fmtfrmat("osl_{}_", op.opname());
     std::vector<llvm::Value *> args;
     // only use derivatives for result if:
     //   result has derivs and (value || knots) have derivs

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -850,7 +850,7 @@ ShaderGroup::serialize () const
                 bool lockgeom = dstsyms_exist ? s->lockgeom()
                                               : inst->instoverride(p)->lockgeom();
                 if (! lockgeom)
-                    out << Strutil::sprintf (" [[int lockgeom=%d]]", lockgeom);
+                    print(out, " [[int lockgeom={}]]", lockgeom);
                 out << " ;\n";
             }
         }

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -401,10 +401,8 @@ LLVMGEN (llvm_gen_printf)
 
     // Some ops prepend things
     if (op.opname() == op_error || op.opname() == op_warning) {
-        std::string prefix = Strutil::sprintf ("Shader %s [%s]: ",
-                                               op.opname(),
-                                               rop.inst()->shadername());
-        s = prefix + s;
+        s = fmtformat("Shader {} [{}]: {}", op.opname(),
+                      rop.inst()->shadername(), s);
     }
 
     // Now go back and put the new format string in its place
@@ -3262,7 +3260,7 @@ LLVMGEN (llvm_gen_spline)
              Knots.typespec().is_array() &&  
              (!has_knot_count || (has_knot_count && Knot_count.typespec().is_int())));
 
-    std::string name = Strutil::sprintf("osl_%s_", op.opname());
+    std::string name = fmtformat("osl_{}_", op.opname());
     // only use derivatives for result if:
     //   result has derivs and (value || knots) have derivs
     bool result_derivs = Result.has_derivs() && (Value.has_derivs() || Knots.has_derivs());
@@ -3820,7 +3818,7 @@ LLVMGEN (llvm_gen_blackbody)
 
     llvm::Value* args[] = { rop.sg_void_ptr(), rop.llvm_void_ptr(Result),
                             rop.llvm_load_value(Temperature) };
-    rop.ll.call_function (Strutil::sprintf("osl_%s_vf",op.opname()).c_str(), args);
+    rop.ll.call_function (fmtformat("osl_{}_vf",op.opname()).c_str(), args);
 
     // Punt, zero out derivs.
     // FIXME -- only of some day, someone truly needs blackbody() to

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -48,18 +48,18 @@ TypeSpec::string () const
         if (is_unsized_array())
             str += "[]";
         else if (arraylength() > 0)
-            str += Strutil::sprintf ("[%d]", arraylength());
+            str += Strutil::fmt::format("[{}]", arraylength());
     }
     else if (structure() > 0) {
         StructSpec *ss = structspec();
         if (ss)
-            str += Strutil::sprintf ("struct %s", structspec()->name());
+            str += Strutil::fmt::format("struct {}", structspec()->name());
         else
-            str += Strutil::sprintf ("struct %d", structure());
+            str += Strutil::fmt::format("struct {}", structure());
         if (is_unsized_array())
             str += "[]";
         else if (arraylength() > 0)
-            str += Strutil::sprintf ("[%d]", arraylength());
+            str += Strutil::fmt::format("[{}]", arraylength());
     } else {
         str += simpletype().c_str();
     }


### PR DESCRIPTION
Banish the last of the sprintf calls (except the handful that need
to be there, because such formatting is still supported in shaders
themselves, so something needs to understand them).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
