### PR TITLE
Make `testshade --help` print texturesystem options and hardware info

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -604,6 +604,7 @@ print_info()
     TextureSystem* texturesys = TextureSystem::create();
     shadingsys = new ShadingSystem(rend, texturesys, &errhandler);
     rend->init_shadingsys(shadingsys);
+    set_shadingsys_options();
 
     std::cout << "\n" << shadingsys->getstats(5) << "\n";
 
@@ -630,6 +631,8 @@ getargs(int argc, const char* argv[])
     ap.arg("filename")
       .hidden()
       .action([&](cspan<const char*> argv){ stash_shader_arg(argv); });
+    ap.arg("--help")
+      .help("Print help message");
     ap.arg("-v", &verbose)
       .help("Verbose messages");
     ap.arg("-t %d:NTHREADS", &num_threads)


### PR DESCRIPTION
This was meant to work all along, which is why this patch is so small!

But a tiny detail -- not explicitly passing info about the `--help` argument -- made ArgParse substitute its own default, which exits after printing the usage info. But, as I apparently meant to do all along, if you specify it explicitly, you get to handle it, and the way we handled it also printed the extra information.

Anyway, with this patch, `testshade --help` not only prints all the testshade command options, but also it prints some information at the end about some of the build settings of OSL, versions of key dependencies, hardware info, and a run-down of the ShadingSystem options. This can be helpful for debugging.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
