### PR TITLE
Sonar static analysis improvements

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -61,11 +61,12 @@ jobs:
       CXX: ${{matrix.cxx_compiler}}
       CC: ${{matrix.cc_compiler}}
       CMAKE_CXX_STANDARD: ${{matrix.cxx_std}}
-      USE_SIMD: ${{matrix.simd}}
       FMT_VERSION: ${{matrix.fmt_ver}}
       OPENEXR_VERSION: ${{matrix.openexr_ver}}
       PYBIND11_VERSION: ${{matrix.pybind11_ver}}
       PYTHON_VERSION: ${{matrix.python_ver}}
+      USE_BATCHED: ${{matrix.batched}}
+      USE_SIMD: ${{matrix.simd}}
       # DEBUG_CI: 1
     steps:
       # We would like to use harden-runner, but it flags too many false

--- a/src/build-scripts/ci-coverage.bash
+++ b/src/build-scripts/ci-coverage.bash
@@ -12,6 +12,15 @@ pushd _coverage
 
 ls -R ../build/src/
 
+# Remove files or directories we want to exclude from code coverage analysis,
+# generally because we don't expect to execute any of their code during our
+# CI. (Because it's only used interactively, or is fallback code only used
+# when certain dependencies are not found.) Including these when we know we
+# won't be calling them during coverage gathering will just make our coverage
+# percentage look artifically low.
+rm -f ../build/src/osltoy/CMakeFiles/osltoy.dir/*.cpp.{gcno,gcda}
+
+
 # The sed command below converts from:
 #   ../build/src/liboslexec/CMakeFiles/oslexec.dir/foo.gcno
 # to:

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -959,6 +959,7 @@ LLVMGEN(llvm_gen_select)
                 && Result.typespec().is_float_based());
     int num_components = type.aggregate;
     int x_components   = X.typespec().aggregate();
+    OSL_DASSERT(x_components <= 3);
     bool derivs = (Result.has_derivs() && (A.has_derivs() || B.has_derivs()));
 
     llvm::Value* zero = X.typespec().is_int() ? rop.ll.constant(0)


### PR DESCRIPTION
* Exclude osltoy from coverage analysis, since we don't have a way to
  run it from CI
* Run batch shading for analysis to get better code coverage
* llvm_gen_select: extra check that we can't overrun memory of cond[]

Signed-off-by: Larry Gritz <lg@larrygritz.com>
