### PR TITLE
Generate deterministic ptx for OptiX cache hits

### DIFF
--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -374,6 +374,7 @@ BackendLLVM::addCUDAGlobalVariable(const std::string& name, int size,
     g_var->setAlignment(alignment);
 #endif
 
+    g_var->setLinkage(llvm::GlobalValue::PrivateLinkage);
     g_var->setVisibility(llvm::GlobalValue::DefaultVisibility);
     g_var->setInitializer(constant);
     m_const_map[name] = g_var;
@@ -394,10 +395,9 @@ BackendLLVM::getOrAllocateCUDAVariable(const Symbol& sym)
     // variable names, then prepend another underscore.
     std::string sym_name = Strutil::replace(sym.name(), ".", "_", true);
 
-    std::string name = fmtformat("{}{}_{}_{}_{}_{}",
-                                 sym_name.front() == '$' ? "_" : "", sym_name,
-                                 group().name(), group().id(),
-                                 inst()->layername(), sym.layer());
+    std::string name
+        = fmtformat("{}{}_{}_{}_{}", sym_name.front() == '$' ? "_" : "",
+                    sym_name, group().name(), inst()->layername(), sym.layer());
 
     // Return the Value if it has already been allocated
     auto it = get_const_map().find(name);

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -858,8 +858,8 @@ BackendLLVM::build_llvm_init()
 {
     // Make a group init function: void group_init(ShaderGlobals*, GroupData*)
     // Note that the GroupData* is passed as a void*.
-    std::string unique_name = fmtformat("__direct_callable__group_{}_{}_init",
-                                        group().name(), group().id());
+    std::string unique_name = fmtformat("__direct_callable__group_{}_init",
+                                        group().name());
     ll.current_function(
         ll.make_function(unique_name, false,
                          ll.type_void(),  // return type
@@ -1620,8 +1620,7 @@ BackendLLVM::run()
     }
 
     if (use_optix()) {
-        std::string name = fmtformat("{}_{}", group().name(), group().id());
-        ll.ptx_compile_group(nullptr, name,
+        ll.ptx_compile_group(nullptr, group().name().c_str(),
                              group().m_llvm_ptx_compiled_version);
         if (group().m_llvm_ptx_compiled_version.empty()) {
             OSL_ASSERT(0 && "Unable to generate PTX");

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1620,7 +1620,7 @@ BackendLLVM::run()
     }
 
     if (use_optix()) {
-        ll.ptx_compile_group(nullptr, group().name().c_str(),
+        ll.ptx_compile_group(nullptr, group().name().string(),
                              group().m_llvm_ptx_compiled_version);
         if (group().m_llvm_ptx_compiled_version.empty()) {
             OSL_ASSERT(0 && "Unable to generate PTX");

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -2564,7 +2564,8 @@ public:
     std::string layer_function_name(const ShaderGroup& group,
                                     const ShaderInstance& inst)
     {
-        return fmtformat("{}_{}_{}", group.name(), inst.layername(), inst.id());
+        return fmtformat("{}_{}", group.name(), inst.layername());
+
     }
     std::string layer_function_name()
     {

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -2565,7 +2565,6 @@ public:
                                     const ShaderInstance& inst)
     {
         return fmtformat("{}_{}", group.name(), inst.layername());
-
     }
     std::string layer_function_name()
     {

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1974,18 +1974,16 @@ ShadingSystemImpl::getattribute(ShaderGroup* group, string_view name,
         return true;
     }
     if (name == "group_init_name" && type.basetype == TypeDesc::STRING) {
-        *(ustring*)val
-            = ustring::fmtformat("__direct_callable__group_{}_{}_init",
-                                 group->name(), group->id());
+        *(ustring*)val = ustring::fmtformat("__direct_callable__group_{}_init",
+                                            group->name());
         return true;
     }
     if (name == "group_entry_name" && type.basetype == TypeDesc::STRING) {
         int nlayers          = group->nlayers();
         ShaderInstance* inst = (*group)[nlayers - 1];
         // This formulation mirrors OSOProcessorBase::layer_function_name()
-        *(ustring*)val = ustring::fmtformat("__direct_callable__{}_{}_{}",
-                                            group->name(), inst->layername(),
-                                            inst->id());
+        *(ustring*)val = ustring::fmtformat("__direct_callable__{}_{}",
+                                            group->name(), inst->layername());
         return true;
     }
     if (name == "layer_osofiles" && type.basetype == TypeDesc::STRING) {


### PR DESCRIPTION
## Description

In multithreaded environments, use of global counter ids inside function and variable identifiers in generated ptx code leads to cache misses during OptiX module compilation.

With this change we assume unique shadergroup names, and remove the non-deterministic ids. In my testing, everything is still OptiX-compatible even with duplicate shadergroup names, but I'm not sure I've considered all the valid cases.

## Tests

Existing tests pass; I can add tests that run shaders twice and grep the logs for cache misses if desired.
<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

