### PR TITLE
Batched analysis: ReadEvent remove uninitialized members

### DIFF
--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -1053,8 +1053,10 @@ typedef std::vector<WriteEvent> WriteChronology;
 
 class ReadEvent {
     DependencyTreeTracker::Position m_pos_in_tree;
+#ifdef OSL_DEV
     int m_op_num;
     int m_loop_op_index;
+#endif
 
 public:
     ReadEvent(DependencyTreeTracker::Position pos_in_tree_


### PR DESCRIPTION
The little ReadEvent class had two members that are never set when
OSL_DEV is not defined, nor are they accessible (the accessor
functions also are disabled based on OSL_DEV). It looked to the static
analyzer like the data members were uninitialized, which they were. Add
OSL_DEV guards around the declarations of those members as well, so
they aren't even present in the struct when not needed for this
debugging mode.

Food for thought: another alternative is to keep the members but just
remove the OSL_DEV guards entirely -- just let the two int data
members be used all the time, not just for OSL_DEV. It's too small to
have any perf penalty, and it unclutters the declaration by removing
all those `#ifdef` lines.

For that matter, I also wonder if there's any real point to having
private members and accessor functions for this tiny internal-only
class, and maybe it's better to just let it be compact declaration
of a simple `struct` with three directly accessible data members?

Signed-off-by: Larry Gritz <lg@larrygritz.com>
