### PR TITLE
add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ build
 *.pyc
 *.log
 .vscode
+.envrc
 


### PR DESCRIPTION
## Description

direnv (https://github.com/direnv/direnv) can be used for local developer workflow enhancements.  direnv uses .envrc file for configuration.  Because .envrc is usually specific to a developer workflow, it is generally not committed.

## Tests

None

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

*just emailed my signed CLA today*

Signed-off-by: Mark Sisson <5761292+marksisson@users.noreply.github.com>
