### PR TITLE
Remove confusing licensing comment

### DIFF
--- a/src/liboslnoise/simplexnoise.cpp
+++ b/src/liboslnoise/simplexnoise.cpp
@@ -39,8 +39,7 @@
  * 
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
 


### PR DESCRIPTION
The implementation of simplex noise we've been using is public domain,
but looks like when we pasted the license notice into our repo, there
was one stray sentence (probably left over from an earlier license
scheme Stefan Gustavson used?) that makes reference to GPL. But the
software and its repo are NOT -- it's very clear that it's public
domain: https://github.com/stegu/perlin-noise/blob/master/LICENSE.md

So remove this confusing sentence.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
