### PR TITLE
CI: Improvements to the coverage analysis

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -53,7 +53,7 @@ jobs:
                             TESTRENDER_AA=1
                             OSL_TESTSUITE_SKIP_DIFF=1
                             CTEST_TEST_TIMEOUT=1200
-                            OSL_CMAKE_FLAGS="-DOSL_TEST_BIG_TIMEOUT=1200"
+                            OSL_CMAKE_FLAGS="-DOSL_TEST_BIG_TIMEOUT=1200 -DUSE_QT=0"
                             CTEST_EXCLUSIONS="broken|noise-reg.regress|noise-gabor-reg.regress"
 
     runs-on: ${{ matrix.os }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,6 +18,7 @@ sonar.links.issue=https://github.com/AcademySoftwareFoundation/OpenShadingLangua
 # Source properties
 sonar.sources=src
 sonar.sourceEncoding=UTF-8
+sonar.exclusions=src/include/OSL/Imath/*.h
 
 # C/C++ analyzer properties
 sonar.cfamily.build-wrapper-output=build/bw_output


### PR DESCRIPTION
* For analysis, USE_QT=0 will disable osltoy from building (since we don't/can't test it in the testsuite, it's unexecuted but really shouldn't count against our code coverage metric).

* Exclude Imath duplicate headers from Sonar analysis.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
