### PR TITLE
New closure docs

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -66,7 +66,7 @@ All rights reserved.
 Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
-\date{{\large Date: 24 Nov 2021 \\
+\date{{\large Date: 27 Aug 2022 \\
 % (with corrections, 24 Nov 2021)
 }
 \bigskip
@@ -4626,9 +4626,689 @@ closures, passed as token/value pairs following the required arguments
 (much like the optional arguments to the {\cf texture()} function).
 Consult the documentation for your specific renderer for details.
 
+OSL's standard material closures are by synchronized to match the names and
+properties of the physically-based shading nodes of MaterialX v1.38
+(\url{https://www.materialx.org/}).
+
+\subsection{Surface BSDF closures}
+
+\apiitem{\closurecolor\ {\ce oren_nayar_diffuse_bsdf}(normal N, color albedo, float roughness)}
+\indexapi{oren_nayar_diffuse_bsdf()}
+
+Constructs a diffuse reflection BSDF based on the Oren-Nayar reflectance
+model.
+
+\noindent Parameters include:
+
+  \apiitem{N}
+  \vspace{12pt}
+  Normal vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{albedo}
+  \vspace{12pt}
+  Surface albedo.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness}
+  \vspace{12pt}
+  Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
+  \apiend
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+
+The Oren-Nayar reflection model is described in  M.\ Oren and S.\ K.\
+Nayar, ``Generalization of Lambert's Reflectance Model,'' Proceedings of
+SIGGRAPH 1994, pp.239-246 (July, 1994).
+
+\apiend
 
 
-\subsection{Surface material closures}
+\apiitem{\colorclosure\ {\ce burley_diffuse_bsdf} (normal N, color albedo, float roughness)}
+\indexapi{burley_diffuse_bsdf()}
+
+Constructs a diffuse reflection BSDF based on the corresponding component of 
+the Disney Principled shading model.
+
+\noindent Parameters include:
+
+  \apiitem{N}
+  \vspace{12pt}
+  Normal vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{albedo}
+  \vspace{12pt}
+  Surface albedo.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness}
+  \vspace{12pt}
+  Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
+  \apiend
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+
+\apiend
+
+
+\apiitem{\colorclosure\ {\ce dielectric_bsdf} (normal N, vector U, color reflection_tint, \\
+\spc\spc color transmission_tint, float roughness_x, float roughness_y, \\
+\spc\spc float ior, string distribution)}
+\indexapi{dielectric_bsdf()}
+
+Constructs a reflection and/or transmission BSDF based on a microfacet
+reflectance model and a Fresnel curve for dielectrics. The two tint parameters
+control the contribution of each reflection/transmission lobe. The tints
+should remain 100\% white for a physically correct dielectric, but can be
+tweaked for artistic control or set to 0.0 for disabling a lobe.
+
+The closure may be vertically layered over a base BSDF for the surface beneath
+the dielectric layer. This is done using the {\cf layer()} closure. By
+chaining multiple {\cf dielectric_bsdf} closures you can describe a surface
+with multiple specular lobes. If transmission is enabled (transmission_tint
+$>$ 0.0) the closure may be layered over a VDF closure describing the surface
+interior to handle absorption and scattering inside the medium.
+
+\noindent Parameters include:
+
+  \apiitem{N}
+  \vspace{12pt}
+  Normal vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{U}
+  \vspace{12pt}
+  Tangent vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{reflection_tint}
+  \vspace{12pt}
+  Weight per color channel for the reflection lobe. Should be (1,1,1) for a physically-correct dielectric surface, but can be tweaked for artistic control. Set to (0,0,0) to disable reflection.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{transmission_tint}
+  \vspace{12pt}
+  Weight per color channel for the transmission lobe. Should be (1,1,1) for a physically-correct dielectric surface, but can be tweaked for artistic control. Set to (0,0,0) to disable transmission.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness_x}
+  \vspace{12pt}
+  Surface roughness in the U direction with a perceptually linear response over its range.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness_y}
+  \vspace{12pt}
+  Surface roughness in the V direction with a perceptually linear response
+  over its range.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{ior}
+  \vspace{12pt}
+  Refraction index.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{distribution}
+  \vspace{12pt}
+  Microfacet distribution. An implementation is expected to support the
+  following distributions: \qkw{ggx}
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{thinfilm_thickness}
+  \vspace{12pt}
+  Optional float parameter for thickness of an iridescent thin film layer on
+  top of this BSDF. Given in nanometers.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{thinfilm_ior}
+  \vspace{12pt}
+  Optional float parameter for refraction index of the thin film layer.
+  \apiend
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+
+\apiend
+
+
+\apiitem{\colorclosure\ {\ce conductor_bsdf} (normal N, vector U, float roughness_x, \\
+\spc\spc float roughness_y, color ior, color extinction, string distribution)}
+\indexapi{conductor_bsdf()}
+
+Constructs a reflection BSDF based on a microfacet reflectance model. Uses a
+Fresnel curve with complex refraction index for conductors/metals. If an
+artistic parametrization is preferred the {\cf artistic_ior()} utility
+function can be used to convert from artistic to physical parameters.
+
+\noindent Parameters include:
+
+  \apiitem{N}
+  \vspace{12pt}
+  Normal vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{U}
+  \vspace{12pt}
+  Tangent vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness_x}
+  \vspace{12pt}
+  Surface roughness in the U direction with a perceptually linear response over its range.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness_y}
+  \vspace{12pt}
+  Surface roughness in the V direction with a perceptually linear response over its range.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{ior}
+  \vspace{12pt}
+  Refraction index.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{extinction}
+  \vspace{12pt}
+  Extinction coefficient.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{distribution}
+  \vspace{12pt}
+  Microfacet distribution. An implementation is expected to support the
+  following distributions: \qkw{ggx}
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{thinfilm_thickness}
+  \vspace{12pt}
+  Optional float parameter for thickness of an iridescent thin film layer on
+  top of this BSDF. Given in nanometers.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{thinfilm_ior}
+  \vspace{12pt}
+  Optional float parameter for refraction index of the thin film layer.
+  \apiend
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+
+\apiend
+
+
+\apiitem{\colorclosure\ {\ce generalized_schlick_bsdf} (normal N, vector U, \\
+\spc\spc  color reflection_tint, color transmission_tint, \\
+\spc\spc float roughness_x, float roughness_y, color f0, color f90, \\
+\spc\spc float exponent, string distribution)}
+\indexapi{generalized_schlick_bsdf()}
+
+Constructs a reflection and/or transmission BSDF based on a microfacet
+reflectance model and a generalized Schlick Fresnel curve. The two tint
+parameters control the contribution of each reflection/transmission lobe.
+
+The closure may be vertically layered over a base BSDF for the surface beneath
+the dielectric layer. This is done using the layer() closure. By chaining
+multiple dielectric_bsdf closures you can describe a surface with multiple
+specular lobes. If transmission is enabled (transmission_tint $>$ 0.0) the
+closure may be layered over a VDF closure describing the surface interior to
+handle absorption and scattering inside the medium.
+
+\noindent Parameters include:
+
+  \apiitem{N}
+  \vspace{12pt}
+  Normal vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{U}
+  \vspace{12pt}
+  Tangent vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{reflection_tint}
+  \vspace{12pt}
+  Weight per color channel for the reflection lobe. Set to (0,0,0) to disable
+  reflection.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{transmission_tint}
+  \vspace{12pt}
+  Weight per color channel for the transmission lobe. Set to (0,0,0) to
+  disable transmission.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness_x}
+  \vspace{12pt}
+  Surface roughness in the U direction with a perceptually linear response
+  over its range.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness_y}
+  \vspace{12pt}
+  Surface roughness in the V direction with a perceptually linear response
+  over its range.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{f0}
+  \vspace{12pt}
+  Reflectivity per color channel at facing angles.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{f90}
+  \vspace{12pt}
+  Reflectivity per color channel at grazing angles.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{exponent}
+  \vspace{12pt}
+  Variable exponent for the Schlick Fresnel curve, the default value should be
+  5.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{distribution}
+  \vspace{12pt}
+  Microfacet distribution. An implementation is expected to support the
+  following distributions: \qkw{ggx}
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{thinfilm_thickness}
+  \vspace{12pt}
+  Optional float parameter for thickness of an iridescent thin film layer on
+  top of this BSDF. Given in nanometers.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{thinfilm_ior}
+  \vspace{12pt}
+  Optional float parameter for refraction index of the thin film layer.
+  \apiend
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+
+\apiend
+
+
+
+\apiitem{\colorclosure\ {\ce translucent_bsdf} (normal N, color albedo)}
+\indexapi{translucent_bsdf()}
+
+Constructs a translucent (diffuse transmission) BSDF based on the Lambert
+reflectance model.
+
+\noindent Parameters include:
+
+  \apiitem{N}
+  \vspace{12pt}
+  Normal vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{albedo}
+  \vspace{12pt}
+  Surface albedo.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness}
+  \vspace{12pt}
+  Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
+  \apiend
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+
+\apiend
+
+
+\apiitem{\colorclosure\ {\ce transparent_bsdf} ( )}
+\indexapi{transparent_bsdf()}
+
+Constructs a closure that represents straight transmission through a surface.
+
+\apiend
+
+
+
+\apiitem{\colorclosure\ {\ce subsurface_bssrdf} ( )}
+\indexapi{subsurface_bssrdf}
+Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
+
+\noindent Parameters include:
+
+  \apiitem{N}
+  \vspace{12pt}
+  Normal vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{albedo}
+  \vspace{12pt}
+  Single-scattering albedo of the medium.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{transmission_depth}
+  \vspace{12pt}
+  Distance travelled inside the medium by white light before its color becomes
+  transmission_color by Beer's law. Given in scene length units, range
+  [0,infinity). Together with transmission_color this determines the
+  extinction coefficient of the medium.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{transmission_color}
+  \vspace{12pt}
+  Desired color resulting from white light transmitted a distance of
+  'transmission_depth' through the medium. Together with transmission_depth
+  this determines the extinction coefficient of the medium.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{anisotropy}
+  \vspace{12pt}
+  Scattering anisotropy [-1,1]. Negative values give backwards scattering,
+  positive values give forward scattering, and 0.0 gives uniform scattering.
+  \apiend
+  
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+\apiend
+
+
+\apiitem{\colorclosure\ {\ce sheen_bsdf} (normal N, color albedo, float roughness)}
+\indexapi{sheen_bsdf()}
+
+Constructs a microfacet BSDF for the back-scattering properties of cloth-like
+materials. This closure may be vertically layered over a base BSDF, where
+energy that is not reflected will be transmitted to the base closure.
+
+\noindent Parameters include:
+
+  \apiitem{N}
+  \vspace{12pt}
+  Normal vector of the surface point being shaded.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{albedo}
+  \vspace{12pt}
+  Surface albedo.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{roughness}
+  \vspace{12pt}
+  Surface roughness [0,1].
+  \apiend
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+
+\apiend
+
+
+
+\subsection{Volumetric material closures}
+
+\apiitem{\colorclosure\ {\ce anisotropic_vdf} (color albedo, color extinction, float anisotropy)}
+\indexapi{anisotropic_vdf}
+
+Constructs a VDF scattering light for a general participating medium, based on
+the Henyey-Greenstein phase function. Forward, backward and uniform scattering
+is supported and controlled by the anisotropy input.
+
+\noindent Parameters include:
+
+  \apiitem{albedo}
+  \vspace{12pt}
+  Single-scattering albedo of the medium.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{extinction}
+  \vspace{12pt}
+  Volume extinction coefficient.
+  \apiend
+  
+  \apiitem{anisotropy}
+  \vspace{12pt}
+  Scattering anisotropy [-1,1]. Negative values give backwards scattering,
+  positive values give forward scatterixng, and 0.0 gives uniform scattering.
+  \apiend
+  
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+\apiend
+
+
+\apiitem{\colorclosure\ {\ce medium_vdf} (color albedo, float transmission_depth, \\
+\spc\spc color transmission_color, float anisotropy, float ior, int priority)}
+\indexapi{medium_vdf}
+
+Constructs a VDF for light passing through a dielectric homogeneous medium,
+such as glass or liquids. The parameters {\cf transmission_depth} and
+{\cf transmission_color} control the extinction coefficient of the medium in and
+artist-friendly way. A priority can be set to determine the ordering of
+overlapping media.
+
+\noindent Parameters include:
+
+  \apiitem{albedo}
+  \vspace{12pt}
+  Single-scattering albedo of the medium.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{transmission_depth}
+  \vspace{12pt}
+  Distance travelled inside the medium by white light before its color becomes
+  transmission_color by Beer's law. Given in scene length units, range
+  [0,infinity). Together with transmission_color this determines the
+  extinction coefficient of the medium.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{transmission_color}
+  \vspace{12pt}
+  Desired color resulting from white light transmitted a distance of
+  'transmission_depth' through the medium. Together with transmission_depth
+  this determines the extinction coefficient of the medium.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{anisotropy}
+  \vspace{12pt}
+  Scattering anisotropy [-1,1]. Negative values give backwards scattering,
+  positive values give forward scattering, and 0.0 gives uniform scattering.
+  \apiend
+  
+  \apiitem{ior}
+  \vspace{12pt}
+  Refraction index of the medium.
+  \apiend
+  \vspace{-16pt}
+  
+  \apiitem{priority}
+  \vspace{12pt}
+  Priority of this medium (for nested dielectrics).
+  \apiend
+  \vspace{-16pt}
+  
+%   \vspace{-16pt}
+  
+  % \apiitem{label}
+  % \vspace{12pt}
+  % Optional string parameter to name this component. For use in AOVs / LPEs.
+  % \apiend
+\apiend
+
+
+\subsection{Light emission closures}
+
+\apiitem{\colorclosure\ {\ce uniform_edf} (color emittance)}
+\indexapi{uniform_edf}
+Constructs an EDF emitting light uniformly in all directions.
+This is used to represent a glowing/emissive material.
+When called in the context of a surface shader group, it implies that
+light is emitted in a full hemisphere centered around the surface
+normal. When called in the context of a volume shader group, it implies
+that light is emitted evenly in all directions around the point being
+shaded.
+
+The {\cf emittance} parameter is the amount of emission and
+has units of radiance (e.g.,
+$\mathrm{W}\cdot\mathrm{sr}^{-1}\cdot\mathrm{m}^{-2}$). This means that a surface
+directly seen by the camera will directly reproduce the closure weight in the
+final pixel, regardless of being a surface or a volume.
+
+For surface emission, If you divide {\cf emission} by 
+{\cf surfacearea() * M_PI}, then you can easily specify the total emissive
+power of the light (e.g., $\mathrm{W}$), regardless of its physical size.
+\apiend
+
+
+\subsection{Layering and Signaling closures}
+
+\apiitem{\colorclosure\ {\ce layer} (closure color top, closure color base)}
+\indexapi{layer()}
+Vertically layer a layerable BSDF such as {\cf dielectric_bsdf},
+{\cf generalized_schlick_bsdf} or {\cf sheen_bsdf} over a BSDF or VDF. The
+implementation is target specific, but a standard way of handling this is by
+albedo scaling, using {\cf base*(1-reflectance(top)) + top}, where
+reflectance() calculates the directional albedo of a given top BSDF.
+\apiend
+
+
+\apiitem{\colorclosure\ {\ce holdout} ( )}
+\indexapi{holdout()}
+Returns a \colorclosure that does not represent any additional light
+reflection from the surface, but does signal to the renderer that 
+the surface is a \emph{holdout object} (appears transparent in
+the final output yet hides objects behind it).  ``Partial holdouts''
+may be designated by weighting the {\cf holdout()} closure by a
+weight that is less than 1.0.
+\apiend
+
+
+\apiitem{\colorclosure\ {\ce debug} (string outputname)}
+\indexapi{debug()}
+Returns a \colorclosure that does not represent any additional light
+reflection from the surface, but does signal to the renderer to add
+the weight of the closure (which may be a {\cf float} or a \color)
+to the named output (i.e., AOV).
+\apiend
+
+
+\subsection{Material utility functions}
+
+\apiitem{void {\ce artistic_ior} (color reflectivity, color edge_tint, \\
+\spc\spc output color ior, output color extinction)}
+\indexapi{artistic_ior()}
+Converts the artistic parameterization reflectivity and edge_tint to complex IOR values.
+To be used with the conductor_bsdf() closure.
+
+\noindent Parameters include:
+
+\apiitem{reflectivity}
+\vspace{12pt}
+Reflectivity per color channel at facing angles (\emph{r} parameter in [OG14])
+\apiend
+\vspace{-16pt}
+
+\apiitem{edge_tint}
+\vspace{12pt}
+Color bias for grazing angles (\emph{g} parameter in [OG14]).
+NOTE: This is not equal to 'f90' in a Schlick Fresnel parameterization.
+\apiend
+\vspace{-16pt}
+
+\apiitem{ior}
+\vspace{12pt}
+Output refraction index.
+\apiend
+\vspace{-16pt}
+  
+\apiitem{extinction}
+\vspace{12pt}
+Output extinction coefficient.
+\apiend
+%   \vspace{-16pt}
+
+Reference: [OG14] Ole Gulbrandsen, "Artist Friendly Metallic Fresnel", Journal
+of Computer Graphics Tools 3(4), 2014.
+\url{http://jcgt.org/published/0003/04/03/paper.pdf}
+\apiend
+
+
+\subsection{Deprecated closures}
+
+These were described in the original OSL language specification, but
+beginning with OSL 1.12, these are considered deprecated. Support for
+them will be removed entirely in OSL 2.0.
+
+\subsubsection{Deprecated Surface closures}
 
 \apiitem{\colorclosure\ {\ce diffuse} (normal N)}
 \indexapi{diffuse()}
@@ -4745,33 +5425,6 @@ implemented as follows:
 \end{comment}
 \apiend
 
-
-\apiitem{\colorclosure\ {\ce microfacet} (string distribution, normal N, vector
-U, \\ \bigspc\bigspc float xalpha, float yalpha, float eta, int refract)}
-\indexapi{microfacet()}
-
-Returns a \colorclosure that represents scattering on the
-surface using some microfacet distribution such as \qkw{beckmann} or \qkw{ggx} (as
-described in Walter et al., ``Microfacet Models for Refraction through Rough
-Surfaces,'' Eurographics Symposium on Rendering, 2007).
-Both {\cf xalpha} and {\cf yalpha} control how rough the microstructure of the
-surface is, possibly in an anisotropic way if they are different. In the
-anisotropic case {\cf U} must be a vector orthogonal to {\cf N} to specify the
-direction.  These values are expected to be the alpha values of the distribution
-as it appears in the literature, not a universal roughness measure.
-The {\cf eta} parameter is the index of refraction of the material, and
-{\cf refract} is a enumeration flag that controls if the BSDF is reflective ({\cf 0}),
-refractive ({\cf 1}) or both at once ({\cf 2}). The implementation must not rely on
-{\cf U} when the roughness is isotropic or the given vector is zero.
-
-The list of supported distributions will change from renderer to renderer, and
-also the behavior when an unsupported distribution is requested. It is up to the
-implementation to issue an error or to default to a supported one. Also it is
-expected that the alias \qkw{default} must work as a distribution in any renderer.
-
-\apiend
-
-
 \apiitem{\colorclosure\ {\ce microfacet} (string distribution, normal N,
 \\ \bigspc\bigspc float alpha, float eta, int refract)}
 \indexapi{microfacet()}
@@ -4823,7 +5476,6 @@ implemented as follows:
 \end{code}
 \apiend
 
-
 \apiitem{\colorclosure\ {\ce transparent} ( )}
 \indexapi{transparent()}
 
@@ -4867,8 +5519,7 @@ scattering} exhibited by the surface.
 \apiend
 \end{comment}
 
