### PR TITLE
Hashing cleanup for ustrings

### DIFF
--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -235,7 +235,7 @@ template<> struct hash<OSL::ustring> {
 };
 
 template<> struct hash<OSL::ustringhash> {
-    std::size_t operator()(OSL::ustringhash u) const noexcept
+    constexpr std::size_t operator()(OSL::ustringhash u) const noexcept
     {
         return u.hash();
     }

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -102,7 +102,7 @@ using OIIO::TextureOpt;
 // And some other things we borrow from OIIO...
 using OIIO::ErrorHandler;
 using OIIO::ustring;
-using OIIO::ustringHash;
+using OIIO::ustringhash;
 using OIIO::string_view;
 using OIIO::span;
 using OIIO::cspan;
@@ -225,3 +225,29 @@ using ConstIndex = std::integral_constant<int, N>;
 
 
 OSL_NAMESPACE_EXIT
+
+
+namespace std {  // not necessary in C++17, then we can just say std::hash
+#ifndef OIIO_USTRING_HAS_STDHASH
+// Not a new enough OIIO to define std::hash<ustring>, so we'll do it
+template<> struct hash<OSL::ustring> {
+    std::size_t operator()(OSL::ustring u) const noexcept { return u.hash(); }
+};
+
+template<> struct hash<OSL::ustringhash> {
+    std::size_t operator()(OSL::ustringhash u) const noexcept
+    {
+        return u.hash();
+    }
+};
+#endif
+
+// Not necessary once minimum OIIO defines operator< for ustringhash
+template<> struct less<OSL::ustringhash> {
+    constexpr bool operator()(OSL::ustringhash u,
+                              OSL::ustringhash v) const noexcept
+    {
+        return u.hash() < v.hash();
+    }
+};
+}  // namespace std

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -235,7 +235,8 @@ template<> struct hash<OSL::ustring> {
 };
 
 template<> struct hash<OSL::ustringhash> {
-    constexpr std::size_t operator()(OSL::ustringhash u) const noexcept
+    OSL_HOSTDEVICE constexpr std::size_t
+    operator()(OSL::ustringhash u) const noexcept
     {
         return u.hash();
     }
@@ -244,8 +245,8 @@ template<> struct hash<OSL::ustringhash> {
 
 // Not necessary once minimum OIIO defines operator< for ustringhash
 template<> struct less<OSL::ustringhash> {
-    constexpr bool operator()(OSL::ustringhash u,
-                              OSL::ustringhash v) const noexcept
+    OSL_HOSTDEVICE constexpr bool operator()(OSL::ustringhash u,
+                                             OSL::ustringhash v) const noexcept
     {
         return u.hash() < v.hash();
     }

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -490,7 +490,7 @@ private:
     int m_main_method_start;     ///< Instruction where 'main' starts
     bool m_declaring_shader_formals;  ///< Are we declaring shader formals?
     std::set<std::pair<ustring, int>> m_nowarn_lines;  ///< Lines for 'nowarn'
-    typedef std::unordered_map<ustring, std::string, ustringHash> FCMap;
+    typedef std::unordered_map<ustring, std::string> FCMap;
     FCMap m_filecontents_map;   ///< Contents of source files we've seen
     ustring m_last_sourcefile;  ///< Last filename for retrieve_source
     std::string* m_last_filecontents = nullptr;  //< Last file contents

--- a/src/liboslcomp/symtab.h
+++ b/src/liboslcomp/symtab.h
@@ -186,7 +186,7 @@ private:
 ///
 class SymbolTable {
 public:
-    typedef std::unordered_map<ustring, Symbol*, ustringHash> ScopeTable;
+    typedef std::unordered_map<ustring, Symbol*> ScopeTable;
     typedef std::vector<ScopeTable> ScopeTableStack;
     typedef SymbolPtrVec::iterator iterator;
     typedef SymbolPtrVec::const_iterator const_iterator;

--- a/src/liboslexec/automata.h
+++ b/src/liboslexec/automata.h
@@ -23,12 +23,12 @@ OSL_NAMESPACE_ENTER
 typedef std::set<int>
     IntSet;  // probably faster to test for equality, unions and so
 
-typedef std::unordered_set<ustring, ustringHash> SymbolSet;
+typedef std::unordered_set<ustring> SymbolSet;
 // This is for the transition table used in DfAutomata::State
-typedef std::unordered_map<ustring, int, ustringHash> SymbolToInt;
+typedef std::unordered_map<ustring, int> SymbolToInt;
 // And this is for the transition table in NdfAutomata which
 // has several movements for each symbol
-typedef std::unordered_map<ustring, IntSet, ustringHash> SymbolToIntList;
+typedef std::unordered_map<ustring, IntSet> SymbolToIntList;
 typedef std::unordered_map<int, int> HashIntInt;
 
 // For the rules in the deterministic states, we don't need a real set

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -240,7 +240,7 @@ private:
     static constexpr OpcodeTest no_test = nullptr;
 
     // Map opcode names to a Dependency info
-    std::unordered_map<ustring, Dependency, ustringHash> m_lookup;
+    std::unordered_map<ustring, Dependency> m_lookup;
 
     /// Return the ptr to the symbol that is the argnum-th argument to the
     /// given op in the instance.

--- a/src/liboslexec/dictionary.cpp
+++ b/src/liboslexec/dictionary.cpp
@@ -115,7 +115,7 @@ private:
     };
 
     typedef std::unordered_map<Query, QueryResult, QueryHash> QueryMap;
-    typedef std::unordered_map<ustring, int, ustringHash> DocMap;
+    typedef std::unordered_map<ustring, int> DocMap;
 
     ShadingContext* m_context;  // back-pointer to shading context
 

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -72,7 +72,7 @@ private:
     int m_oso_major, m_oso_minor;     ///< oso file format version
     int m_sym_default_index;          ///< Next sym default value to fill in
     bool m_errors;                    ///< Did we hit any errors?
-    typedef std::unordered_map<ustring, int, ustringHash> UstringIntMap;
+    typedef std::unordered_map<ustring, int> UstringIntMap;
     UstringIntMap m_symmap;  ///< map sym name to index
 };
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -60,7 +60,6 @@ using OIIO::ParamValueList;
 using OIIO::RefCnt;
 using OIIO::spin_lock;
 using OIIO::spin_mutex;
-using OIIO::ustringHash;
 namespace Strutil = OIIO::Strutil;
 
 
@@ -702,8 +701,7 @@ public:
     void optimize_all_groups(int nthreads = 0, int mythread = 0,
                              int totalthreads = 1, bool do_jit = true);
 
-    typedef std::unordered_map<ustring, OpDescriptor, ustringHash>
-        OpDescriptorMap;
+    typedef std::unordered_map<ustring, OpDescriptor> OpDescriptorMap;
 
     /// Look up OpDescriptor for the named op, return NULL for unknown op.
     ///
@@ -2361,8 +2359,7 @@ private:
         nullptr, &OIIO::aligned_free
     };
     size_t m_heapsize = 0;
-    using RegexMap
-        = std::unordered_map<ustring, std::unique_ptr<std::regex>, ustringHash>;
+    using RegexMap = std::unordered_map<ustring, std::unique_ptr<std::regex>>;
     RegexMap m_regex_map;    ///< Compiled regex's
     MessageList m_messages;  ///< Message blackboard
 #if OSL_USE_BATCHED

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -12,8 +12,7 @@ OSL_NAMESPACE_ENTER
 namespace pvt {
 
 #ifdef USE_PARTIO
-typedef std::unordered_map<ustring, std::unique_ptr<PointCloud>, ustringHash>
-    PointCloudMap;
+typedef std::unordered_map<ustring, std::unique_ptr<PointCloud>> PointCloudMap;
 static PointCloudMap pointclouds;
 static OIIO::spin_mutex pointcloudmap_mutex;
 

--- a/src/liboslexec/pointcloud.h
+++ b/src/liboslexec/pointcloud.h
@@ -22,8 +22,8 @@ public:
     ~PointCloud();
     static PointCloud* get(ustring filename, bool write = false);
 
-    typedef std::unordered_map<
-        ustring, std::unique_ptr<Partio::ParticleAttribute>, ustringHash>
+    typedef std::unordered_map<ustring,
+                               std::unique_ptr<Partio::ParticleAttribute>>
         AttributeMap;
 
     const Partio::ParticlesData* read_access() const

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -481,7 +481,7 @@ private:
     ShaderGlobals m_shaderglobals;  ///< Dummy ShaderGlobals
 
     // Keep track of some things for the whole shader group:
-    typedef std::unordered_map<ustring, ustring, ustringHash> ustringmap_t;
+    typedef std::unordered_map<ustring, ustring> ustringmap_t;
     std::vector<ustringmap_t> m_params_holding_globals;
     ///< Which params of each layer really just hold globals
 

--- a/src/osltoy/osltoyrenderer.h
+++ b/src/osltoy/osltoyrenderer.h
@@ -115,7 +115,7 @@ private:
     typedef bool (OSLToyRenderer::*AttrGetter)(ShaderGlobals* sg, bool derivs,
                                                ustring object, TypeDesc type,
                                                ustring name, void* val);
-    typedef std::unordered_map<ustring, AttrGetter, ustringHash> AttrGetterMap;
+    typedef std::unordered_map<ustring, AttrGetter> AttrGetterMap;
     AttrGetterMap m_attr_getters;
 
     // Attribute getters

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -93,9 +93,8 @@ private:
                          OptixProgramGroup* pg);
 
     std::string m_materials_ptx;
-    std::unordered_map<OIIO::ustring, optix::TextureSampler, OIIO::ustringHash>
-        m_samplers;
-    std::unordered_map<OIIO::ustring, uint64_t, OIIO::ustringHash> m_globals_map;
+    std::unordered_map<OIIO::ustring, optix::TextureSampler> m_samplers;
+    std::unordered_map<OIIO::ustring, uint64_t> m_globals_map;
 };
 
 

--- a/src/testrender/simpleraytracer.h
+++ b/src/testrender/simpleraytracer.h
@@ -132,7 +132,7 @@ private:
     typedef bool (SimpleRaytracer::*AttrGetter)(ShaderGlobals* sg, bool derivs,
                                                 ustring object, TypeDesc type,
                                                 ustring name, void* val);
-    typedef std::unordered_map<ustring, AttrGetter, ustringHash> AttrGetterMap;
+    typedef std::unordered_map<ustring, AttrGetter> AttrGetterMap;
     AttrGetterMap m_attr_getters;
 
     // Attribute getters

--- a/src/testshade/batched_simplerend.h
+++ b/src/testshade/batched_simplerend.h
@@ -99,8 +99,8 @@ public:
 
 private:
     SimpleRenderer& m_sr;
-    std::unordered_set<ustring, ustringHash> m_uniform_objects;
-    std::unordered_set<ustring, ustringHash> m_uniform_attributes;
+    std::unordered_set<ustring> m_uniform_objects;
+    std::unordered_set<ustring> m_uniform_attributes;
 
     // Attribute and userdata retrieval -- for fast dispatch, use a hash
     // table to map attribute names to functions that retrieve them. We
@@ -110,15 +110,13 @@ private:
     typedef bool (BatchedSimpleRenderer::*VaryingAttrGetter)(ustring object,
                                                              ustring name,
                                                              MaskedData val);
-    typedef std::unordered_map<ustring, VaryingAttrGetter, ustringHash>
-        VaryingAttrGetterMap;
+    typedef std::unordered_map<ustring, VaryingAttrGetter> VaryingAttrGetterMap;
     VaryingAttrGetterMap m_varying_attr_getters;
 
     typedef bool (BatchedSimpleRenderer::*UniformAttrGetter)(ustring object,
                                                              ustring name,
                                                              RefData val);
-    typedef std::unordered_map<ustring, UniformAttrGetter, ustringHash>
-        UniformAttrGetterMap;
+    typedef std::unordered_map<ustring, UniformAttrGetter> UniformAttrGetterMap;
     UniformAttrGetterMap m_uniform_attr_getters;
 
     // Attribute getters

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -90,9 +90,8 @@ private:
     const unsigned long OSL_PRINTF_BUFFER_SIZE = 8 * 1024 * 1024;
 
     std::string m_materials_ptx;
-    std::unordered_map<OIIO::ustring, optix::TextureSampler, OIIO::ustringHash>
-        m_samplers;
-    std::unordered_map<OIIO::ustring, uint64_t, OIIO::ustringHash> m_globals_map;
+    std::unordered_map<OIIO::ustring, optix::TextureSampler> m_samplers;
+    std::unordered_map<OIIO::ustring, uint64_t> m_globals_map;
 
     OSL::Matrix44 m_shader2common;  // "shader" space to "common" space matrix
     OSL::Matrix44 m_object2common;  // "object" space to "common" space matrix

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -183,7 +183,7 @@ protected:
     typedef bool (SimpleRenderer::*AttrGetter)(ShaderGlobals* sg, bool derivs,
                                                ustring object, TypeDesc type,
                                                ustring name, void* val);
-    typedef std::unordered_map<ustring, AttrGetter, ustringHash> AttrGetterMap;
+    typedef std::unordered_map<ustring, AttrGetter> AttrGetterMap;
     AttrGetterMap m_attr_getters;
 
     // Attribute getters

--- a/testsuite/example-cuda/cuda_grid_renderer.h
+++ b/testsuite/example-cuda/cuda_grid_renderer.h
@@ -10,10 +10,8 @@
 #include <OSL/rendererservices.h>
 
 
-using GlobalsMap
-    = std::unordered_map<OIIO::ustring, uint64_t, OIIO::ustringHash>;
-using TextureSamplerMap
-    = std::unordered_map<OIIO::ustring, cudaTextureObject_t, OIIO::ustringHash>;
+using GlobalsMap        = std::unordered_map<OIIO::ustring, uint64_t>;
+using TextureSamplerMap = std::unordered_map<OIIO::ustring, cudaTextureObject_t>;
 
 // Just use 4x4 matrix for transformations
 typedef OSL::Matrix44 Transformation;


### PR DESCRIPTION
Define std::hash for ustring and ustringhash, when not using an OIIO new enough to do so.

Define std::less for ustringhash, when not using an OIIO new enough to have operator< defined for ustringhash (will be fixed separately).

No need now for ustringHash, which is also unwisely similar to ustringhash, just use std::hash instead.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
