### PR TITLE
Allow naming of llvm symbols for many ops

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -660,26 +660,26 @@ public:
     /// Return the human-readable name of the type of the llvm value.
     std::string llvm_typenameof(llvm::Value* val) const;
 
-    /// Return an llvm::Value holding the given floating point constant.
+    /// Return an llvm::Constant holding the given floating point constant.
     llvm::Constant* constant(float f);
 
-    /// Return an llvm::Value holding the given integer constant.
+    /// Return an llvm::Constant holding the given integer constant.
     llvm::Constant* constant(int i);
 
-    /// Return an llvm::Value holding the given integer constant.
+    /// Return an llvm::Constant holding the given integer constant.
     llvm::Constant* constant8(int i);
     llvm::Constant* constant16(uint16_t i);
     llvm::Constant* constant64(uint64_t i);
     llvm::Constant* constant128(uint64_t i);
     llvm::Constant* constant128(uint64_t left, uint64_t right);
 
-    // Return an llvm::value holding an explicit signed int64_t constant.
+    // Return an llvm::Constant holding an explicit signed int64_t constant.
     llvm::Constant* constanti64(int64_t i);
 
-    /// Return an llvm::Value holding the given size_t constant.
+    /// Return an llvm::Constant holding the given size_t constant.
     llvm::Constant* constant(size_t i);
 
-    /// Return an llvm::Value holding the given bool constant.
+    /// Return an llvm::Constant holding the given bool constant.
     /// Change the name so it doesn't get mixed up with int.
     llvm::Constant* constant_bool(bool b);
 
@@ -735,19 +735,23 @@ public:
 
     /// Cast the pointer variable specified by val to the kind of pointer
     /// described by type (as an llvm pointer type).
-    llvm::Value* ptr_cast(llvm::Value* val, llvm::Type* type);
-    llvm::Value* ptr_cast(llvm::Value* val, llvm::PointerType* type)
+    llvm::Value* ptr_cast(llvm::Value* val, llvm::Type* type,
+                          const std::string& llname = {});
+    llvm::Value* ptr_cast(llvm::Value* val, llvm::PointerType* type,
+                          const std::string& llname = {})
     {
-        return ptr_cast(val, (llvm::Type*)type);
+        return ptr_cast(val, (llvm::Type*)type, llname);
     }
 
     /// Cast the pointer variable specified by val to a pointer to the type
     /// described by type (as an llvm data type).
-    llvm::Value* ptr_to_cast(llvm::Value* val, llvm::Type* type);
+    llvm::Value* ptr_to_cast(llvm::Value* val, llvm::Type* type,
+                             const std::string& llname = {});
 
     /// Cast the pointer variable specified by val to a pointer to the given
     /// data type, return the llvm::Value of the new pointer.
-    llvm::Value* ptr_cast(llvm::Value* val, const OIIO::TypeDesc& type);
+    llvm::Value* ptr_cast(llvm::Value* val, const OIIO::TypeDesc& type,
+                          const std::string& llname = {});
 
     llvm::Value* wide_ptr_cast(llvm::Value* val, const OIIO::TypeDesc& type);
 
@@ -757,7 +761,7 @@ public:
 
     /// Cast the pointer variable specified by val to a pointer of type
     /// void* return the llvm::Value of the new pointer.
-    llvm::Value* void_ptr(llvm::Value* val);
+    llvm::Value* void_ptr(llvm::Value* val, const std::string& llname = {});
 
     /// Generate a pointer that is (ptrtype)((char *)ptr + offset).
     /// If ptrtype is NULL, just return a void*.
@@ -865,9 +869,10 @@ public:
 
     /// Dereference a pointer:  return *ptr
     /// type is the type of the thing being pointed to.
-    llvm::Value* op_load(llvm::Type* type, llvm::Value* ptr);
+    llvm::Value* op_load(llvm::Type* type, llvm::Value* ptr,
+                         const std::string& llname = {});
     // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* op_load(llvm::Value* ptr);
+    llvm::Value* op_load(llvm::Value* ptr, const std::string& llname = {});
 
     llvm::Value* op_gather(llvm::Value* ptr, llvm::Value* index);
 
@@ -898,24 +903,29 @@ public:
     /// llvm::Value, which can be generated from either a constant or a
     /// runtime-computed integer element index. `type` is the type of the data
     /// we're retrieving.
-    llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, llvm::Value* elem);
+    llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, llvm::Value* elem,
+                     const std::string& llname = {});
     // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, llvm::Value* elem);
