### PR TITLE
Fix OptiX + clang14 issue with duplicate symbols

### DIFF
--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -38,6 +38,7 @@ namespace pvt {
 #define IlluminantE    0.33333333, 0.33333333  /* CIE equal-energy illuminant */
 #define IlluminantACES 0.32168, 0.33767        /* For ACES, approximate D60 */
 
+namespace {  // anon namespace to avoid duplicate OptiX symbols
 OSL_CONSTANT_DATA const static ColorSystem::Chroma k_color_systems[13] = {
    // Index, Name        xRed    yRed   xGreen  yGreen   xBlue   yBlue    White point
    /* 0  Rec709     */ { 0.64,   0.33,   0.30,   0.60,   0.15,   0.06,   IlluminantD65 },
@@ -54,6 +55,7 @@ OSL_CONSTANT_DATA const static ColorSystem::Chroma k_color_systems[13] = {
    /* 11 ACES2065-1 */ { 0.7347, 0.2653, 0.0,    1.0,    0.0001, -0.077, IlluminantACES },
    /* 12 ACEScg     */ { 0.713,  0.293,  0.165,  0.83,   0.128,  0.044,  IlluminantACES },
 };
+}  // namespace
 
 // clang-format on
 

--- a/src/liboslexec/opcolor_impl.h
+++ b/src/liboslexec/opcolor_impl.h
@@ -49,7 +49,8 @@ clamp_zero(Color3& c)
 //        cie_colour_match[(lambda - 380) / 5][2] = zBar
 //OSL_CONSTANT_DATA const float cie_colour_match[81][3] =
 // Choose to access 1d array vs 2d to allow better code generation of gathers
-OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) = {
+namespace {  // anon namespace to avoid duplicate OptiX symbols
+static OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) = {
     // clang-format off
     0.0014,0.0000,0.0065, 0.0022,0.0001,0.0105, 0.0042,0.0001,0.0201,
     0.0076,0.0002,0.0362, 0.0143,0.0004,0.0679, 0.0232,0.0006,0.1102,
@@ -80,7 +81,7 @@ OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) = {
     0.0001,0.0000,0.0000, 0.0001,0.0000,0.0000, 0.0000,0.0000,0.0000
     // clang-format on
 };
-
+}  // namespace
 
 
 // For a given wavelength lambda (in nm), return the XYZ triple giving the

--- a/src/liboslexec/splineimpl.h
+++ b/src/liboslexec/splineimpl.h
@@ -41,6 +41,7 @@ enum {
 
 
 // clang-format off
+namespace {  // anon namespace to avoid duplicate OptiX symbols
 OSL_CONSTANT_DATA const static SplineBasis gBasisSet[kNumSplineTypes] = {
 //
 // catmullrom
@@ -85,6 +86,7 @@ OSL_CONSTANT_DATA const static SplineBasis gBasisSet[kNumSplineTypes] = {
           {0,  0,  0,  0},
           {0,  0,  0,  0} } }
 };
+}  // namespace
 // clang-format on
 
 

--- a/src/liboslnoise/simplexnoise.cpp
+++ b/src/liboslnoise/simplexnoise.cpp
@@ -66,11 +66,12 @@ scramble(uint32_t v0, uint32_t v1 = 0, uint32_t v2 = 0)
 /* Static data ---------------------- */
 // clang-format off
 
-static OSL_DEVICE float zero[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+namespace {  // anon namespace to avoid duplicate OptiX symbols
+static OSL_CONSTANT_DATA float zero[] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
 // Gradient table for 2D. These could be programmed the Ken Perlin way with
 // some clever bit-twiddling, but this is more clear, and not really slower.
-static OSL_DEVICE float grad2lut[8][2] = {
+static OSL_CONSTANT_DATA float grad2lut[8][2] = {
     { -1.0f, -1.0f }, { 1.0f,  0.0f }, { -1.0f, 0.0f }, { 1.0f,  1.0f },
     { -1.0f,  1.0f }, { 0.0f, -1.0f }, {  0.0f, 1.0f }, { 1.0f, -1.0f }
 };
@@ -81,7 +82,7 @@ static OSL_DEVICE float grad2lut[8][2] = {
 // but these 12 (including 4 repeats to make the array length a power
 // of two) work better. They are not random, they are carefully chosen
 // to represent a small, isotropic set of directions.
-static OSL_DEVICE float grad3lut[16][3] = {
+static OSL_CONSTANT_DATA float grad3lut[16][3] = {
     {  1.0f,  0.0f,  1.0f }, {  0.0f,  1.0f,  1.0f }, // 12 cube edges
     { -1.0f,  0.0f,  1.0f }, {  0.0f, -1.0f,  1.0f },
     {  1.0f,  0.0f, -1.0f }, {  0.0f,  1.0f, -1.0f },
@@ -93,7 +94,7 @@ static OSL_DEVICE float grad3lut[16][3] = {
 };
 
 // Gradient directions for 4D
-static OSL_DEVICE float grad4lut[32][4] = {
+static OSL_CONSTANT_DATA float grad4lut[32][4] = {
   { 0.0f, 1.0f, 1.0f, 1.0f }, { 0.0f, 1.0f, 1.0f, -1.0f }, { 0.0f, 1.0f, -1.0f, 1.0f }, { 0.0f, 1.0f, -1.0f, -1.0f }, // 32 tesseract edges
   { 0.0f, -1.0f, 1.0f, 1.0f }, { 0.0f, -1.0f, 1.0f, -1.0f }, { 0.0f, -1.0f, -1.0f, 1.0f }, { 0.0f, -1.0f, -1.0f, -1.0f },
   { 1.0f, 0.0f, 1.0f, 1.0f }, { 1.0f, 0.0f, 1.0f, -1.0f }, { 1.0f, 0.0f, -1.0f, 1.0f }, { 1.0f, 0.0f, -1.0f, -1.0f },
@@ -107,7 +108,7 @@ static OSL_DEVICE float grad4lut[32][4] = {
 // A lookup table to traverse the simplex around a given point in 4D.
 // Details can be found where this table is used, in the 4D noise method.
 /* TODO: This should not be required, backport it from Bill's GLSL code! */
-static OSL_DEVICE unsigned char simplex[64][4] = {
+static OSL_CONSTANT_DATA unsigned char simplex[64][4] = {
   {0,1,2,3},{0,1,3,2},{0,0,0,0},{0,2,3,1},{0,0,0,0},{0,0,0,0},{0,0,0,0},{1,2,3,0},
   {0,2,1,3},{0,0,0,0},{0,3,1,2},{0,3,2,1},{0,0,0,0},{0,0,0,0},{0,0,0,0},{1,3,2,0},
   {0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},
@@ -116,6 +117,7 @@ static OSL_DEVICE unsigned char simplex[64][4] = {
   {0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},
   {2,0,1,3},{0,0,0,0},{0,0,0,0},{0,0,0,0},{3,0,1,2},{3,0,2,1},{0,0,0,0},{3,1,2,0},
   {2,1,0,3},{0,0,0,0},{0,0,0,0},{0,0,0,0},{3,1,0,2},{0,0,0,0},{3,2,0,1},{3,2,1,0}};
+}  // namespace
 
 // clang-format on
 /* --------------------------------------------------------------------- */


### PR DESCRIPTION
We had been using clang/llvm 12 and when trying out 14 I started
getting test failures with OptiX compliaining about duplicate
symbols. They all seemed to be the things we declared as
OSL_CONSTANT_DATA. It looks like there's a difference in llvm 12 vs 14
in how the generated PTX marks its symbol visibility.

The solution (thanks to a clever suggestion by Alex Conty) was just to
enclose those declarations in anonymous namespaces. Works like a
charm!

Signed-off-by: Larry Gritz <lg@larrygritz.com>
