### PR TITLE
Fix error message for texture-errormsg test

### DIFF
--- a/testsuite/texture-errormsg/ref/out-travis.txt
+++ b/testsuite/texture-errormsg/ref/out-travis.txt
@@ -1,4 +1,0 @@
-Compiled test.osl -> test.oso
-
-Output Cout to out.tif
-err 0.508 0.00781: Could not open file: bad.tif: Cannot open

--- a/testsuite/texture-errormsg/ref/out.txt
+++ b/testsuite/texture-errormsg/ref/out.txt
@@ -1,4 +1,4 @@
 Compiled test.osl -> test.oso
 
 Output Cout to out.tif
-err 0.508 0.00781: Could not open file: bad.tif: No such file or directory
+err Could not open file: bad.tif: No such file or directory

--- a/testsuite/texture-errormsg/test.osl
+++ b/testsuite/texture-errormsg/test.osl
@@ -13,6 +13,6 @@ test (output color Cout = 0)
     } else {
         Cout = color(1,0,0);
         if (err != "unknown")
-            printf ("err %0.03g %0.03g: %s\n", u, v, err);
+            printf ("err %s\n", err);
     }
 }


### PR DESCRIPTION
It printed the u,v coordinates where the error was first discovered.
This is not necessarily deterministic, of course!

Signed-off-by: Larry Gritz <lg@larrygritz.com>