-
-\subsection{Volumetric material closures}
+\subsubsection{Deprecated Volumetric closures}
 
 \apiitem{\colorclosure\ {\ce isotropic} ( )}
 \indexapi{isotropic}
@@ -4876,7 +5527,6 @@ Returns a \colorclosure that represents the scattering of an isotropic
 volumetric material, scattering light evenly in all directions,
 regardless of its original direction.
 \apiend
-
 
 \apiitem{\colorclosure\ {\ce henyey_greenstein} (float g)}
 \indexapi{henyey_greenstein}
@@ -4888,7 +5538,6 @@ predominantly back-scattering, and value of $g=0$ resulting in isotropic
 scattering.
 \apiend
 
-
 \apiitem{\colorclosure\ {\ce absorption} ( )}
 \indexapi{absorption}
 Returns a \colorclosure that does not represent any additional
@@ -4898,8 +5547,7 @@ volumetric material, scattering light evenly in all directions,
 regardless of its original direction.
 \apiend
 
-
-\subsection{Light emission closures}
+\subsubsection{Deprecated Emission closures}
 
 \apiitem{\colorclosure\ {\ce emission} ( )}
 \indexapi{emission}
@@ -4928,30 +5576,6 @@ Returns a \colorclosure that represents the radiance of the
 implementation is renderer-specific, but often involves looking
 up from an HDRI environment map.
 \apiend