+    llvm::Value* GEP(llvm::Value* ptr, llvm::Value* elem,
+                     const std::string& llname = {});
 
     /// Generate a GEP (get element pointer) with an integer element
     /// offset. `type` is the type of the data we're retrieving.
-    llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem);
+    llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem,
+                     const std::string& llname = {});
     // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, int elem);
+    llvm::Value* GEP(llvm::Value* ptr, int elem, const std::string& llname = {});
 
     /// Generate a GEP (get element pointer) with two integer element
     /// offsets.  This is just a special (and common) case of GEP where
     /// we have a 2-level hierarchy and we have fixed element indices
     /// that are known at compile time.  `type` is the type of the data we're
     /// retrieving.
-    llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2);
+    llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2,
+                     const std::string& llname = {});
     // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, int elem1, int elem2);
+    llvm::Value* GEP(llvm::Value* ptr, int elem1, int elem2,
+                     const std::string& llname = {});
 
     // Arithmetic ops.  It auto-detects the type (int vs float).
     // ...

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -259,7 +259,8 @@ BackendLLVM::llvm_global_symbol_ptr(ustring name)
     // the ShaderGlobals struct.
     int sg_index = ShaderGlobalNameToIndex(name);
     OSL_ASSERT(sg_index >= 0);
-    return ll.void_ptr(ll.GEP(sg_ptr(), 0, sg_index));
+    return ll.void_ptr(ll.GEP(sg_ptr(), 0, sg_index),
+                       fmtformat("glob_{}_voidptr", name));
 }
 
 
@@ -560,7 +561,7 @@ BackendLLVM::llvm_load_value(const Symbol& sym, int deriv,
     }
 
     return llvm_load_value(llvm_get_pointer(sym), sym.typespec(), deriv,
-                           arrayindex, component, cast);
+                           arrayindex, component, cast, sym.name().string());
 }
 
 
@@ -568,7 +569,7 @@ BackendLLVM::llvm_load_value(const Symbol& sym, int deriv,
 llvm::Value*
 BackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type, int deriv,
                              llvm::Value* arrayindex, int component,
-                             TypeDesc cast)
+                             TypeDesc cast, const std::string& llname)
 {
     if (!ptr)
         return NULL;  // Error
@@ -590,7 +591,7 @@ BackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type, int deriv,
         ptr = ll.GEP(ptr, 0, component);
 
     // Now grab the value
-    llvm::Value* result = ll.op_load(ptr);
+    llvm::Value* result = ll.op_load(ptr, llname);
 
     if (type.is_closure_based())
         return result;

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -99,7 +99,8 @@ public:
     /// (no conversion is performed if cast is the default of UNKNOWN).
     llvm::Value *llvm_load_value (llvm::Value *ptr, const TypeSpec &type,
                               int deriv, llvm::Value *arrayindex,
-                              int component, TypeDesc cast=TypeDesc::UNKNOWN);
+                              int component, TypeDesc cast=TypeDesc::UNKNOWN,
+                              const std::string& llname = {});
 
     /// Just like llvm_load_value, but when both the symbol and the
     /// array index are known to be constants.  This can even handle

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -3250,26 +3250,30 @@ LLVM_Util::void_ptr_null ()
 
 
 
-llvm::Value *
-LLVM_Util::ptr_to_cast (llvm::Value* val, llvm::Type *type)
+llvm::Value*
+LLVM_Util::ptr_to_cast(llvm::Value* val, llvm::Type* type,
+                       const std::string& llname)
 {
-    return builder().CreatePointerCast(val,llvm::PointerType::get(type, 0));
+    return builder().CreatePointerCast(val, llvm::PointerType::get(type, 0),
+                                       llname);
 }
 
 
 
-llvm::Value *
-LLVM_Util::ptr_cast (llvm::Value* val, llvm::Type *type)
+llvm::Value*
+LLVM_Util::ptr_cast(llvm::Value* val, llvm::Type* type,
+                    const std::string& llname)
 {
-    return builder().CreatePointerCast(val,type);
+    return builder().CreatePointerCast(val, type, llname);
 }
 
 
 
-llvm::Value *
-LLVM_Util::ptr_cast (llvm::Value* val, const TypeDesc &type)
+llvm::Value*
+LLVM_Util::ptr_cast(llvm::Value* val, const TypeDesc& type,
+                    const std::string& llname)
 {
-    return ptr_cast (val, llvm::PointerType::get (llvm_type(type), 0));
+    return ptr_cast(val, llvm::PointerType::get(llvm_type(type), 0), llname);
 }
 
 
