### PR TITLE
Fix incorrect transform(m44,v4) in vector4.h

### DIFF
--- a/src/shaders/vector4.h
+++ b/src/shaders/vector4.h
@@ -383,10 +383,10 @@ vector4 atan2(vector4 a, vector4 b)
 
 vector4 transform (matrix M, vector4 p)
 {
-    return vector4 (M[0][0]*p.x + M[0][1]*p.y + M[0][2]*p.z + M[0][2]*p.w,
-                    M[1][0]*p.x + M[1][1]*p.y + M[1][2]*p.z + M[1][2]*p.w,
-                    M[2][0]*p.x + M[2][1]*p.y + M[2][2]*p.z + M[2][2]*p.w,
-                    M[3][0]*p.x + M[3][1]*p.y + M[3][2]*p.z + M[3][2]*p.w);
+    return vector4 (M[0][0]*p.x + M[1][0]*p.y + M[2][0]*p.z + M[3][0]*p.w,
+                    M[0][1]*p.x + M[1][1]*p.y + M[2][1]*p.z + M[3][1]*p.w,
+                    M[0][2]*p.x + M[1][2]*p.y + M[2][2]*p.z + M[3][2]*p.w,
+                    M[0][3]*p.x + M[1][3]*p.y + M[2][3]*p.z + M[3][3]*p.w);
 }
 
 vector4 transform (string fromspace, string tospace, vector4 p)


### PR DESCRIPTION
I think we were multiplying by the transpose. Can people please check my
math? This is obviously easy to get confused about. Remember that by
our conventions, points are column vectors and matrices have the
bottom row containing the translation (like RenderMan, not like math/physics),
and they are stored in memory in row-major order (like C, not like Fortran).

Signed-off-by: Larry Gritz <lg@larrygritz.com>