-
-
-\subsection{Signaling closures}
-
-\apiitem{\colorclosure\ {\ce holdout} ( )}
-\indexapi{holdout()}
-Returns a \colorclosure that does not represent any additional light
-reflection from the surface, but does signal to the renderer that 
-the surface is a \emph{holdout object} (appears transparent in
-the final output yet hides objects behind it).  ``Partial holdouts''
-may be designated by weighting the {\cf holdout()} closure by a
-weight that is less than 1.0.
-\apiend
-
-
-\apiitem{\colorclosure\ {\ce debug} (string outputname)}
-\indexapi{debug()}
-Returns a \colorclosure that does not represent any additional light
-reflection from the surface, but does signal to the renderer to add
-the weight of the closure (which may be a {\cf float} or a \color)
-to the named output (i.e., AOV).
-\apiend
-
-
 
 
 \newpage
@@ -6134,6 +6758,9 @@ full control in the shader.
   may be shared among multiple geometric primitives.  Also sometimes
   called \emph{graphics state}.
 
+\item[BSDF.] Bidirectional scattering distribution function, a
+  function that describes light scattering properties of a surface.
+
 \item[Built-in function.] A function callable from within a shader, where
   the implementation of the function is provided by the renderer (as
   opposed to a function that the shader author writes in \langname
@@ -6154,6 +6781,9 @@ full control in the shader.
   within the \emph{group}.  The default value of a shader parameter
   is explicitly given in the code for that shader, and may either be
   a constant or a computed expression.
+
+\item[EDF.] Emission distribution function, a function that describes
+    the distribution of light emitted by a light source.
 
 \item[Geometric primitive.] A single shape, such as a NURBS patch, a
   polygon or subdivision mesh, a hair primitive, etc.
@@ -6238,6 +6868,9 @@ full control in the shader.
 
 \item[Shading.] The computations within a renderer that implement the
   behavior and visual appearance of materials and lights.
+
+\item[VDF.] Volumetric distribution function, a function that describes
+  the scattering properties of a volume.
 
 \end{description}
 

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -470,7 +470,7 @@ closure color debug(string tag) BUILTIN;
 closure color holdout() BUILTIN;
 closure color subsurface(float eta, float g, color mfp, color albedo) BUILTIN;
 
-#ifdef MATERIALX_CLOSURES
+#ifndef NO_MATERIALX_CLOSURES
 
 // -------------------------------------------------------------//
 // BSDF closures                                                //
@@ -672,7 +672,7 @@ closure color medium_vdf(color albedo, float transmission_depth, color transmiss
 // - This could also be achieved by closure nesting where each layerable closure takes
 //   a closure color "base" input instead.
 // - One advantage having a dedicated layer() closure is that in the future we may want to
-//   introduce parameters to describe the sandwitched medium between the layer interfaces.
+//   introduce parameters to describe the sandwiched medium between the layer interfaces.
 //   Such parameterization could then be added on this layer() closure as extra arguments.
 // - Do we want/need parameters for the medium here now, or do we look at that later?
 //
@@ -685,9 +685,11 @@ closure color layer(closure color top, closure color base) BUILTIN;
 // Utility functions                                            //
 // -------------------------------------------------------------//
 
-// Converts the artistic parameterization reflectivity and edge_tint to complex IOR values.
-// To be used with the conductor_bsdf() closure.
-// [OG14] "Artist Friendly Metallic Fresnel", http://jcgt.org/published/0003/04/03/paper.pdf
+// Converts the artistic parameterization reflectivity and edge_tint to
+// complex IOR values. To be used with the conductor_bsdf() closure.
+//
+// [OG14] Ole Gulbrandsen, "Artist Friendly Metallic Fresnel", Journal of
+// Computer Graphics Tools 3(4), 2014. http://jcgt.org/published/0003/04/03/paper.pdf
 //
 //  \param  reflectivity  Reflectivity per color channel at facing angles ('r' parameter in [OG14]).
 //  \param  edge_tint     Color bias for grazing angles ('g' parameter in [OG14]).

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -92,7 +92,7 @@ filter_re = None
 cleanup_on_success = False
 if int(os.getenv('TESTSUITE_CLEANUP_ON_SUCCESS', '0')) :
     cleanup_on_success = True;
-oslcargs = "-Wall -DMATERIALX_CLOSURES"
+oslcargs = "-Wall"
 
 image_extensions = [ ".tif", ".tx", ".exr", ".jpg", ".png", ".rla",
                      ".dpx", ".iff", ".psd" ]


### PR DESCRIPTION
* Change the languagespec to document the new MaterialX-synchronized
  closures.

* Document the old ones as "deprecated" -- still supported for 1.x but
  assumed to be on the slate for removal in OSL 2.x.

* Change stdosl.h so that the new closures, instead of being seen only
  if MATERIALX_CLOSURES is defined, to being enabled by default, but
  (for now) can be disabled if NO_MATERIALX_CLOSURES is defined.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
