### PR TITLE
Raise OIIO minimum to 2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             vfxyear: 2019
             vfxsuffix: -clang9
             cxx_std: 14
-            openimageio_ver: v2.2.17.0
+            openimageio_ver: v2.3.17.0
             python_ver: 2.7
             pybind11_ver: v2.4.2
           - desc: clang9/C++14 llvm9 oiio-release boost1.66 avx2 exr2.3 py2.7
@@ -72,7 +72,7 @@ jobs:
             os: ubuntu-latest
             vfxyear: 2020
             cxx_std: 14
-            openimageio_ver: v2.2.17.0
+            openimageio_ver: v2.3.17.0
             python_ver: 3.7
             pybind11_ver: v2.5.0
             simd: sse4.2
@@ -83,7 +83,7 @@ jobs:
             vfxyear: 2021
             vfxsuffix: -clang11
             cxx_std: 17
-            openimageio_ver: dev-2.2
+            openimageio_ver: dev-2.3
             python_ver: 3.7
             pybind11_ver: v2.7.0
             simd: avx2,f16c
@@ -149,7 +149,7 @@ jobs:
             vfxyear: 2019
             vfxsuffix: -clang9
             cxx_std: 14
-            openimageio_ver: v2.2.17.0
+            openimageio_ver: v2.3.17.0
             python_ver: 2.7
             pybind11_ver: v2.6.2
             simd: 0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
    - Intel C++ compiler icc **version 17 or newer** or LLVM-based icx compiler
      **version 2022 or newer**.
 
-* **[OpenImageIO](http://openimageio.org) 2.2 or newer** (tested through 2.4)
+* **[OpenImageIO](http://openimageio.org) 2.3 or newer** (tested through 2.4)
 
     OSL uses OIIO both for its texture mapping functionality as well as
     numerous utility classes.  If you are integrating OSL into an existing

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -105,7 +105,7 @@ endif ()
 
 # OpenImageIO
 checked_find_package (OpenImageIO REQUIRED
-                      VERSION_MIN 2.2.6
+                      VERSION_MIN 2.3.17
                       DEFINITIONS -DOIIO_HIDE_FORMAT=1)
 
 checked_find_package (pugixml REQUIRED

--- a/src/liboslexec/batched_rendservices.cpp
+++ b/src/liboslexec/batched_rendservices.cpp
@@ -117,7 +117,6 @@ BatchedRendererServices<WidthT>::resolve_udim_uniform(
     if (!texture_handle)
         texture_handle = texturesys()->get_texture_handle(filename,
                                                           texture_thread_info);
-#if OPENIMAGEIO_VERSION >= 20307
     if (texturesys()->is_udim(texture_handle)) {
         // Newer versions of the TextureSystem interface are able to determine the
         // specific UDIM tile we're using.
@@ -131,9 +130,9 @@ BatchedRendererServices<WidthT>::resolve_udim_uniform(
             udim_handle = texture_handle;
         }
         return udim_handle;
-    } else
-#endif
+    } else {
         return texture_handle;
+    }
 }
 
 
@@ -151,7 +150,6 @@ BatchedRendererServices<WidthT>::resolve_udim(
     if (!texture_handle)
         texture_handle = texturesys()->get_texture_handle(filename,
                                                           texture_thread_info);
-#if OPENIMAGEIO_VERSION >= 20307
     if (texturesys()->is_udim(texture_handle)) {
         // Newer versions of the TextureSystem interface are able to determine the
         // specific UDIM tile we're using.
@@ -167,9 +165,9 @@ BatchedRendererServices<WidthT>::resolve_udim(
             }
             wresult[l] = udim_handle;
         });
-    } else
-#endif
+    } else {
         assign_all(wresult, texture_handle);
+    }
 }
 
 

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -114,12 +114,9 @@ RendererServices::good(TextureHandle* texture_handle)
 bool
 RendererServices::is_udim(TextureHandle* texture_handle)
 {
-#if OPENIMAGEIO_VERSION >= 20307
     return texturesys()->is_udim(texture_handle);
-#else
-    return false;
-#endif
 }
+
 
 
 bool


### PR DESCRIPTION
Traditionally, OSL has supported building against the current and also the previous supported version of OIIO, but not necessarily any older.

With OIIO 2.4 released (any day now), and OSL "main" is actually going to be next year's supported release, it seems reasonable to change the forward-looking development of OSL to have a minimum of OIIO 2.3, which means that OSL-next will support OIIO 2.3, 2.4, and the currently-in-progress 2.5 (or whatever it's called by that point).

The main reason to do this bump is because we'd like to depend on the ustringhash class, and possibly other things we will probably be able to easily backport to 2.3 but not to 2.2.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
