### PR TITLE
Change OSL's ArgParse use to the modern syntax

### DIFF
--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -26,17 +26,14 @@ getargs(int argc, char* argv[])
     bool help = false;
     OIIO::ArgParse ap;
     // clang-format off
-    ap.options("llvmutil_test\n"
-               OIIO_INTRO_STRING "\n"
-               "Usage:  llvmutil_test [options]",
-               "--help", &help, "Print help message",
-               "-v", &verbose, "Verbose mode",
-               "--debug", &debug, "Debug mode",
-               "--memtest %d", &memtest, "Memory test mode (arg: iterations)",
-               // "--iters %d", &iterations,
-               //     Strutil::fmt::format("Number of iterations (default: {})", iterations).c_str(),
-               // "--trials %d", &ntrials, "Number of trials",
-               NULL);
+    ap.intro("llvmutil_test\n" OIIO_INTRO_STRING);
+    ap.usage("llvmutil_test [options]");
+    ap.arg("-v", &verbose)
+      .help("Verbose output");
+    ap.arg("--debug", &debug)
+      .help("Debug mode");
+    ap.arg("--memtest %d:ITERATIONS", &memtest)
+      .help("Memory test mode");
     // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;

--- a/src/liboslnoise/oslnoise_test.cpp
+++ b/src/liboslnoise/oslnoise_test.cpp
@@ -372,17 +372,18 @@ getargs(int argc, const char* argv[])
     bool help = false;
     OIIO::ArgParse ap;
     // clang-format off
-    ap.options("oslnoise_test  (" OSL_INTRO_STRING ")\n"
-               "Usage:  oslnoise_test [options]",
-               // "%*", parse_files, "",
-               "--help", &help, "Print help message",
-               "-v", &verbose, "Verbose mode",
-               "--img", &make_images, "Make test images",
-               "--iterations %d", &iterations,
-                   ustring::fmtformat("Number of iterations (default: {})", iterations).c_str(),
-               "--trials %d", &ntrials, "Number of trials",
-               NULL);
+    ap.intro("oslnoise_test  (" OSL_INTRO_STRING ")");
+    ap.usage("oslnoise_test [options]");
+    ap.arg("-v", &verbose)
+      .help("Verbose output");
+    ap.arg("--img", &make_images)
+      .help("Make test images");
+    ap.arg("--iterations %d:N", &iterations)
+      .help(ustring::fmtformat("Number of iterations (default: {})", iterations).c_str());
+    ap.arg("--trials %d:N", &ntrials)
+      .help("Number of trials");
     // clang-format on
+
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
         ap.usage();

--- a/src/osltoy/osltoymain.cpp
+++ b/src/osltoy/osltoymain.cpp
@@ -41,29 +41,23 @@ static int xres = 512, yres = 512;
 static std::vector<std::string> filenames;
 
 
-static int
-parse_files(int argc, const char* argv[])
-{
-    for (int i = 0; i < argc; i++)
-        filenames.emplace_back(argv[i]);
-    return 0;
-}
-
-
 static void
 getargs(int argc, char* argv[])
 {
     bool help = false;
     OIIO::ArgParse ap;
     // clang-format off
-    ap.options("osltoy -- interactive OSL plaything\n" OSL_INTRO_STRING "\n"
-               "Usage:  osltoy [options] [filename...]",
-               "%*", parse_files, "",
-               "--help", &help, "Print help message",
-               "-v", &verbose, "Verbose status messages",
-               "--threads %d", &threads, "Set thread count (0=cores)",
-               "--res %d %d", &xres, &yres, "Set resolution (x, y)",
-               NULL);
+    ap.intro("osltoy -- interactive OSL plaything\n" OSL_INTRO_STRING);
+    ap.usage("osltoy [options] [filename...]");
+    ap.arg("filename")
+      .hidden()
+      .action([&](cspan<const char*> argv){ filenames.emplace_back(argv[0]); });
+    ap.arg("-v", &verbose)
+      .help("Verbose output");
+    ap.arg("--threads %d:NTHREADS", &threads)
+      .help("Set thread count (0=cores)");
+    ap.arg("--res %d:XRES %d:YRES", &xres, &yres)
+      .help("Set resolution");
     // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;


### PR DESCRIPTION
We'd been waiting until the minimum OIIO requirement was high enough
to include support for the newer syntax.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
