### PR TITLE
Branch for eventual release, call it alpha

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,16 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright Contributors to the Open Shading Language Project. -->
 
-Release 1.12 -- ?? (compared to 1.11)
+Release 1.12 -- ?? 1 Aug 2022 ?? (compared to 1.11)
 --------------------------------------------------
+Big Deal Changes:
+
+* Batch shading: A fully operational "batch shading" support when using CPUs
+  supporting the AVX2 or AVX512 instruction set architectures, allows shading
+  8 or 16 points at a time, accelerated by using SIMD instructions.
+* A reasonable subset of the OSL language can run on NVIDIA GPUs for
+  Cuda or OptiX-based renderers.
+
 Dependency and standards requirements changes:
 * The minimum (and default) compilation mode is now C++14. C++17 and 20 are
   also supported. #1362 #1369 (1.12.2)
@@ -58,7 +66,7 @@ API changes, new options, new ShadingSystem features (for renderer writers):
   triggered for those cases that cannot be resolved by the end of the "runtime
   optimization" phase. #1497 (1.12.4.6)
 
-Continued work on experimental SIMD batched shading mode:
+SIMD batched shading mode:
 * Added support for masked operations to LLVMUtil. #1248 #1250 (1.12.0.0)
 * Add interface to ShadingSystem for batched execution. #1272 (1.12.0.1)
 * Add interface to batched RendererServices. #1276 (1.12.0.1)
@@ -84,7 +92,7 @@ Continued work on experimental SIMD batched shading mode:
 * Batched userdata and output placement. #1455 (1.12.4.2)
 * Batched pointcloud functions. #1464 (1.12.4.4)
 
-Continued work on experimental OptiX rendering:
+OptiX rendering:
 * Explicitly set the OptiX pipeline stack size. #1254 (1.12.0.0)
 * CI tests now at least compile and build with USE_OPTIX=1 (though not yet
   run the tests). #1281 (1.12.0.1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,12 @@ project (OSL VERSION 1.12.5.0
 set (PROJ_NAME ${PROJECT_NAME})    # short name
 string (TOLOWER ${PROJ_NAME} PROJ_NAME_LOWER)  # short name lower case
 string (TOUPPER ${PROJ_NAME} PROJ_NAME_UPPER)  # short name upper case
-set (PROJECT_VERSION_RELEASE_TYPE "dev" CACHE STRING
+set (PROJECT_VERSION_RELEASE_TYPE "alpha1" CACHE STRING
     "Build type, for example: dev, beta2, RC1 (empty string for normal release)")
 set (${PROJECT_NAME}_VERSION_RELEASE_TYPE ${PROJECT_VERSION_RELEASE_TYPE})
 set (PROJECT_AUTHORS "Contributors to the Open Shading Language project")
 option (${PROJECT_NAME}_SUPPORTED_RELEASE
-       "Set ON for supported release branch, OFF for master" OFF)
+       "Set ON for supported release branch, OFF for master" ON)
 if (${PROJECT_NAME}_SUPPORTED_RELEASE)
     set (${PROJECT_NAME}_DEV_RELEASE OFF)
 else ()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,11 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 * **[LLVM](http://www.llvm.org) 9, 10, 11, 12, 13, or 14**, including clang
   libraries.
 
+* (optional) For GPU rendering on NVIDIA GPUs:
+    * [Cuda](https://developer.nvidia.com/cuda-downloads) 8.0 or higher.
+    * [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) 5.1 or higher
+      (though 7.0+ is highly recommended).
+
 * [Boost](https://www.boost.org) 1.55 or newer (tested through boost 1.78)
 * [Ilmbase or Imath](https://github.com/AcademySoftwareFoundation/openexr) 2.3
    or newer (recommended: 2.4 or higher; tested through 3.1)


### PR DESCRIPTION
Aiming to declare a stable beta soon and release circa SIGGRAPH.

Primarily, this branch is to allow us to continue changing main in
ways that would be destabilizing before the release.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

