### PR TITLE
Fix typo error that prevented correct typecheck of ternary

### DIFF
--- a/src/liboslcomp/typecheck.cpp
+++ b/src/liboslcomp/typecheck.cpp
@@ -618,7 +618,7 @@ ASTternary_expression::typecheck(TypeSpec expected)
         errorfmt("Cannot use an array as a condition");
 
     // No arrays
-    if (t.is_array() || t.is_array()) {
+    if (t.is_array() || f.is_array()) {
         errorfmt("Not allowed: '{} ? {} : {}'", c, t, f);
         return TypeSpec();
     }


### PR DESCRIPTION
Didn't properly detect the disallowed use of arrays for the false
clause because we checked `t` twice.

Yay for static analysis!

Signed-off-by: Larry Gritz <lg@larrygritz.com>
