### PR TITLE
Fix permission error and build errors when running serialize-bc.py on Linux

### DIFF
--- a/src/build-scripts/serialize-bc.py
+++ b/src/build-scripts/serialize-bc.py
@@ -1,3 +1,4 @@
+#!/bin/env python
 # Copyright Contributors to the Open Shading Language project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage

--- a/src/build-scripts/serialize-bc.py
+++ b/src/build-scripts/serialize-bc.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # Copyright Contributors to the Open Shading Language project.
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage


### PR DESCRIPTION
Signed-off-by: Adrien Herubel <adrien.herubel@autodesk.com>


## Description

This PR fixes the following two issues I encountered while building the head of the main branch on Linux (Centos 7)

`/bin/sh: /home/herubea/dev/vanilla_osl/OpenShadingLanguage/src/build-scripts/serialize-bc.py: Permission denied
`

It looks like the serialize-bc.py script is missing the execution permission, and a shebang declaration for running the script as python.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

