### PR TITLE
Deal with deprecated bit_cast function in OIIO 2.5

### DIFF
--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -141,6 +141,19 @@ inline OSL_HOSTDEVICE float bits_to_01 (unsigned int bits) {
 }
 
 
+OSL_FORCEINLINE OSL_HOSTDEVICE int
+bitcast_to_uint (float x)
+{
+#if OPENIMAGEIO_VERSION >= 20500
+    return OIIO::bitcast<unsigned int, float>(x);
+#else
+    // obsolete call
+    return OIIO::bit_cast<float, unsigned int>(x);
+#endif
+}
+
+
+
 #ifndef __CUDA_ARCH__
 // Perform a bjmix (see OpenImageIO/hash.h) on 4 sets of values at once.
 OSL_FORCEINLINE void
@@ -467,7 +480,7 @@ struct HashNoise: public IntHashNoiseBase<HashNoise>  {
     static OSL_FORCEINLINE OSL_HOSTDEVICE unsigned int
     transformToUint(float val)
     {
-        return OIIO::bit_cast<float,unsigned int>(val);
+        return bitcast_to_uint(val);
     }
 };
 
@@ -544,7 +557,6 @@ using PeriodicHashNoise = PeriodicAdaptionOf<HashNoise>;
 
 
 
-
 inline OSL_HOSTDEVICE int
 inthashi (int x)
 {
@@ -557,7 +569,7 @@ inline OSL_HOSTDEVICE int
 inthashf (float x)
 {
     return static_cast<int>(
-		inthash(OIIO::bit_cast<float,unsigned int>(x))
+		inthash(bitcast_to_uint(x))
 	);
 }
 
@@ -566,8 +578,8 @@ inthashf (float x, float y)
 {
     return static_cast<int>(
 		inthash(
-			OIIO::bit_cast<float,unsigned int>(x),
-			OIIO::bit_cast<float,unsigned int>(y)
+			bitcast_to_uint(x),
+			bitcast_to_uint(y)
 		)
 	);
 }
@@ -578,9 +590,9 @@ inthashf (const float *x)
 {
     return static_cast<int>(
 		inthash(
-			OIIO::bit_cast<float,unsigned int>(x[0]),
-			OIIO::bit_cast<float,unsigned int>(x[1]),
-			OIIO::bit_cast<float,unsigned int>(x[2])
+			bitcast_to_uint(x[0]),
+			bitcast_to_uint(x[1]),
+			bitcast_to_uint(x[2])
 		)
 	);
 }
@@ -591,10 +603,10 @@ inthashf (const float *x, float y)
 {
     return static_cast<int>(
 		inthash(
-			OIIO::bit_cast<float,unsigned int>(x[0]),
-			OIIO::bit_cast<float,unsigned int>(x[1]),
-			OIIO::bit_cast<float,unsigned int>(x[2]),
-			OIIO::bit_cast<float,unsigned int>(y)
+			bitcast_to_uint(x[0]),
+			bitcast_to_uint(x[1]),
+			bitcast_to_uint(x[2]),
+			bitcast_to_uint(y)
 		)
 	);
 }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -232,15 +232,18 @@ struct AttributeNeeded {
 
 
 // Handy re-casting macros
-#define USTR(cstr)  (*((ustring*)&cstr))
-#define MAT(m)      (*(Matrix44*)m)
-#define VEC(v)      (*(Vec3*)v)
-#define DFLOAT(x)   (*(Dual2<Float>*)x)
-#define DVEC(x)     (*(Dual2<Vec3>*)x)
-#define COL(x)      (*(Color3*)x)
-#define DCOL(x)     (*(Dual2<Color3>*)x)
-#define TYPEDESC(x) OIIO::bit_cast<long long, TypeDesc>(x)
-
+#define USTR(cstr) (*((ustring*)&cstr))
+#define MAT(m)     (*(Matrix44*)m)
+#define VEC(v)     (*(Vec3*)v)
+#define DFLOAT(x)  (*(Dual2<Float>*)x)
+#define DVEC(x)    (*(Dual2<Vec3>*)x)
+#define COL(x)     (*(Color3*)x)
+#define DCOL(x)    (*(Dual2<Color3>*)x)
+#if OPENIMAGEIO_VERSION >= 20500
+#    define TYPEDESC(x) OIIO::bitcast<TypeDesc, long long>(x)
+#else
+#    define TYPEDESC(x) OIIO::bit_cast<long long, TypeDesc>(x)
+#endif
 
 
 /// Like an int (of type T), but also internally keeps track of the

--- a/src/liboslexec/wide/wide_ophash.cpp
+++ b/src/liboslexec/wide/wide_ophash.cpp
@@ -25,15 +25,26 @@ OSL_USING_DATA_WIDTH(__OSL_WIDTH)
 
 namespace {
 
+OSL_FORCEINLINE OSL_HOSTDEVICE int
+bitcast_to_uint(float x)
+{
+#if OPENIMAGEIO_VERSION >= 20500
+    return OIIO::bitcast<unsigned int, float>(x);
+#else
+    // obsolete call
+    return OIIO::bit_cast<float, unsigned int>(x);
+#endif
+}
+
+
 // TODO: to avoid ansi aliasing issues,
 // suggest replacing inthashf (const float *x) with inthashv
 inline OSL_HOSTDEVICE int
 inthashv(const Vec3& v)
 {
-    return static_cast<int>(
-        pvt::inthash(OIIO::bit_cast<float, unsigned int>(v.x),
-                     OIIO::bit_cast<float, unsigned int>(v.y),
-                     OIIO::bit_cast<float, unsigned int>(v.z)));
+    return static_cast<int>(pvt::inthash(bitcast_to_uint(v.x),
+                                         bitcast_to_uint(v.y),
+                                         bitcast_to_uint(v.z)));
 }
 
 
@@ -43,10 +54,8 @@ inline OSL_HOSTDEVICE int
 inthashvf(const Vec3& v, float y)
 {
     return static_cast<int>(
-        pvt::inthash(OIIO::bit_cast<float, unsigned int>(v.x),
-                     OIIO::bit_cast<float, unsigned int>(v.y),
-                     OIIO::bit_cast<float, unsigned int>(v.z),
-                     OIIO::bit_cast<float, unsigned int>(y)));
+        pvt::inthash(bitcast_to_uint(v.x), bitcast_to_uint(v.y),
+                     bitcast_to_uint(v.z), bitcast_to_uint(y)));
 }
 
 


### PR DESCRIPTION
Today's branching of OIIO 2.4 and subsequent changing of its master
branch to think it's "2.5" seems to have triggered an automatic fuse
that annotates a particular function in OIIO as deprecated for version
2.5 and beyond. OSL was still calling the old version, so some
immediate changes are necessary to call the correct new name when
using a new OIIO.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
