### PR TITLE
GPU string overhaul

### DIFF
--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -405,16 +405,6 @@ public:
     /// Return a pointer to the texture system (if available).
     virtual TextureSystem *texturesys () const;
 
-    /// Register a string with the renderer, so that the renderer can arrange
-    /// to make the string available in GPU memory as needed. Optionally specify
-    /// a variable name to associate with the string value.
-    virtual uint64_t register_string (const std::string& str,
-                                      const std::string& var_name)
-    {
-        ustring ustr = ustring(str);
-        return ustr.hash();
-    }
-
     virtual uint64_t register_global (const std::string& var_name,
                                       uint64_t           value)
     {

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -411,7 +411,8 @@ public:
     virtual uint64_t register_string (const std::string& str,
                                       const std::string& var_name)
     {
-        return 0;
+        ustring ustr = ustring(str);
+        return ustr.hash();
     }
 
     virtual uint64_t register_global (const std::string& var_name,

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -188,7 +188,7 @@ BatchedBackendLLVM::llvm_pass_type(const TypeSpec& typespec)
     else if (t == TypeDesc::INT)
         lt = ll.type_int();
     else if (t == TypeDesc::STRING)
-        lt = (llvm::Type*)ll.type_string();
+        lt = (llvm::Type*)ll.type_ustring();
     else if (t.aggregate == TypeDesc::VEC3)
         lt = (llvm::Type*)ll.type_void_ptr();  //llvm_type_triple_ptr();
     else if (t.aggregate == TypeDesc::MATRIX44)
@@ -867,7 +867,7 @@ BatchedBackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
                 || (ll.llvm_typeof(result) == ll.type_float())
                 || (ll.llvm_typeof(result) == ll.type_triple())
                 || (ll.llvm_typeof(result) == ll.type_int())
-                || (ll.llvm_typeof(result) == (llvm::Type*)ll.type_string())
+                || (ll.llvm_typeof(result) == ll.type_ustring())
                 || (ll.llvm_typeof(result) == ll.type_matrix())
                 || (ll.llvm_typeof(result) == ll.type_longlong())) {
                 result = ll.widen_value(result);
@@ -888,7 +888,7 @@ BatchedBackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
                     (ll.llvm_typeof(result) == ll.type_wide_float())
                     || (ll.llvm_typeof(result) == ll.type_wide_int())
                     || (ll.llvm_typeof(result) == ll.type_wide_triple())
-                    || (ll.llvm_typeof(result) == ll.type_wide_string())
+                    || (ll.llvm_typeof(result) == ll.type_wide_ustring())
                     || (ll.llvm_typeof(result) == ll.type_wide_bool())
                     || (ll.llvm_typeof(result) == ll.type_wide_matrix())
                     || (ll.llvm_typeof(result) == ll.type_wide_longlong()));
@@ -1218,7 +1218,8 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
         if (!type.is_closure_based() && t.aggregate > 1)
             dst_ptr = ll.GEP(dst_ptr, 0, component);
 
-        if (ll.type_ptr(ll.llvm_typeof(new_val)) != ll.llvm_typeof(dst_ptr)) {
+        if ((const llvm::Type*)ll.type_ptr(ll.llvm_typeof(new_val))
+            != ll.llvm_typeof(dst_ptr)) {
             std::cerr << " new_val type=";
             {
                 llvm::raw_os_ostream os_cerr(std::cerr);
@@ -1231,7 +1232,7 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
             }
             std::cerr << std::endl;
         }
-        OSL_ASSERT(ll.type_ptr(ll.llvm_typeof(new_val))
+        OSL_ASSERT((const llvm::Type*)ll.type_ptr(ll.llvm_typeof(new_val))
                    == ll.llvm_typeof(dst_ptr));
 
         // Finally, store the value.
@@ -1766,7 +1767,7 @@ BatchedBackendLLVM::llvm_test_nonzero(const Symbol& val, bool test_derivs)
         llvm::Value* llvmValue = llvm_get_pointer(val);
         //OSL_DEV_ONLY(std::cout << "llvmValue type=" << ll.llvm_typenameof(llvmValue) << std::endl);
 
-        if (ll.llvm_typeof(llvmValue) == ll.type_ptr(ll.type_bool())) {
+        if (ll.llvm_typeof(llvmValue) == (const llvm::Type*)ll.type_ptr(ll.type_bool())) {
             return ll.op_ne(llvm_load_value(val), ll.constant_bool(0));
         } else {
             return ll.op_ne(llvm_load_value(val), ll.constant(0));

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -7706,7 +7706,7 @@ LLVMGEN(llvm_gen_pointcloud_write)
                                          TypeDesc::NOSEMANTICS, nattrs } };
     TypeSpec valuesArrayType { TypeDesc { TypeDesc::PTR, TypeDesc::SCALAR,
                                           TypeDesc::NOSEMANTICS, nattrs } };
-    llvm::Value* names  = rop.ll.op_alloca(rop.ll.type_string(), nattrs);
+    llvm::Value* names  = rop.ll.op_alloca(rop.ll.type_ustring(), nattrs);
     llvm::Value* types  = rop.ll.op_alloca(rop.ll.type_typedesc(), nattrs);
     llvm::Value* values = rop.ll.op_alloca(rop.ll.type_void_ptr(), nattrs);
 

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -763,8 +763,7 @@ BatchedBackendLLVM::llvm_type_batched_trace_options()
     sg_types.push_back(ll.type_float());  // mindist
     sg_types.push_back(ll.type_float());  // maxdist
     sg_types.push_back(ll.type_int());    // shade
-    sg_types.push_back(
-        reinterpret_cast<llvm::Type*>(ll.type_string()));  // traceset
+    sg_types.push_back(ll.type_ustring());  // traceset
 
     m_llvm_type_batched_trace_options = ll.type_struct(sg_types, "TraceOptions",
                                                        false /*is_packed*/);
@@ -1252,8 +1251,7 @@ BatchedBackendLLVM::llvm_assign_initial_value(
                             data_type = ll.type_float();
                         } else if (elemtype.is_string()) {
                             ptr_type  = ll.type_ustring_ptr();
-                            data_type = static_cast<llvm::Type*>(
-                                ll.type_string());
+                            data_type = ll.type_ustring();
                         } else if (elemtype.is_int()) {
                             ptr_type  = ll.type_int_ptr();
                             data_type = ll.type_int();

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -459,7 +459,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
 
     // Handle interpolated params by calling osl_bind_interpolated_param,
     // which will check if userdata is already retrieved, if not it will
-    // call RendererServices::get_userdata to retrive it. In either case,
+    // call RendererServices::get_userdata to retrieve it. In either case,
     // it will return 1 if it put the userdata in the right spot (either
     // retrieved de novo or copied from a previous retrieval), or 0 if no
     // such userdata was available.

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -244,6 +244,7 @@ BackendLLVM::llvm_type_groupdata ()
     std::vector<llvm::Type*> fields;
     int offset = 0;
     int order = 0;
+    m_groupdata_field_names.clear();
 
     if (llvm_debug() >= 2)
         std::cout << "Group param struct:\n";
@@ -255,6 +256,7 @@ BackendLLVM::llvm_type_groupdata ()
                   << " at offset " << offset << "\n";
     int sz = (m_num_used_layers + 3) & (~3);  // Round up to 32 bit boundary
     fields.push_back (ll.type_array (ll.type_bool(), sz));
+    m_groupdata_field_names.emplace_back("layer_runflags");
     offset += sz * sizeof(bool);
     ++order;
 
@@ -270,6 +272,7 @@ BackendLLVM::llvm_type_groupdata ()
         int *offsets = & group().m_userdata_offsets[0];
         int sz = (nuserdata + 3) & (~3);
         fields.push_back (ll.type_array (ll.type_bool(), sz));
+        m_groupdata_field_names.emplace_back("userdata_init_flags");
         offset += nuserdata * sizeof(bool);
         ++order;
         for (int i = 0; i < nuserdata; ++i) {
@@ -283,6 +286,8 @@ BackendLLVM::llvm_type_groupdata ()
                 : type.numelements();
             type.arraylen = n;
             fields.push_back (llvm_type (type));
+            m_groupdata_field_names.emplace_back(
+                fmtformat("userdata{}_{}_", i, names[i]));
             // Alignment
             int align = type.basesize();
             offset = OIIO::round_to_multiple_of_pow2 (offset, align);
@@ -311,6 +316,8 @@ BackendLLVM::llvm_type_groupdata ()
             const int derivSize = (sym.has_derivs() ? 3 : 1);
             ts.make_array (arraylen * derivSize);
             fields.push_back (llvm_type (ts));
+            m_groupdata_field_names.emplace_back(
+                fmtformat("lay{}param_{}_", layer, sym.name()));
 
             // FIXME(arena) -- temporary debugging
             if (debug() && sym.symtype() == SymTypeOutputParam
@@ -343,9 +350,8 @@ BackendLLVM::llvm_type_groupdata ()
     if (llvm_debug() >= 2)
         print(" Group struct had {} fields, total size {}\n\n", order, offset);
 
-    std::string groupdataname = fmtformat("Groupdata_{}",
-                                          group().name().hash());
-    m_llvm_type_groupdata = ll.type_struct (fields, groupdataname);
+    m_llvm_type_groupdata = ll.type_struct (fields, "Groupdata");
+    OSL_ASSERT(fields.size() == m_groupdata_field_names.size());
 
     return m_llvm_type_groupdata;
 }
@@ -393,10 +399,9 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
     if (!force && sym.valuesource() == Symbol::ConnectedVal &&
           !sym.typespec().is_closure_based())
         return;
+    // For "globals" that are closures, there is nothing to initialize.
     if (sym.typespec().is_closure_based() && sym.symtype() == SymTypeGlobal)
         return;
-
-    int arraylen = std::max (1, sym.typespec().arraylength());
 
     // Closures need to get their storage before anything can be
     // assigned to them.  Unless they are params, in which case we took
@@ -407,9 +412,11 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
         return;
     }
 
+    // For local variables (including temps), when "debug_uninit" is enabled,
+    // we store special values in the variable to make it easier to detect
+    // uninitialized use.
     if ((sym.symtype() == SymTypeLocal || sym.symtype() == SymTypeTemp)
           && shadingsys().debug_uninit()) {
-        // Handle the "debug uninitialized values" case
         bool isarray = sym.typespec().is_array();
         int alen = isarray ? sym.typespec().arraylength() : 1;
         llvm::Value *u = NULL;
@@ -421,7 +428,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
         else if (sym.typespec().is_int_based())
             u = ll.constant (std::numeric_limits<int>::min());
         else if (sym.typespec().is_string_based())
-            u = ll.constant (Strings::uninitialized_string);
+            u = llvm_load_string(Strings::uninitialized_string);
         if (u) {
             for (int a = 0;  a < alen;  ++a) {
                 llvm::Value *aval = isarray ? ll.constant(a) : NULL;
@@ -432,6 +439,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
         return;
     }
 
+    // Local/temp strings are always initialzed to the empty string.
     if ((sym.symtype() == SymTypeLocal || sym.symtype() == SymTypeTemp) &&
         sym.typespec().is_string_based()) {
         // Strings are pointers.  Can't take any chance on leaving
@@ -440,6 +448,10 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
         return;  // we're done, the parts below are just for params
     }
 
+    // FIXME: Future work -- how expensive would it be to initialize all
+    // locals to 0? We should test this for performance hit, and if
+    // reasonable, it may be a good idea to do it by default.
+
     // From here on, everything we are dealing with is a shader parameter
     // (either ordinary or output).
     OSL_ASSERT_MSG (sym.symtype() == SymTypeParam || sym.symtype() == SymTypeOutputParam,
@@ -447,7 +459,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
 
     // Handle interpolated params by calling osl_bind_interpolated_param,
     // which will check if userdata is already retrieved, if not it will
-    // call RendererServices::get_userdata to retrived it. In either case,
+    // call RendererServices::get_userdata to retrive it. In either case,
     // it will return 1 if it put the userdata in the right spot (either
     // retrieved de novo or copied from a previous retrieval), or 0 if no
     // such userdata was available.
@@ -487,21 +499,9 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
                 ll.op_memset(ll.offset_ptr(dstptr, size), 0, 2*size);
         } else {
             // No pre-placement: fall back to call to the renderer callback.
-            llvm::Value* name_arg = NULL;
-            if (use_optix()) {
-                // We need to make a DeviceString for the parameter name
-                ustring arg_name = ustring::fmtformat("osl_paramname_{}_{}",
-                                                      symname, sym.layer());
-                Symbol symname_const (arg_name, TypeDesc::TypeString, SymTypeConst);
-                symname_const.set_dataptr(SymArena::Absolute, &symname);
-                name_arg = llvm_load_device_string (symname_const, /*follow*/ true);
-            } else {
-                name_arg = ll.constant (symname);
-            }
-
             llvm::Value* args[] = {
                 sg_void_ptr(),
-                name_arg,
+                llvm_load_string(symname),
                 ll.constant (type),
                 ll.constant ((int) group().m_userdata_derivs[userdata_index]),
                 groupdata_field_ptr (2 + userdata_index), // userdata data ptr
@@ -518,10 +518,10 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
             int ncomps = type.numelements() * type.aggregate;
             llvm::Value *args[] = { ll.constant(ncomps), llvm_void_ptr(sym),
                                     ll.constant((int)sym.has_derivs()), sg_void_ptr(),
-                                    ll.constant(ustring(inst()->shadername())),
-                                    ll.constant(0), ll.constant(sym.unmangled()),
+                                    llvm_load_string(inst()->shadername()),
+                                    ll.constant(0), llvm_load_string(sym.unmangled()),
                                     ll.constant(0), ll.constant(ncomps),
-                                    ll.constant("<get_userdata>")
+                                    llvm_load_string("<get_userdata>")
             };
             ll.call_function ("osl_naninf_check", args);
         }
@@ -544,29 +544,15 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
         if (sym.has_init_ops() && sym.valuesource() == Symbol::DefaultVal) {
             // Handle init ops.
             build_llvm_code (sym.initbegin(), sym.initend());
-        } else if (use_optix() && ! sym.typespec().is_closure() && ! sym.typespec().is_string()) {
+        } else if (use_optix() && ! sym.typespec().is_closure()) {
             // If the call to osl_bind_interpolated_param returns 0, the default
             // value needs to be loaded from a CUDA variable.
-            ustring var_name = ustring::fmtformat("{}_{}_{}_{}", sym.name(),
-                                                  inst()->layername(),
-                                                  group().name(), group().id());
-
-            // The "true" argument triggers the creation of the metadata needed to
-            // make the variable visible to OptiX.
-            llvm::Value* cuda_var = getOrAllocateCUDAVariable (sym, true);
-
+            llvm::Value* cuda_var = getOrAllocateCUDAVariable (sym);
             // memcpy the initial value from the CUDA variable
             llvm::Value* src = ll.ptr_cast (ll.GEP (cuda_var, 0), ll.type_void_ptr());
             llvm::Value* dst = llvm_void_ptr (sym);
             TypeDesc t = sym.typespec().simpletype();
             ll.op_memcpy (dst, src, t.size(), t.basesize());
-        } else if (use_optix() && ! sym.typespec().is_closure()) {
-            // For convenience, we always pack string addresses into the groupdata
-            // struct.
-            int userdata_index = find_userdata_index (sym);
-            llvm::Value* init_val = getOrAllocateCUDAVariable (sym);
-            init_val = ll.ptr_cast (init_val, ll.type_void_ptr());
-            ll.op_memcpy (groupdata_field_ptr (2 + userdata_index), init_val, 8, 4);
         } else if (! sym.lockgeom() && ! sym.typespec().is_closure()) {
             // geometrically-varying param; memcpy its default value
             TypeDesc t = sym.typespec().simpletype();
@@ -578,6 +564,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
             // Use default value
             int num_components = sym.typespec().simpletype().aggregate;
             TypeSpec elemtype = sym.typespec().elementtype();
+            int arraylen = std::max (1, sym.typespec().arraylength());
             for (int a = 0, c = 0; a < arraylen;  ++a) {
                 llvm::Value *arrind = sym.typespec().is_array() ? ll.constant(a) : NULL;
                 if (sym.typespec().is_closure_based())
@@ -588,7 +575,7 @@ BackendLLVM::llvm_assign_initial_value (const Symbol& sym, bool force)
                     if (elemtype.is_float_based())
                         init_val = ll.constant(sym.get_float(c));
                     else if (elemtype.is_string())
-                        init_val = ll.constant(sym.get_string(c));
+                        init_val = llvm_load_string(sym.get_string(c));
                     else if (elemtype.is_int())
                         init_val = ll.constant(sym.get_int(c));
                     OSL_DASSERT (init_val);

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -89,11 +89,6 @@ OptixRaytracer::OptixRaytracer()
 
     CUDA_CHECK(cudaSetDevice(0));
     CUDA_CHECK(cudaStreamCreate(&m_cuda_stream));
-
-#define STRDECL(str, var_name) \
-    register_string(str, OSL_NAMESPACE_STRING "::DeviceStrings::" #var_name);
-#include <OSL/strdecls.h>
-#undef STRDECL
 }
 
 
@@ -169,9 +164,6 @@ OptixRaytracer::synch_attributes()
     ustring userdata_str1("ud_str_1");
     ustring userdata_str2("userdata string");
 
-    register_string(userdata_str1.string(), "");
-    register_string(userdata_str2.string(), "");
-
     // Store the user-data
     test_str_1 = userdata_str1.hash();
     test_str_2 = userdata_str2.hash();
@@ -216,7 +208,7 @@ OptixRaytracer::synch_attributes()
         for (const ustring* end = cpuString + numStrings; cpuString < end;
              ++cpuString) {
             // convert the ustring to a device string
-            uint64_t devStr = register_string(cpuString->string(), "");
+            uint64_t devStr = cpuString->hash();
             CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(gpuStrings), &devStr,
                                   sizeof(devStr), cudaMemcpyHostToDevice));
             gpuStrings += sizeof(DeviceString);

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -1050,10 +1050,9 @@ OptixRaytracer::processPrintfBuffer(void* buffer_data, size_t buffer_size)
         // have we reached the end?
         if (fmt_str_hash == 0)
             break;
-        const char* format = m_hash_map[fmt_str_hash];
-        OSL_ASSERT(
-            format != nullptr
-            && "The format string should have been registered with the renderer");
+        const char* format = ustring::from_hash(fmt_str_hash).c_str();
+        OSL_ASSERT(format != nullptr
+                   && "The string should have been a valid ustring");
         const size_t len = strlen(format);
 
         for (size_t j = 0; j < len; j++) {
@@ -1103,10 +1102,10 @@ OptixRaytracer::processPrintfBuffer(void* buffer_data, size_t buffer_size)
                               & ~(sizeof(double) - 1);
                         uint64_t str_hash = *reinterpret_cast<const uint64_t*>(
                             &ptr[src]);
-                        const char* str = m_hash_map[str_hash];
+                        const char* str = ustring::from_hash(str_hash).c_str();
                         OSL_ASSERT(
                             str != nullptr
-                            && "The string should have been regisgtered with the renderer");
+                            && "The string should have been a valid ustring");
                         dst += snprintf(&buffer[dst], BufferSize - dst,
                                         fmt_string.c_str(), str);
                         src += sizeof(uint64_t);

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -25,12 +25,6 @@ public:
     OptixRaytracer();
     virtual ~OptixRaytracer();
 
-    uint64_t register_string(string_view str, string_view var_name)
-    {
-        ustring ustr = ustring(str);
-        return static_cast<uint64_t>(ustr.hash());
-    }
-
     uint64_t register_global(const std::string& str, uint64_t value);
     bool fetch_global(const std::string& str, uint64_t* value);
 

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -25,12 +25,10 @@ public:
     OptixRaytracer();
     virtual ~OptixRaytracer();
 
-    uint64_t register_string(const std::string& str,
-                             const std::string& var_name)
+    uint64_t register_string(string_view str, string_view var_name)
     {
         ustring ustr = ustring(str);
-        m_hash_map[ustr.hash()] = ustr.c_str();
-        return 0;
+        return static_cast<uint64_t>(ustr.hash());
     }
 
     uint64_t register_global(const std::string& str, uint64_t value);
@@ -90,7 +88,6 @@ private:
     uint64_t test_str_1;
     uint64_t test_str_2;
     const unsigned long OSL_PRINTF_BUFFER_SIZE = 8 * 1024 * 1024;
-    std::unordered_map<uint64_t, const char*> m_hash_map;
 
     bool load_optix_module(
         const char* filename,

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -854,14 +854,13 @@ OptixGridRenderer::processPrintfBuffer(void* buffer_data, size_t buffer_size)
         // have we reached the end?
         if (fmt_str_hash == 0)
             break;
-        const char* format = m_hash_map[fmt_str_hash];
-        OSL_ASSERT(
-            format != nullptr
-            && "The format string should have been registered with the renderer");
+        const char* format = ustring::from_hash(fmt_str_hash).c_str();
+        OSL_ASSERT(format != nullptr
+                   && "The string should have been a valid ustring");
         const size_t len = strlen(format);
 
         for (size_t j = 0; j < len; j++) {
-            // If we encounter a '%', then we'l copy the format string to 'fmt_string'
+            // If we encounter a '%', then we'll copy the format string to 'fmt_string'
             // and provide that to printf() directly along with a pointer to the argument
             // we're interested in printing.
             if (format[j] == '%') {
@@ -903,16 +902,13 @@ OptixGridRenderer::processPrintfBuffer(void* buffer_data, size_t buffer_size)
                         format_end_found = true;
                         break;
                     case 's':
-                        src = (src + sizeof(double) - 1)
-                              & ~(sizeof(double) - 1);
+                        src = (src + sizeof(uint64_t) - 1)
+                              & ~(sizeof(uint64_t) - 1);
                         uint64_t str_hash = *reinterpret_cast<const uint64_t*>(
                             &ptr[src]);
-                        const char* str = m_hash_map[str_hash];
-                        OSL_ASSERT(
-                            str != nullptr
-                            && "The string should have been regisgtered with the renderer");
+                        ustring str = ustring::from_hash(str_hash);
                         dst += snprintf(&buffer[dst], BufferSize - dst,
-                                        fmt_string.c_str(), str);
+                                        fmt_string.c_str(), str.c_str());
                         src += sizeof(uint64_t);
                         format_end_found = true;
                         break;

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -25,14 +25,6 @@ public:
     OptixGridRenderer();
     virtual ~OptixGridRenderer();
 
-    uint64_t register_string(const std::string& str,
-                             const std::string& var_name)
-    {
-        ustring ustr = ustring(str);
-        m_hash_map[ustr.hash()] = ustr.c_str();
-        return static_cast<uint64_t>(ustr.hash());
-    }
-
     uint64_t register_global(const std::string& str, uint64_t value);
     bool fetch_global(const std::string& str, uint64_t* value);
 
@@ -96,8 +88,6 @@ private:
     uint64_t test_str_1;
     uint64_t test_str_2;
     const unsigned long OSL_PRINTF_BUFFER_SIZE = 8 * 1024 * 1024;
-
-    std::unordered_map<uint64_t, const char*> m_hash_map;
 
     std::string m_materials_ptx;
     std::unordered_map<OIIO::ustring, optix::TextureSampler, OIIO::ustringHash>

--- a/testsuite/example-cuda/cuda_grid_renderer.h
+++ b/testsuite/example-cuda/cuda_grid_renderer.h
@@ -39,17 +39,6 @@ public:
     CudaGridRenderer();
     virtual ~CudaGridRenderer();
 
-    uint64_t register_string(const std::string& str,
-                             const std::string& var_name)
-    {
-        uint64_t addr = _string_table.addString(OIIO::ustring(str),
-                                                OIIO::ustring(var_name));
-        if (!var_name.empty()) {
-            register_global(var_name, addr);
-        }
-        return addr;
-    }
-
     uint64_t register_global(const std::string& str, uint64_t value);
     bool fetch_global(const std::string& str, uint64_t* value);
 


### PR DESCRIPTION
Big string cleanup, yet again, for GPU. We still had this tricky
double indirection happening with strings for OptiX -- the string was
a pointer to a "global", which in turn held the hash. No, throw all
that out.  Just directly store strings as the ustring hash on
OptiX. No extra indirection. Many fewer differences between how things
are handled on OptiX versus CPU (except for the fact itself that the
"string" holds the hash rather than the char*).

Some details worth noting:

* LLVM_Util loses "type_string()" and calls it "type_ustring()" to
  emphasize it's the type we're using to represent a ustring, and
  definitely not a C or C++std string. Also, LLVM_Util itself now lets
  the caller tell it whether it prefers that the representation of a
  ustring be the charptr or the hash, and then handles most of the
  details internally. The BackendLLVM, then, makes that decision early
  on, charptr for CPU and hash for GPU.

* Several more spots in LLVM_Util and BackendLLVM have been plumbed to
  pass around llvm IR SSA variable names to try to make the resulting
  LLVM IR more readable when I'm trying to debug it. (This was
  strictly debugging scaffalding aid for me, but comes along for the
  ride because it's useful to keep.) I also added a
  BackendLLVM::llnamefmt to format strings, which only does the
  formatting when the shading system knows it's going to save the IR
  for inspection, and otherwise (that is, in production) it does not
  do the string formatting or pass the names along, so it's not doing
  all that string manipulation when no human is going to be looking at
  the IR dumps.

* A lot of clunky OptiX-only code disappears.

* Some side effects of my reducing complexity of the IR as I debugged:
  there were times we were generating redundant pointer casting in the
  IR, such as grabbing a pointer, then casting it to a void*, then
  casting back to some other kind of pointer. In some cases I reduced
  that quite a bit. Again, this was mostly just a scramble to make the
  IR more readable while I debugged, but it probably has a minor
  performance gain as well since it reduced somewhat the sheer amount
  of IR we generate and pass to the optimizer and JIT.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
