### PR TITLE
Build/test: parameterize the timeout for expensive tests

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -50,9 +50,11 @@ jobs:
                             CMAKE_BUILD_TYPE=Debug
                             CMAKE_UNITY_BUILD=OFF
                             CODECOV=1
-                            CTEST_TEST_TIMEOUT=1200
                             TESTRENDER_AA=1
                             OSL_TESTSUITE_SKIP_DIFF=1
+                            CTEST_TEST_TIMEOUT=1200
+                            OSL_CMAKE_FLAGS="-DOSL_TEST_BIG_TIMEOUT=1200"
+                            CTEST_EXCLUSIONS="broken|noise-reg.regress|noise-gabor-reg.regress"
 
     runs-on: ${{ matrix.os }}
     container:

--- a/src/build-scripts/ci-test.bash
+++ b/src/build-scripts/ci-test.bash
@@ -8,17 +8,24 @@
 # any command in it fails. This is crucial for CI tests.
 set -ex
 
+: ${CTEST_EXCLUSIONS:="broken"}
+: ${CTEST_TEST_TIMEOUT:=60}
+
 $OSL_ROOT/bin/testshade --help
 
-echo "Parallel test " ${CTEST_PARALLEL_LEVEL}
+echo "Parallel test ${CTEST_PARALLEL_LEVEL}"
+echo "Default timeout ${CTEST_TEST_TIMEOUT}"
+echo "Test exclusions '${CTEST_EXCLUSIONS}'"
+echo "CTEST_ARGS '${CTEST_ARGS}'"
+
 pushd build
 
-ctest -C ${CMAKE_BUILD_TYPE} -E broken --force-new-ctest-process \
-    --output-on-failure --timeout ${CTEST_TEST_TIMEOUT:=60} ${CTEST_ARGS} \
+ctest -C ${CMAKE_BUILD_TYPE} --force-new-ctest-process --output-on-failure \
+    --timeout ${CTEST_TEST_TIMEOUT} -E "${CTEST_EXCLUSIONS}" ${CTEST_ARGS} \
   || \
-ctest -C ${CMAKE_BUILD_TYPE} -E broken --force-new-ctest-process \
-    --rerun-failed --repeat until-pass:5 -R render \
-    --output-on-failure --timeout ${CTEST_TEST_TIMEOUT:=60} ${CTEST_ARGS}
+ctest -C ${CMAKE_BUILD_TYPE} --force-new-ctest-process \
+    --rerun-failed --repeat until-pass:5 -R render --output-on-failure \
+    --timeout ${CTEST_TEST_TIMEOUT} -E "${CTEST_EXCLUSIONS}" ${CTEST_ARGS}
 # The weird construct above allows the render-* tests to run multiple times
 
 popd

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -16,6 +16,10 @@ add_custom_command (OUTPUT "${CMAKE_BINARY_DIR}/testsuite/runtest.py"
                     MAIN_DEPENDENCY "${CMAKE_SOURCE_DIR}/testsuite/runtest.py")
 add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest.py" )
 
+
+set (OSL_TEST_BIG_TIMEOUT 800 CACHE STRING "Timeout for tests that take a long time")
+
+
 # add_one_testsuite() - set up one testsuite entry
 #
 # Usage:
@@ -26,6 +30,7 @@ add_custom_target ( CopyFiles ALL DEPENDS "${CMAKE_BINARY_DIR}/testsuite/runtest
 #                  [COMMAND cmd...] - optional override of launch command
 #                 )
 #
+
 macro (add_one_testsuite testname testsrcdir)
     cmake_parse_arguments (_tst "" "" "ENV;COMMAND" ${ARGN})
     set (testsuite "${CMAKE_SOURCE_DIR}/testsuite")
@@ -53,7 +58,7 @@ macro (add_one_testsuite testname testsrcdir)
     # from piling up together, allocate a few cores each.
     if (${testname} MATCHES "^render-")
         set_tests_properties (${testname} PROPERTIES LABELS render
-                              PROCESSORS 4 COST 10 TIMEOUT 240)
+                              PROCESSORS 4 COST 10 TIMEOUT ${OSL_TEST_BIG_TIMEOUT})
     endif ()
     # Some labeling for fun
     if (${testname} MATCHES "^texture")
@@ -75,7 +80,7 @@ macro (add_one_testsuite testname testsrcdir)
         # These are batched shading regression tests. Some are quite
         # long, so give them a higher cost and timeout.
         set_tests_properties (${testname} PROPERTIES LABELS batchregression
-                              COST 15 TIMEOUT 300)
+                              COST 15 TIMEOUT ${OSL_TEST_BIG_TIMEOUT})
     endif ()
 endmacro ()
 
@@ -124,7 +129,7 @@ macro ( TESTSUITE )
                                ENV TESTSHADE_OPT=2 )
         endif ()
         if (_testname MATCHES "render-" AND ${CMAKE_BUILD_TYPE} STREQUAL Debug)
-            set_tests_properties (${_testname} PROPERTIES TIMEOUT 600)
+            set_tests_properties (${_testname} PROPERTIES TIMEOUT ${OSL_TEST_BIG_TIMEOUT})
         endif ()
         # When building for OptiX support, also run it in OptiX mode
         # if there is an OPTIX marker file in the directory.
@@ -376,8 +381,11 @@ macro (osl_add_all_tests)
 
     # Some regression tests have a lot of combinations and may need more time to finish
     if (BUILD_BATCHED)
-        set_tests_properties (arithmetic-reg.regress.batched.opt PROPERTIES TIMEOUT 800)
-        set_tests_properties (transform-reg.regress.batched.opt PROPERTIES TIMEOUT 800)
+        set_tests_properties (arithmetic-reg.regress.batched.opt
+                              PROPERTIES TIMEOUT ${OSL_TEST_BIG_TIMEOUT})
+        set_tests_properties (transform-reg.regress.batched.opt
+                              PROPERTIES TIMEOUT ${OSL_TEST_BIG_TIMEOUT})
     endif ()
-    set_tests_properties (matrix-reg.regress.rsbitcode.opt PROPERTIES TIMEOUT 800)
+    set_tests_properties (matrix-reg.regress.rsbitcode.opt
+                          PROPERTIES TIMEOUT ${OSL_TEST_BIG_TIMEOUT})
 endmacro()


### PR DESCRIPTION
We had hard-coded longer allowable timeouts for particular testsuite
tests. But for the static analysis runs, it takes extra long and we
need a way to tell it to increase the timeouts even more, and to
exclude the longest running tests from the analysis coverage run (it's
not necessary to run those tests, they don't increase coverage enough
to justify being an hours long run).

Signed-off-by: Larry Gritz <lg@larrygritz.com>