@@ -3289,9 +3293,9 @@ LLVM_Util::int_to_ptr_cast (llvm::Value* val)
 
 
 llvm::Value *
-LLVM_Util::void_ptr (llvm::Value* val)
+LLVM_Util::void_ptr (llvm::Value* val, const std::string& llname)
 {
-    return builder().CreatePointerCast(val,type_void_ptr());
+    return builder().CreatePointerCast(val,type_void_ptr(), llname);
 }
 
 
@@ -3590,18 +3594,19 @@ LLVM_Util::op_memcpy (llvm::Value *dst, int dstalign,
 
 
 
-llvm::Value *
-LLVM_Util::op_load (llvm::Type* type, llvm::Value* ptr)
+llvm::Value*
+LLVM_Util::op_load(llvm::Type* type, llvm::Value* ptr,
+                   const std::string& llname)
 {
-    return builder().CreateLoad (type, ptr);
+    return builder().CreateLoad(type, ptr, llname);
 }
 
 
 
-llvm::Value *
-LLVM_Util::op_load (llvm::Value *ptr)
+llvm::Value*
+LLVM_Util::op_load(llvm::Value* ptr, const std::string& llname)
 {
-    return op_load(ptr->getType()->getPointerElementType(), ptr);
+    return op_load(ptr->getType()->getPointerElementType(), ptr, llname);
 }
 
 
@@ -5073,53 +5078,57 @@ LLVM_Util::op_store_mask (llvm::Value *llvm_mask, llvm::Value *native_mask_ptr)
 
 
 
-llvm::Value *
-LLVM_Util::GEP (llvm::Type* type, llvm::Value* ptr, llvm::Value* elem)
+llvm::Value*
+LLVM_Util::GEP(llvm::Type* type, llvm::Value* ptr, llvm::Value* elem,
+               const std::string& llname)
 {
-    return builder().CreateGEP(type, ptr, elem);
+    return builder().CreateGEP(type, ptr, elem, llname);
 }
 
 
 
-llvm::Value *
-LLVM_Util::GEP (llvm::Value *ptr, llvm::Value *elem)
+llvm::Value*
+LLVM_Util::GEP(llvm::Value* ptr, llvm::Value* elem, const std::string& llname)
 {
     return GEP(ptr->getType()->getScalarType()->getPointerElementType(), ptr,
-               elem);
+               elem, llname);
 }
 
 
 
-llvm::Value *
-LLVM_Util::GEP (llvm::Type* type, llvm::Value* ptr, int elem)
+llvm::Value*
+LLVM_Util::GEP(llvm::Type* type, llvm::Value* ptr, int elem,
+               const std::string& llname)
 {
-    return builder().CreateConstGEP1_32(type, ptr, elem);
+    return builder().CreateConstGEP1_32(type, ptr, elem, llname);
 }
 
 
 
-llvm::Value *
-LLVM_Util::GEP (llvm::Value *ptr, int elem)
-{
-    return GEP(ptr->getType()->getScalarType()->getPointerElementType(), ptr,
-               elem);
-}
-
-
-
-llvm::Value *
-LLVM_Util::GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2)
-{
-    return builder().CreateConstGEP2_32 (type, ptr, elem1, elem2);
-}
-
-
-
-llvm::Value *
-LLVM_Util::GEP (llvm::Value *ptr, int elem1, int elem2)
+llvm::Value*
+LLVM_Util::GEP(llvm::Value* ptr, int elem, const std::string& llname)
 {
     return GEP(ptr->getType()->getScalarType()->getPointerElementType(), ptr,
-               elem1, elem2);
+               elem, llname);
+}
+
+
+
+llvm::Value*
+LLVM_Util::GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2,
+               const std::string& llname)
+{
+    return builder().CreateConstGEP2_32 (type, ptr, elem1, elem2, llname);
+}
+
+
+
+llvm::Value*
+LLVM_Util::GEP(llvm::Value* ptr, int elem1, int elem2,
+               const std::string& llname)
+{
+    return GEP(ptr->getType()->getScalarType()->getPointerElementType(), ptr,
+               elem1, elem2, llname);
 }
 
 


### PR DESCRIPTION
Most LLVM API IR calls that generate ops allow an optional name of the
llvm symbol that will hold the result of the operation. By default, it
will make one up, such as "%37", "%38", etc. Needless to say, these
are difficult to understand when reading volumes of IR dumped for
debugging purposes.

So in this patch, I'm starting to expose the ability for our own code
to pass names through our wrapper functions. I needed this for some
deep debugging.

I haven't instrumented the entire set, just trying it on for some of
the specific areas I needed to debug. But this is a useful first step.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

