### PR TITLE
Bug fix: assigning init-op param its default value as instance got lost

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -246,7 +246,9 @@ macro (osl_add_all_tests)
                 globals-needed
                 group-outputs groupstring
                 hash hashnoise hex hyperb
-                ieee_fp ieee_fp-reg if if-reg incdec initlist initops intbits isconnected
+                ieee_fp ieee_fp-reg if if-reg incdec initlist
+                initops initops-instance-clash
+                intbits isconnected
                 isconstant
                 layers layers-Ciassign layers-entry layers-lazy layers-lazyerror
                 layers-nonlazycopy layers-repeatedoutputs

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -330,12 +330,19 @@ ShaderInstance::parameters(const ParamValueList& params)
                 // definite length in subsequent rerenders. Don't do that.
             } else {
                 // If the instance value is the same as the master's default,
-                // just skip the parameter, let it "keep" the default.
-                // Note that this can't/shouldn't happen for the indefinite-
-                // sized array case, which is why we have it in the 'else'
-                // clause of that test.
+                // just skip the parameter, let it "keep" the default by
+                // marking the source as DefaultVal.
+                //
+                // N.B. Beware the situation where it has init ops, and so the
+                // "default value" slot only coincidentally has the same value
+                // as the instance value.  We can't mark it as DefaultVal in
+                // that case, because the init ops need to be run.
+                //
+                // Note that this case also can't/shouldn't happen for the
+                // indefinite- sized array case, which is why we have it in
+                // the 'else' clause of that test.
                 void* defaultdata = m_master->param_default_storage(i);
-                if (lockgeom
+                if (lockgeom && !sm->has_init_ops()
                     && memcmp(defaultdata, data, valuetype.size()) == 0) {
                     // Must reset valuesource to default, in case the parameter
                     // was set already, and now is being changed back to default.

--- a/testsuite/initops-instance-clash/ref/out.txt
+++ b/testsuite/initops-instance-clash/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+A = 0.5, B = 1
+

--- a/testsuite/initops-instance-clash/run.py
+++ b/testsuite/initops-instance-clash/run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command = testshade("-param B 1.0 test")

--- a/testsuite/initops-instance-clash/test.osl
+++ b/testsuite/initops-instance-clash/test.osl
@@ -1,0 +1,17 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
+
+// This is a regression test for a weird case where we have a parameter (B)
+// that by default is initialized to the value of A (i.e. it has init ops),
+// but if it is given instance value 0.0, the bug was that it would revert to
+// thinking its true value was 0.0 and forget about the init ops entirely.
+
+
+shader test (float A = 0.5,
+             float B = A)
+{
+    printf("A = %g, B = %g\n", A, B);
+}


### PR DESCRIPTION
This is a tricky situation to describe. Consider this shader:

    shader test (float A = 0.5,
                 float B = A)
    {
        printf("A = %g, B = %g\n", A, B);
    }

By default, A is 0.5 and B gets A's value, also 0.5. If you give A a different instance value, like 1.0, then B will also get the same value, they'll both be 1.0.  If you give B an instance value, that will be used for B rather than copying A's value, like this:

    $ testshade  -param B 1.0 -shader test test
    A = 0.5, B = 1

But there is a corner case bug: if we assign B an instance value of 0.0, it will incorrectly fall into a special case where it thinks it gets a default value, only coincidentally because 0.0 is in an unused slot for the default value (unused because it has no default -- its default comes from "init ops", that assignment).

    $ testshade  -param B 0.0 -shader test test
    A = 0.5, B = 0.5

!!!

Reading the patch should be self-explanatory for what the bug is and how we fix it.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
