### PR TITLE
Move string representation entirely to ustringhash -- phase I

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.12)
 
-set (OSL_VERSION "1.13.1.0" CACHE STRING "Version")
+set (OSL_VERSION "1.13.2.0" CACHE STRING "Version")
 project (OSL VERSION ${OSL_VERSION}
          LANGUAGES CXX C
          HOMEPAGE_URL "https://github.com/AcademySoftwareFoundation/OpenShadingLanguage")
@@ -100,6 +100,7 @@ set (OSL_SHADER_INSTALL_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/shade
 set (OSL_PTX_INSTALL_DIR "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}/ptx"
      CACHE STRING "Directory where OptiX PTX files will be installed")
 set (CMAKE_DEBUG_POSTFIX "" CACHE STRING "Library naming postfix for Debug builds (e.g., '_debug')")
+option (OSL_USTRINGREP_IS_HASH "Always use ustringhash for strings" OFF)
 
 
 set (OSL_NO_DEFAULT_TEXTURESYSTEM OFF CACHE BOOL "Do not use create a raw OIIO::TextureSystem")

--- a/src/include/OSL/batched_rendererservices.h
+++ b/src/include/OSL/batched_rendererservices.h
@@ -82,12 +82,13 @@ public:
     /// Return a Mask with lanes set to  true if ok, false if the named matrix
     /// is not known.
     virtual Mask get_matrix(BatchedShaderGlobals* bsg, Masked<Matrix44> wresult,
-                            ustring from, Wide<const float> wtime)
+                            ustringhash from, Wide<const float> wtime)
     {
         return Mask(false);
     }
     virtual Mask get_matrix(BatchedShaderGlobals* bsg, Masked<Matrix44> result,
-                            Wide<const ustring> wfrom, Wide<const float> wtime);
+                            Wide<const ustringhash> wfrom,
+                            Wide<const float> wtime);
     virtual bool is_overridden_get_matrix_WmWsWf() const = 0;
 
 
@@ -97,12 +98,12 @@ public:
     /// particular renderer may have a better technique and overload the
     /// implementation.
     virtual Mask get_inverse_matrix(BatchedShaderGlobals* bsg,
-                                    Masked<Matrix44> wresult, ustring to,
+                                    Masked<Matrix44> wresult, ustringhash to,
                                     Wide<const float> wtime);
     virtual bool is_overridden_get_inverse_matrix_WmsWf() const = 0;
     virtual Mask get_inverse_matrix(BatchedShaderGlobals* bsg,
                                     Masked<Matrix44> wresult,
-                                    Wide<const ustring> wto,
+                                    Wide<const ustringhash> wto,
                                     Wide<const float> wtime);
     virtual bool is_overridden_get_inverse_matrix_WmWsWf() const = 0;
 
@@ -124,22 +125,23 @@ public:
     /// specified (object == ustring()), then the renderer should search *first*
     /// for the attribute on the currently shaded object, and next, if
     /// unsuccessful, on the currently shaded "scene".
-    virtual Mask get_attribute(BatchedShaderGlobals* bsg, ustring object,
-                               ustring name, MaskedData wval)
+    virtual Mask get_attribute(BatchedShaderGlobals* bsg, ustringhash object,
+                               ustringhash name, MaskedData wval)
     {
         return Mask(false);
     }
 
     /// Similar to get_attribute();  this method will fetch the 'index'
     /// element of an attribute array.
-    virtual Mask get_array_attribute(BatchedShaderGlobals* bsg, ustring object,
-                                     ustring name, int index, MaskedData wval)
+    virtual Mask get_array_attribute(BatchedShaderGlobals* bsg,
+                                     ustringhash object, ustringhash name,
+                                     int index, MaskedData wval)
     {
         return Mask(false);
     }
 
     virtual bool get_attribute_uniform(BatchedShaderGlobals* bsg,
-                                       ustring object, ustring name,
+                                       ustringhash object, ustringhash name,
                                        RefData val)
     {
         return false;
@@ -148,8 +150,9 @@ public:
     /// Similar to get_attribute();  this method will fetch the 'index'
     /// element of an attribute array.
     virtual bool get_array_attribute_uniform(BatchedShaderGlobals* bsg,
-                                             ustring object, ustring name,
-                                             int index, RefData val)
+                                             ustringhash object,
+                                             ustringhash name, int index,
+                                             RefData val)
     {
         return false;
     }
@@ -159,7 +162,7 @@ public:
     /// as well. It is assumed the results are varying and returns Mask
     // with its bit set to off if no user-data with the given name and type was
     /// found.
-    virtual Mask get_userdata(ustring name, BatchedShaderGlobals* bsg,
+    virtual Mask get_userdata(ustringhash name, BatchedShaderGlobals* bsg,
                               MaskedData wval)
     {
         return Mask(false);
@@ -206,7 +209,7 @@ public:
     /// error.
     ///
     virtual Mask
-    texture(ustring filename, TextureSystem::TextureHandle* texture_handle,
+    texture(ustringhash filename, TextureSystem::TextureHandle* texture_handle,
             TextureSystem::Perthread* texture_thread_info,
             const BatchedTextureOptions& options, BatchedShaderGlobals* bsg,
             Wide<const float> ws, Wide<const float> wt, Wide<const float> wdsdx,
@@ -240,7 +243,7 @@ public:
     /// messages (in case of failure, when the function returns false) will
     /// be stored there, leaving it up to the caller/shader to handle the
     /// error.
-    virtual Mask texture3d(ustring filename,
+    virtual Mask texture3d(ustringhash filename,
                            TextureSystem::TextureHandle* texture_handle,
                            TextureSystem::Perthread* texture_thread_info,
                            const BatchedTextureOptions& options,
@@ -273,7 +276,7 @@ public:
     /// messages (in case of failure, when the function returns false) will
     /// be stored there, leaving it up to the caller/shader to handle the
     /// error.
-    virtual Mask environment(ustring filename,
+    virtual Mask environment(ustringhash filename,
                              TextureSystem::TextureHandle* texture_handle,
                              TextureSystem::Perthread* texture_thread_info,
                              const BatchedTextureOptions& options,
@@ -300,12 +303,12 @@ public:
 
     virtual TextureSystem::TextureHandle* resolve_udim_uniform(
         BatchedShaderGlobals* bsg, TexturePerthread* texture_thread_info,
-        ustring filename, TextureSystem::TextureHandle* texture_handle, float S,
-        float T);
+        ustringhash filename, TextureSystem::TextureHandle* texture_handle,
+        float S, float T);
 
     virtual void resolve_udim(BatchedShaderGlobals* bsg,
                               TexturePerthread* texture_thread_info,
-                              ustring filename,
+                              ustringhash filename,
                               TextureSystem::TextureHandle* texture_handle,
                               Wide<const float> wS, Wide<const float> wT,
                               Masked<TextureSystem::TextureHandle*> wresult);
@@ -313,8 +316,8 @@ public:
     // Assumes any UDIM has been resolved already
     virtual bool get_texture_info_uniform(
         BatchedShaderGlobals* bsg, TexturePerthread* texture_thread_info,
-        ustring filename, TextureSystem::TextureHandle* texture_handle,
-        int subimage, ustring dataname, RefData val);
+        ustringhash filename, TextureSystem::TextureHandle* texture_handle,
+        int subimage, ustringhash dataname, RefData val);
 
 
     /// Lookup nearest points in a point cloud. It will search for
@@ -407,26 +410,25 @@ public:
     };
 
 
-    virtual void pointcloud_search(BatchedShaderGlobals* bsg, ustring filename,
-                                   const void* wcenter,
+    virtual void pointcloud_search(BatchedShaderGlobals* bsg,
+                                   ustringhash filename, const void* wcenter,
                                    Wide<const float> wradius, int max_points,
                                    bool sort, PointCloudSearchResults& results);
     virtual bool is_overridden_pointcloud_search() const = 0;
 
 
-    virtual Mask pointcloud_get(BatchedShaderGlobals* bsg, ustring filename,
+    virtual Mask pointcloud_get(BatchedShaderGlobals* bsg, ustringhash filename,
                                 Wide<const int[]> windices,
-                                Wide<const int> wnum_points, ustring attr_name,
-                                MaskedData wout_data);
+                                Wide<const int> wnum_points,
+                                ustringhash attr_name, MaskedData wout_data);
     virtual bool is_overridden_pointcloud_get() const = 0;
 
 
-    virtual Mask pointcloud_write(BatchedShaderGlobals* bsg, ustring filename,
-                                  Wide<const OSL::Vec3> wpos, int nattribs,
-                                  const ustring* attr_names,
-                                  const TypeDesc* attr_types,
-                                  const void** pointers_to_wide_attr_value,
-                                  Mask mask);
+    virtual Mask
+    pointcloud_write(BatchedShaderGlobals* bsg, ustringhash filename,
+                     Wide<const OSL::Vec3> wpos, int nattribs,
+                     const ustring* attr_names, const TypeDesc* attr_types,
+                     const void** pointers_to_wide_attr_value, Mask mask);
     virtual bool is_overridden_pointcloud_write() const = 0;
 
     /// Options for the trace call.
@@ -441,7 +443,8 @@ public:
                        Wide<const Vec3> wdRdy);
 
     virtual void getmessage(BatchedShaderGlobals* bsg, Masked<int> wresult,
-                            ustring source, ustring name, MaskedData wval);
+                            ustringhash source, ustringhash name,
+                            MaskedData wval);
 
     // pointcloud_search is T.B.D.
 

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -133,6 +133,56 @@ fmtformat(const Str& fmt, Args&&... args)
 
 
 
+/// OSL_USTRINGREP_IS_HASH will be 1 if the build-time option was enabled to
+/// make the ustringrep be a ustringhash, rather than a ustring directly.
+#cmakedefine01 OSL_USTRINGREP_IS_HASH
+
+#if OSL_USTRINGREP_IS_HASH
+using ustringrep = ustringhash;
+#else
+using ustringrep = ustring;
+#endif
+
+
+/// Convenience function to convert to a ustring.
+inline ustring
+ustring_from(ustringhash h)
+{
+    return ustring::from_hash(h.hash());
+}
+
+/// Convenience function to convert to a ustring.
+inline ustring
+ustring_from(ustring u)
+{
+    return u;
+}
+
+
+/// Convenience function to convert to a ustringrep.
+inline ustringrep
+ustringrep_from(ustringhash h)
+{
+#if OSL_USTRINGREP_IS_HASH
+    return h;
+#else
+    return ustring::from_hash(h.hash());
+#endif
+}
+
+/// Convenience function to convert to a ustringrep.
+inline ustringrep
+ustringrep_from(ustring u)
+{
+#if OSL_USTRINGREP_IS_HASH
+    return u.hash();
+#else
+    return u;
+#endif
+}
+
+
+
 // N.B. SymArena is not really "configuration", but we cram it here for
 // lack of a better home.
 

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
-// clang-format off
-
 #pragma once
 
 
@@ -13,14 +11,13 @@
 OSL_NAMESPACE_ENTER
 
 class RendererServices;
-template<int WidthT>
-class BatchedRendererServices;
+template<int WidthT> class BatchedRendererServices;
 class ShadingContext;
 struct ShaderGlobals;
 
 // Tags for polymorphic dispatch
-template <int SimdWidthT>
-class WidthOf {};
+template<int SimdWidthT> class WidthOf {
+};
 
 
 /// Opaque pointer to whatever the renderer uses to represent a
@@ -49,7 +46,7 @@ public:
 
 
     RendererServices(TextureSystem* texsys = NULL);
-    virtual ~RendererServices () { }
+    virtual ~RendererServices() {}
 
     /// Given the name of a 'feature', return whether this RendererServices
     /// supports it. Feature names include:
@@ -62,28 +59,34 @@ public:
     /// support it, as long as the OSL runtime only uses that feature if the
     /// supports("feature") says it's present, thus preserving source
     /// compatibility.
-    virtual int supports (string_view feature) const { return false; }
+    virtual int supports(string_view feature) const { return false; }
 
     /// Get the 4x4 matrix that transforms by the specified
     /// transformation at the given time.  Return true if ok, false
     /// on error.
-    virtual bool get_matrix (ShaderGlobals *sg, Matrix44 &result,
-                             TransformationPtr xform, float time) { return false; }
+    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                            TransformationPtr xform, float time)
+    {
+        return false;
+    }
 
     /// Get the 4x4 matrix that transforms by the specified
     /// transformation at the given time.  Return true if ok, false on
     /// error.  The default implementation is to use get_matrix and
     /// invert it, but a particular renderer may have a better technique
     /// and overload the implementation.
-    virtual bool get_inverse_matrix (ShaderGlobals *sg, Matrix44 &result,
-                                     TransformationPtr xform, float time);
+    virtual bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
+                                    TransformationPtr xform, float time);
 
     /// Get the 4x4 matrix that transforms by the specified
     /// transformation.  Return true if ok, false on error.  Since no
     /// time value is given, also return false if the transformation may
     /// be time-varying.
-    virtual bool get_matrix (ShaderGlobals *sg, Matrix44 &result,
-                             TransformationPtr xform) { return false; }
+    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                            TransformationPtr xform)
+    {
+        return false;
+    }
 
     /// Get the 4x4 matrix that transforms by the specified
     /// transformation.  Return true if ok, false on error.  Since no
@@ -91,29 +94,29 @@ public:
     /// be time-varying.  The default implementation is to use
     /// get_matrix and invert it, but a particular renderer may have a
     /// better technique and overload the implementation.
-    virtual bool get_inverse_matrix (ShaderGlobals *sg, Matrix44 &result,
-                                     TransformationPtr xform);
+    virtual bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
+                                    TransformationPtr xform);
 
     /// Get the 4x4 matrix that transforms points from the named
     /// 'from' coordinate system to "common" space at the given time.
     /// Returns true if ok, false if the named matrix is not known.
-    virtual bool get_matrix (ShaderGlobals *sg, Matrix44 &result,
-                             ustring from, float time) { return false; }
+    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                            ustringhash from, float time);
 
     /// Get the 4x4 matrix that transforms points from "common" space to
     /// the named 'to' coordinate system to at the given time.  The
     /// default implementation is to use get_matrix and invert it, but a
     /// particular renderer may have a better technique and overload the
     /// implementation.
-    virtual bool get_inverse_matrix (ShaderGlobals *sg, Matrix44 &result,
-                                     ustring to, float time);
+    virtual bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
+                                    ustringhash to, float time);
 
     /// Get the 4x4 matrix that transforms 'from' to "common" space.
     /// Since there is no time value passed, return false if the
     /// transformation may be time-varying (as well as if it's not found
     /// at all).
-    virtual bool get_matrix (ShaderGlobals *sg, Matrix44 &result,
-                             ustring from) { return false; }
+    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                            ustringhash from);
 
     /// Get the 4x4 matrix that transforms points from "common" space to
     /// the named 'to' coordinate system.  Since there is no time value
@@ -122,8 +125,8 @@ public:
     /// implementation is to use get_matrix and invert it, but a
     /// particular renderer may have a better technique and overload the
     /// implementation.
-    virtual bool get_inverse_matrix (ShaderGlobals *sg, Matrix44 &result,
-                                     ustring to);
+    virtual bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
+                                    ustringhash to);
 
     /// Transform points Pin[0..npoints-1] in named coordinate system
     /// 'from' into 'to' coordinates, storing the result in Pout[] using
@@ -148,11 +151,10 @@ public:
     /// Note to RendererServices implementations: just return 'false'
     /// if there isn't a special nonlinear transformation between the
     /// two spaces.
-    virtual bool transform_points (ShaderGlobals *sg,
-                                   ustring from, ustring to, float time,
-                                   const Vec3 *Pin, Vec3 *Pout, int npoints,
-                                   TypeDesc::VECSEMANTICS vectype)
-        { return false; }
+    virtual bool transform_points(ShaderGlobals* sg, ustringhash from,
+                                  ustringhash to, float time, const Vec3* Pin,
+                                  Vec3* Pout, int npoints,
+                                  TypeDesc::VECSEMANTICS vectype);
 
 
     /// Get the named attribute from the renderer and if found then
@@ -167,36 +169,36 @@ public:
     /// run on. Be robust to this situation, return 'true' (retrieve the
     /// attribute) if you can (known object and attribute name), but
     /// otherwise just fail by returning 'false'.
-    virtual bool get_attribute (ShaderGlobals *sg, bool derivatives,
-                                ustring object, TypeDesc type, ustring name,
-                                void *val) { return false; }
+    virtual bool get_attribute(ShaderGlobals* sg, bool derivatives,
+                               ustringhash object, TypeDesc type,
+                               ustringhash name, void* val);
 
     /// Similar to get_attribute();  this method will return the 'index'
     /// element of an attribute array.
-    virtual bool get_array_attribute (ShaderGlobals *sg, bool derivatives,
-                                      ustring object, TypeDesc type,
-                                      ustring name, int index, void *val) { return false; }
+    virtual bool get_array_attribute(ShaderGlobals* sg, bool derivatives,
+                                     ustringhash object, TypeDesc type,
+                                     ustringhash name, int index, void* val);
 
     /// Get the named user-data from the current object and write it into
     /// 'val'. If derivatives is true, the derivatives should be written into val
     /// as well. Return false if no user-data with the given name and type was
     /// found.
-    virtual bool get_userdata (bool derivatives, ustring name, TypeDesc type,
-                               ShaderGlobals *sg, void *val) { return false; }
+    virtual bool get_userdata(bool derivatives, ustringhash name, TypeDesc type,
+                              ShaderGlobals* sg, void* val);
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle * get_texture_handle (ustring filename,
-                                                ShadingContext *context);
+    virtual TextureHandle* get_texture_handle(ustringhash filename,
+                                              ShadingContext* context);
 
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is a valid texture that can be subsequently
     /// read or sampled.
-    virtual bool good (TextureHandle *texture_handle);
+    virtual bool good(TextureHandle* texture_handle);
 
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is udim
-    virtual bool is_udim (TextureHandle *texture_handle);
+    virtual bool is_udim(TextureHandle* texture_handle);
 
     /// Filtered 2D texture lookup for a single point.
     ///
@@ -224,13 +226,13 @@ public:
     /// messages (in case of failure, when the function returns false) will
     /// be stored there, leaving it up to the caller/shader to handle the
     /// error.
-    virtual bool texture (ustring filename, TextureHandle *texture_handle,
-                          TexturePerthread *texture_thread_info,
-                          TextureOpt &options, ShaderGlobals *sg,
-                          float s, float t, float dsdx, float dtdx,
-                          float dsdy, float dtdy, int nchannels,
-                          float *result, float *dresultds, float *dresultdt,
-                          ustring *errormessage);
+    virtual bool texture(ustringhash filename, TextureHandle* texture_handle,
+                         TexturePerthread* texture_thread_info,
+                         TextureOpt& options, ShaderGlobals* sg, float s,
+                         float t, float dsdx, float dtdx, float dsdy,
+                         float dtdy, int nchannels, float* result,
+                         float* dresultds, float* dresultdt,
+                         ustringhash* errormessage);
 
     /// Filtered 3D texture lookup for a single point.
     ///
@@ -257,14 +259,13 @@ public:
     /// messages (in case of failure, when the function returns false) will
     /// be stored there, leaving it up to the caller/shader to handle the
     /// error.
-    virtual bool texture3d (ustring filename, TextureHandle *texture_handle,
-                            TexturePerthread *texture_thread_info,
-                            TextureOpt &options, ShaderGlobals *sg,
-                            const Vec3 &P, const Vec3 &dPdx, const Vec3 &dPdy,
-                            const Vec3 &dPdz, int nchannels,
-                            float *result, float *dresultds,
-                            float *dresultdt, float *dresultdr,
-                            ustring *errormessage);
+    virtual bool texture3d(ustringhash filename, TextureHandle* texture_handle,
+                           TexturePerthread* texture_thread_info,
+                           TextureOpt& options, ShaderGlobals* sg,
+                           const Vec3& P, const Vec3& dPdx, const Vec3& dPdy,
+                           const Vec3& dPdz, int nchannels, float* result,
+                           float* dresultds, float* dresultdt, float* dresultdr,
+                           ustringhash* errormessage);
 
     /// Filtered environment lookup for a single point.
     ///
@@ -288,13 +289,13 @@ public:
     /// messages (in case of failure, when the function returns false) will
     /// be stored there, leaving it up to the caller/shader to handle the
     /// error.
-    virtual bool environment (ustring filename, TextureHandle *texture_handle,
-                              TexturePerthread *texture_thread_info,
-                              TextureOpt &options, ShaderGlobals *sg,
-                              const Vec3 &R, const Vec3 &dRdx, const Vec3 &dRdy,
-                              int nchannels, float *result,
-                              float *dresultds, float *dresultdt,
-                              ustring *errormessage);
+    virtual bool environment(ustringhash filename,
+                             TextureHandle* texture_handle,
+                             TexturePerthread* texture_thread_info,
+                             TextureOpt& options, ShaderGlobals* sg,
+                             const Vec3& R, const Vec3& dRdx, const Vec3& dRdy,
+                             int nchannels, float* result, float* dresultds,
+                             float* dresultdt, ustringhash* errormessage);
 
     /// Get information about the given texture.  Return true if found
     /// and the data has been put in *data.  Return false if the texture
@@ -315,24 +316,20 @@ public:
     /// messages (in case of failure, when the function returns false) will
     /// be stored there, leaving it up to the caller/shader to handle the
     /// error.
-    virtual bool get_texture_info (ustring filename,
-                                   TextureHandle *texture_handle,
-                                   TexturePerthread *texture_thread_info,
-                                   ShadingContext *shading_context,
-                                   int subimage,
-                                   ustring dataname, TypeDesc datatype,
-                                   void *data,
-                                   ustring *errormessage);
+    virtual bool get_texture_info(ustringhash filename,
+                                  TextureHandle* texture_handle,
+                                  TexturePerthread* texture_thread_info,
+                                  ShadingContext* shading_context, int subimage,
+                                  ustringhash dataname, TypeDesc datatype,
+                                  void* data, ustringhash* errormessage);
 
-    virtual bool get_texture_info (ustring filename,
-                                   TextureHandle *texture_handle,
-                                   float s, float t,
-                                   TexturePerthread *texture_thread_info,
-                                   ShadingContext *shading_context,
-                                   int subimage,
-                                   ustring dataname, TypeDesc datatype,
-                                   void *data,
-                                   ustring *errormessage);
+    virtual bool get_texture_info(ustringhash filename,
+                                  TextureHandle* texture_handle, float s,
+                                  float t,
+                                  TexturePerthread* texture_thread_info,
+                                  ShadingContext* shading_context, int subimage,
+                                  ustringhash dataname, TypeDesc datatype,
+                                  void* data, ustringhash* errormessage);
 
 
     /// Lookup nearest points in a point cloud. It will search for
@@ -343,40 +340,38 @@ public:
     /// derivatives will be computed for distances (when provided).
     ///
     /// Return the number of points found, always < max_points
-    virtual int pointcloud_search (ShaderGlobals *sg,
-                                   ustring filename, const OSL::Vec3 &center,
-                                   float radius, int max_points, bool sort,
-                                   size_t *out_indices,
-                                   float *out_distances, int derivs_offset);
+    virtual int pointcloud_search(ShaderGlobals* sg, ustringhash filename,
+                                  const OSL::Vec3& center, float radius,
+                                  int max_points, bool sort,
+                                  size_t* out_indices, float* out_distances,
+                                  int derivs_offset);
 
     /// Retrieve an attribute for an index list. The result is another array
     /// of the requested type stored in out_data.
     ///
     /// Return 1 if the attribute is found, 0 otherwise.
-    virtual int pointcloud_get (ShaderGlobals *sg,
-                                ustring filename, size_t *indices, int count,
-                                ustring attr_name, TypeDesc attr_type,
-                                void *out_data);
+    virtual int pointcloud_get(ShaderGlobals* sg, ustringhash filename,
+                               size_t* indices, int count,
+                               ustringhash attr_name, TypeDesc attr_type,
+                               void* out_data);
 
     /// Write a point to the named pointcloud, which will be saved
     /// at the end of the frame.  Return true if everything is ok,
     /// false if there was an error.
-    virtual bool pointcloud_write (ShaderGlobals *sg,
-                                   ustring filename, const OSL::Vec3 &pos,
-                                   int nattribs, const ustring *names,
-                                   const TypeDesc *types,
-                                   const void **data);
+    virtual bool pointcloud_write(ShaderGlobals* sg, ustringhash filename,
+                                  const OSL::Vec3& pos, int nattribs,
+                                  const ustringrep* names,
+                                  const TypeDesc* types, const void** data);
 
     /// Options for the trace call.
     struct TraceOpt {
-        float mindist;    ///< ignore hits closer than this
-        float maxdist;    ///< ignore hits farther than this
-        bool shade;       ///< whether to shade what is hit
-        ustring traceset; ///< named trace set
-        TraceOpt () : mindist(0.0f), maxdist(1.0e30), shade(false) { }
+        float mindist;        ///< ignore hits closer than this
+        float maxdist;        ///< ignore hits farther than this
+        bool shade;           ///< whether to shade what is hit
+        ustringrep traceset;  ///< named trace set
+        TraceOpt() : mindist(0.0f), maxdist(1.0e30), shade(false) {}
 
-        enum class LLVMMemberIndex
-        {
+        enum class LLVMMemberIndex {
             mindist = 0,
             maxdist,
             shade,
@@ -387,32 +382,28 @@ public:
 
     /// Immediately trace a ray from P in the direction R.  Return true
     /// if anything hit, otherwise false.
-    virtual bool trace (TraceOpt &options, ShaderGlobals *sg,
-                        const OSL::Vec3 &P, const OSL::Vec3 &dPdx,
-                        const OSL::Vec3 &dPdy, const OSL::Vec3 &R,
-                        const OSL::Vec3 &dRdx, const OSL::Vec3 &dRdy) {
-        return false;
-    }
+    virtual bool trace(TraceOpt& options, ShaderGlobals* sg, const OSL::Vec3& P,
+                       const OSL::Vec3& dPdx, const OSL::Vec3& dPdy,
+                       const OSL::Vec3& R, const OSL::Vec3& dRdx,
+                       const OSL::Vec3& dRdy);
 
     /// Get the named message from the renderer and if found then
     /// write it into 'val'.  Otherwise, return false.  This is only
     /// called for "sourced" messages, not ordinary intra-group messages.
-    virtual bool getmessage (ShaderGlobals *sg, ustring source, ustring name,
-                             TypeDesc type, void *val, bool derivatives) {
-        return false;
-    }
+    virtual bool getmessage(ShaderGlobals* sg, ustringhash source,
+                            ustringhash name, TypeDesc type, void* val,
+                            bool derivatives);
 
     /// Return a pointer to the texture system (if available).
-    virtual TextureSystem *texturesys () const;
+    virtual TextureSystem* texturesys() const;
 
-    virtual uint64_t register_global (const std::string& var_name,
-                                      uint64_t           value)
+    virtual uint64_t register_global(const std::string& var_name,
+                                     uint64_t value)
     {
         return 0;
     }
 
-    virtual bool fetch_global (const std::string& var_name,
-                               uint64_t*          value)
+    virtual bool fetch_global(const std::string& var_name, uint64_t* value)
     {
         return false;
     }
@@ -426,19 +417,25 @@ public:
         Vec3 direction;
         float bandwidth;
         float impulses;
-        NoiseOpt () : anisotropic(0), do_filter(true),
-            direction(1.0f,0.0f,0.0f), bandwidth(1.0f), impulses(16.0f) { }
+        NoiseOpt()
+            : anisotropic(0)
+            , do_filter(true)
+            , direction(1.0f, 0.0f, 0.0f)
+            , bandwidth(1.0f)
+            , impulses(16.0f)
+        {
+        }
     };
 
     /// A renderer may choose to support batched execution by providing pointers
     /// to objects satisfying the BatchedRendererServices<WidthOf<#>> interface
     /// for specific batch sizes.
     /// Unless overridden, a nullptr is returned.
-    virtual BatchedRendererServices<16> * batched(WidthOf<16>);
-    virtual BatchedRendererServices<8> * batched(WidthOf<8>);
+    virtual BatchedRendererServices<16>* batched(WidthOf<16>);
+    virtual BatchedRendererServices<8>* batched(WidthOf<8>);
 
 protected:
-    TextureSystem *m_texturesys;   // A place to hold a TextureSystem
+    TextureSystem* m_texturesys;  // A place to hold a TextureSystem
 };
 
 

--- a/src/liboslexec/batched_rendservices.cpp
+++ b/src/liboslexec/batched_rendservices.cpp
@@ -41,7 +41,7 @@ template<int WidthT>
 Mask<WidthT>
 BatchedRendererServices<WidthT>::get_matrix(BatchedShaderGlobals* bsg,
                                             Masked<Matrix44> wresult,
-                                            Wide<const ustring> wfrom,
+                                            Wide<const ustringhash> wfrom,
                                             Wide<const float> wtime)
 {
     OSL_ASSERT(
@@ -70,7 +70,7 @@ template<int WidthT>
 Mask<WidthT>
 BatchedRendererServices<WidthT>::get_inverse_matrix(BatchedShaderGlobals* bsg,
                                                     Masked<Matrix44> wresult,
-                                                    ustring to,
+                                                    ustringhash to,
                                                     Wide<const float> wtime)
 {
     OSL_ASSERT(
@@ -85,7 +85,7 @@ template<int WidthT>
 Mask<WidthT>
 BatchedRendererServices<WidthT>::get_inverse_matrix(BatchedShaderGlobals* bsg,
                                                     Masked<Matrix44> wresult,
-                                                    Wide<const ustring> wto,
+                                                    Wide<const ustringhash> wto,
                                                     Wide<const float> wtime)
 {
     OSL_ASSERT(
@@ -109,13 +109,13 @@ template<int WidthT>
 TextureSystem::TextureHandle*
 BatchedRendererServices<WidthT>::resolve_udim_uniform(
     BatchedShaderGlobals* bsg, TexturePerthread* texture_thread_info,
-    ustring filename, TextureSystem::TextureHandle* texture_handle, float S,
+    ustringhash filename, TextureSystem::TextureHandle* texture_handle, float S,
     float T)
 {
     if (!texture_thread_info)
         texture_thread_info = bsg->uniform.context->texture_thread_info();
     if (!texture_handle)
-        texture_handle = texturesys()->get_texture_handle(filename,
+        texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
     if (texturesys()->is_udim(texture_handle)) {
         // Newer versions of the TextureSystem interface are able to determine the
@@ -141,14 +141,14 @@ template<int WidthT>
 void
 BatchedRendererServices<WidthT>::resolve_udim(
     BatchedShaderGlobals* bsg, TexturePerthread* texture_thread_info,
-    ustring filename, TextureSystem::TextureHandle* texture_handle,
+    ustringhash filename, TextureSystem::TextureHandle* texture_handle,
     Wide<const float> wS, Wide<const float> wT,
     Masked<TextureSystem::TextureHandle*> wresult)
 {
     if (!texture_thread_info)
         texture_thread_info = bsg->uniform.context->texture_thread_info();
     if (!texture_handle)
-        texture_handle = texturesys()->get_texture_handle(filename,
+        texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
     if (texturesys()->is_udim(texture_handle)) {
         // Newer versions of the TextureSystem interface are able to determine the
@@ -176,17 +176,17 @@ template<int WidthT>
 bool
 BatchedRendererServices<WidthT>::get_texture_info_uniform(
     BatchedShaderGlobals* bsg, TexturePerthread* texture_thread_info,
-    ustring filename, TextureSystem::TextureHandle* texture_handle,
-    int subimage, ustring dataname, RefData val)
+    ustringhash filename, TextureSystem::TextureHandle* texture_handle,
+    int subimage, ustringhash dataname, RefData val)
 {
     if (!texture_thread_info)
         texture_thread_info = bsg->uniform.context->texture_thread_info();
     if (!texture_handle)
-        texture_handle = texturesys()->get_texture_handle(filename,
+        texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
     bool status = texturesys()->get_texture_info(texture_handle, NULL, subimage,
-                                                 dataname, val.type(),
-                                                 val.ptr());
+                                                 ustring_from(dataname),
+                                                 val.type(), val.ptr());
 
     if (!status) {
         std::string err = texturesys()->geterror();
@@ -203,7 +203,7 @@ BatchedRendererServices<WidthT>::get_texture_info_uniform(
 template<int WidthT>
 Mask<WidthT>
 BatchedRendererServices<WidthT>::texture(
-    ustring filename, TextureSystem::TextureHandle* texture_handle,
+    ustringhash filename, TextureSystem::TextureHandle* texture_handle,
     TextureSystem::Perthread* texture_thread_info,
     const BatchedTextureOptions& options, BatchedShaderGlobals* bsg,
     Wide<const float> ws, Wide<const float> wt, Wide<const float> wdsdx,
@@ -221,7 +221,7 @@ BatchedRendererServices<WidthT>::texture(
 template<int WidthT>
 Mask<WidthT>
 BatchedRendererServices<WidthT>::texture3d(
-    ustring filename, TextureSystem::TextureHandle* texture_handle,
+    ustringhash filename, TextureSystem::TextureHandle* texture_handle,
     TextureSystem::Perthread* texture_thread_info,
     const BatchedTextureOptions& options, BatchedShaderGlobals* bsg,
     Wide<const Vec3> wP, Wide<const Vec3> wdPdx, Wide<const Vec3> wdPdy,
@@ -238,7 +238,7 @@ BatchedRendererServices<WidthT>::texture3d(
 template<int WidthT>
 Mask<WidthT>
 BatchedRendererServices<WidthT>::environment(
-    ustring filename, TextureSystem::TextureHandle* texture_handle,
+    ustringhash filename, TextureSystem::TextureHandle* texture_handle,
     TextureSystem::Perthread* texture_thread_info,
     const BatchedTextureOptions& options, BatchedShaderGlobals* bsg,
     Wide<const Vec3> wR, Wide<const Vec3> wdRdx, Wide<const Vec3> wdRdy,
@@ -255,7 +255,7 @@ BatchedRendererServices<WidthT>::environment(
 template<int WidthT>
 void
 BatchedRendererServices<WidthT>::pointcloud_search(
-    BatchedShaderGlobals* bsg, ustring filename, const void* wcenter,
+    BatchedShaderGlobals* bsg, ustringhash filename, const void* wcenter,
     Wide<const float> wradius, int max_points, bool sort,
     PointCloudSearchResults& results)
 {
@@ -269,8 +269,8 @@ BatchedRendererServices<WidthT>::pointcloud_search(
 template<int WidthT>
 Mask<WidthT>
 BatchedRendererServices<WidthT>::pointcloud_get(
-    BatchedShaderGlobals* bsg, ustring filename, Wide<const int[]> windices,
-    Wide<const int> wnum_points, ustring attr_name, MaskedData wout_data)
+    BatchedShaderGlobals* bsg, ustringhash filename, Wide<const int[]> windices,
+    Wide<const int> wnum_points, ustringhash attr_name, MaskedData wout_data)
 {
     OSL_ASSERT(
         0
@@ -283,7 +283,7 @@ BatchedRendererServices<WidthT>::pointcloud_get(
 template<int WidthT>
 Mask<WidthT>
 BatchedRendererServices<WidthT>::pointcloud_write(
-    BatchedShaderGlobals* bsg, ustring filename, Wide<const OSL::Vec3> wpos,
+    BatchedShaderGlobals* bsg, ustringhash filename, Wide<const OSL::Vec3> wpos,
     int nattribs, const ustring* attr_names, const TypeDesc* attr_types,
     const void** pointers_to_wide_attr_value, Mask mask)
 {
@@ -312,8 +312,9 @@ BatchedRendererServices<WidthT>::trace(
 template<int WidthT>
 void
 BatchedRendererServices<WidthT>::getmessage(BatchedShaderGlobals* bsg,
-                                            Masked<int> wresult, ustring source,
-                                            ustring name, MaskedData wval)
+                                            Masked<int> wresult,
+                                            ustringhash source,
+                                            ustringhash name, MaskedData wval)
 {
     // Currently this code path should only be followed when source == "trace"
     OSL_DASSERT(wresult.mask() == wval.mask());

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2413,11 +2413,12 @@ DECLFOLDER(constfold_gettextureinfo)
         void* mydata     = OSL_ALLOCA(char, t.size());
         // FIXME(ptex) -- exclude folding of ptex, since these things
         // can vary per face.
-        ustring errormessage;
+        ustringhash em;
         int result = rop.renderer()->get_texture_info(
             filename, nullptr, rop.shadingcontext()->texture_thread_info(),
             rop.shadingcontext(), 0 /* TODO: subimage? */, dataname, t, mydata,
-            &errormessage);
+            &em);
+        ustring errormessage = ustring_from(em);
         // Now we turn
         //       gettextureinfo result filename dataname data
         // into this for success:

--- a/src/liboslexec/pointcloud.h
+++ b/src/liboslexec/pointcloud.h
@@ -17,12 +17,12 @@ namespace pvt {
 
 class PointCloud {
 public:
-    PointCloud(ustring filename, Partio::ParticlesDataMutable* partio_cloud,
+    PointCloud(ustringhash filename, Partio::ParticlesDataMutable* partio_cloud,
                bool write);
     ~PointCloud();
-    static PointCloud* get(ustring filename, bool write = false);
+    static PointCloud* get(ustringhash filename, bool write = false);
 
-    typedef std::unordered_map<ustring,
+    typedef std::unordered_map<ustringhash,
                                std::unique_ptr<Partio::ParticleAttribute>>
         AttributeMap;
 
@@ -37,7 +37,7 @@ public:
         return m_partio_cloud;
     }
 
-    ustring m_filename;
+    ustringhash m_filename;
 
 private:
     // hide just this field, because we want to control how it is accessed

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -48,6 +48,24 @@ RendererServices::texturesys() const
 
 
 bool
+RendererServices::get_matrix(ShaderGlobals* sg, Matrix44& result,
+                             ustringhash from, float time)
+{
+    return false;
+}
+
+
+
+bool
+RendererServices::get_matrix(ShaderGlobals* sg, Matrix44& result,
+                             ustringhash from)
+{
+    return false;
+}
+
+
+
+bool
 RendererServices::get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
                                      TransformationPtr xform, float time)
 {
@@ -73,8 +91,9 @@ RendererServices::get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
 
 bool
 RendererServices::get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
-                                     ustring to, float time)
+                                     ustringhash to, float time)
 {
+    // return get_inverse_matrix(sg, result, ustring_from(to), time);
     bool ok = get_matrix(sg, result, to, time);
     if (ok)
         result.invert();
@@ -85,8 +104,9 @@ RendererServices::get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
 
 bool
 RendererServices::get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
-                                     ustring to)
+                                     ustringhash to)
 {
+    // return get_inverse_matrix(sg, result, ustring_from(to));
     bool ok = get_matrix(sg, result, to);
     if (ok)
         result.invert();
@@ -95,10 +115,52 @@ RendererServices::get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
 
 
 
-RendererServices::TextureHandle*
-RendererServices::get_texture_handle(ustring filename, ShadingContext* context)
+bool
+RendererServices::transform_points(ShaderGlobals* sg, ustringhash from,
+                                   ustringhash to, float time, const Vec3* Pin,
+                                   Vec3* Pout, int npoints,
+                                   TypeDesc::VECSEMANTICS vectype)
 {
-    return texturesys()->get_texture_handle(filename,
+    return false;
+}
+
+
+
+bool
+RendererServices::get_attribute(ShaderGlobals* sg, bool derivatives,
+                                ustringhash object, TypeDesc type,
+                                ustringhash name, void* val)
+{
+    return false;
+}
+
+
+
+bool
+RendererServices::get_array_attribute(ShaderGlobals* sg, bool derivatives,
+                                      ustringhash object, TypeDesc type,
+                                      ustringhash name, int index, void* val)
+{
+    return false;
+}
+
+
+
+bool
+RendererServices::get_userdata(bool derivatives, ustringhash name,
+                               TypeDesc type, ShaderGlobals* sg, void* val)
+{
+    return false;
+    // return get_userdata(derivatives, ustring_from(name), type, sg, val);
+}
+
+
+
+RendererServices::TextureHandle*
+RendererServices::get_texture_handle(ustringhash filename,
+                                     ShadingContext* context)
+{
+    return texturesys()->get_texture_handle(ustring_from(filename),
                                             context->texture_thread_info());
 }
 
@@ -120,19 +182,19 @@ RendererServices::is_udim(TextureHandle* texture_handle)
 
 
 bool
-RendererServices::texture(ustring filename, TextureHandle* texture_handle,
+RendererServices::texture(ustringhash filename, TextureHandle* texture_handle,
                           TexturePerthread* texture_thread_info,
                           TextureOpt& options, ShaderGlobals* sg, float s,
                           float t, float dsdx, float dtdx, float dsdy,
                           float dtdy, int nchannels, float* result,
                           float* dresultds, float* dresultdt,
-                          ustring* errormessage)
+                          ustringhash* errormessage)
 {
     ShadingContext* context = sg->context;
     if (!texture_thread_info)
         texture_thread_info = context->texture_thread_info();
     if (!texture_handle)
-        texture_handle = texturesys()->get_texture_handle(filename,
+        texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
     bool status = texturesys()->texture(texture_handle, texture_thread_info,
                                         options, s, t, dsdx, dtdx, dsdy, dtdy,
@@ -142,12 +204,12 @@ RendererServices::texture(ustring filename, TextureHandle* texture_handle,
         std::string err = texturesys()->geterror();
         if (err.size() && sg) {
             if (errormessage) {
-                *errormessage = ustring(err);
+                *errormessage = ustringhash(err);
             } else {
                 context->errorfmt("[RendererServices::texture] {}", err);
             }
         } else if (errormessage) {
-            *errormessage = Strings::unknown;
+            *errormessage = ustringhash(Strings::unknown);
         }
     }
     return status;
@@ -156,19 +218,19 @@ RendererServices::texture(ustring filename, TextureHandle* texture_handle,
 
 
 bool
-RendererServices::texture3d(ustring filename, TextureHandle* texture_handle,
+RendererServices::texture3d(ustringhash filename, TextureHandle* texture_handle,
                             TexturePerthread* texture_thread_info,
                             TextureOpt& options, ShaderGlobals* sg,
                             const Vec3& P, const Vec3& dPdx, const Vec3& dPdy,
                             const Vec3& dPdz, int nchannels, float* result,
                             float* dresultds, float* dresultdt,
-                            float* dresultdr, ustring* errormessage)
+                            float* dresultdr, ustringhash* errormessage)
 {
     ShadingContext* context = sg->context;
     if (!texture_thread_info)
         texture_thread_info = context->texture_thread_info();
     if (!texture_handle)
-        texture_handle = texturesys()->get_texture_handle(filename,
+        texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
 
     bool status = texturesys()->texture3d(texture_handle, texture_thread_info,
@@ -179,12 +241,12 @@ RendererServices::texture3d(ustring filename, TextureHandle* texture_handle,
         std::string err = texturesys()->geterror();
         if (err.size() && sg) {
             if (errormessage) {
-                *errormessage = ustring(err);
+                *errormessage = ustringhash(err);
             } else {
                 sg->context->errorfmt("[RendererServices::texture3d] {}", err);
             }
         } else if (errormessage) {
-            *errormessage = Strings::unknown;
+            *errormessage = Strings::unknown.uhash();
         }
     }
     return status;
@@ -193,18 +255,19 @@ RendererServices::texture3d(ustring filename, TextureHandle* texture_handle,
 
 
 bool
-RendererServices::environment(ustring filename, TextureHandle* texture_handle,
+RendererServices::environment(ustringhash filename,
+                              TextureHandle* texture_handle,
                               TexturePerthread* texture_thread_info,
                               TextureOpt& options, ShaderGlobals* sg,
                               const Vec3& R, const Vec3& dRdx, const Vec3& dRdy,
                               int nchannels, float* result, float* dresultds,
-                              float* dresultdt, ustring* errormessage)
+                              float* dresultdt, ustringhash* errormessage)
 {
     ShadingContext* context = sg->context;
     if (!texture_thread_info)
         texture_thread_info = context->texture_thread_info();
     if (!texture_handle)
-        texture_handle = texturesys()->get_texture_handle(filename,
+        texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
     bool status = texturesys()->environment(texture_handle, texture_thread_info,
                                             options, R, dRdx, dRdy, nchannels,
@@ -213,13 +276,13 @@ RendererServices::environment(ustring filename, TextureHandle* texture_handle,
         std::string err = texturesys()->geterror();
         if (err.size() && sg) {
             if (errormessage) {
-                *errormessage = ustring(err);
+                *errormessage = ustringhash(err);
             } else {
                 sg->context->errorfmt("[RendererServices::environment] {}",
                                       err);
             }
         } else if (errormessage) {
-            *errormessage = Strings::unknown;
+            *errormessage = Strings::unknown.uhash();
         }
     }
     return status;
@@ -228,34 +291,35 @@ RendererServices::environment(ustring filename, TextureHandle* texture_handle,
 
 
 bool
-RendererServices::get_texture_info(ustring filename,
+RendererServices::get_texture_info(ustringhash filename,
                                    TextureHandle* texture_handle,
                                    TexturePerthread* texture_thread_info,
                                    ShadingContext* shading_context,
-                                   int subimage, ustring dataname,
+                                   int subimage, ustringhash dataname,
                                    TypeDesc datatype, void* data,
-                                   ustring* errormessage)
+                                   ustringhash* errormessage)
 {
     if (!texture_thread_info)
         texture_thread_info = shading_context->texture_thread_info();
     if (!texture_handle)
-        texture_handle = texturesys()->get_texture_handle(filename,
+        texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
     bool status = texturesys()->get_texture_info(texture_handle,
                                                  texture_thread_info, subimage,
-                                                 dataname, datatype, data);
+                                                 ustring_from(dataname),
+                                                 datatype, data);
     if (!status) {
         std::string err = texturesys()->geterror();
         if (err.size()) {
             if (errormessage) {
-                *errormessage = ustring(err);
+                *errormessage = ustringhash(err);
             } else {
                 shading_context->errorfmt(
                     "[RendererServices::get_texture_info] {}", err);
             }
         } else if (errormessage) {
             // gettextureinfo failed but did not provide an error, so none should be emitted
-            *errormessage = ustring();
+            *errormessage = ustringhash();
         }
     }
     return status;
@@ -265,10 +329,10 @@ RendererServices::get_texture_info(ustring filename,
 
 bool
 RendererServices::get_texture_info(
-    ustring filename, TextureHandle* texture_handle, float s, float t,
+    ustringhash filename, TextureHandle* texture_handle, float s, float t,
     TexturePerthread* texture_thread_info, ShadingContext* shading_context,
-    int subimage, ustring dataname, TypeDesc datatype, void* data,
-    ustring* errormessage)
+    int subimage, ustringhash dataname, TypeDesc datatype, void* data,
+    ustringhash* errormessage)
 {
 #if OIIO_VERSION >= 20307
     // Newer versions of the TextureSystem interface are able to determine the
@@ -276,7 +340,7 @@ RendererServices::get_texture_info(
     if (!texture_thread_info)
         texture_thread_info = shading_context->texture_thread_info();
     if (!texture_handle)
-        texture_handle = texturesys()->get_texture_handle(filename,
+        texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
     if (texturesys()->is_udim(texture_handle)) {
         TextureSystem::TextureHandle* udim_handle
@@ -293,6 +357,27 @@ RendererServices::get_texture_info(
     return get_texture_info(filename, texture_handle, texture_thread_info,
                             shading_context, subimage, dataname, datatype, data,
                             errormessage);
+}
+
+
+
+bool
+RendererServices::trace(TraceOpt& options, ShaderGlobals* sg,
+                        const OSL::Vec3& P, const OSL::Vec3& dPdx,
+                        const OSL::Vec3& dPdy, const OSL::Vec3& R,
+                        const OSL::Vec3& dRdx, const OSL::Vec3& dRdy)
+{
+    return false;
+}
+
+
+
+bool
+RendererServices::getmessage(ShaderGlobals* sg, ustringhash source,
+                             ustringhash name, TypeDesc type, void* val,
+                             bool derivatives)
+{
+    return false;
 }
 
 

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -882,16 +882,16 @@ OptixRaytracer::good(TextureHandle* handle OSL_MAYBE_UNUSED)
 /// Given the name of a texture, return an opaque handle that can be
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
-OptixRaytracer::get_texture_handle(ustring filename OSL_MAYBE_UNUSED,
-                                   ShadingContext* shading_context
-                                       OSL_MAYBE_UNUSED)
+OptixRaytracer::get_texture_handle(ustringhash filename,
+                                   ShadingContext* /*shading_context*/)
 {
     auto itr = m_samplers.find(filename);
     if (itr == m_samplers.end()) {
         // Open image
         OIIO::ImageBuf image;
-        if (!image.init_spec(filename, 0, 0)) {
-            errhandler().errorfmt("Could not load: {}", filename);
+        if (!image.init_spec(ustring_from(filename), 0, 0)) {
+            errhandler().errorfmt("Could not load: {} (hash {})",
+                                  ustring_from(filename), filename);
             return (TextureHandle*)nullptr;
         }
 

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -28,7 +28,7 @@ public:
     uint64_t register_global(const std::string& str, uint64_t value);
     bool fetch_global(const std::string& str, uint64_t* value);
 
-    virtual int supports(string_view feature) const
+    int supports(string_view feature) const override
     {
         if (feature == "OptiX")
             return true;
@@ -38,24 +38,24 @@ public:
     std::string load_ptx_file(string_view filename);
     bool synch_attributes();
 
-    virtual bool init_optix_context(int xres, int yres);
-    virtual bool make_optix_materials();
-    virtual bool finalize_scene();
-    virtual void prepare_render();
-    virtual void warmup();
-    virtual void render(int xres, int yres);
-    virtual void finalize_pixel_buffer();
-    virtual void clear();
+    bool init_optix_context(int xres, int yres);
+    bool make_optix_materials();
+    bool finalize_scene();
+    void prepare_render() override;
+    void warmup() override;
+    void render(int xres, int yres) override;
+    void finalize_pixel_buffer() override;
+    void clear() override;
 
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is a valid texture that can be subsequently
     /// read or sampled.
-    virtual bool good(TextureHandle* handle);
+    bool good(TextureHandle* handle) override;
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle* get_texture_handle(ustring filename,
-                                              ShadingContext* shading_context);
+    TextureHandle* get_texture_handle(ustringhash filename,
+                                      ShadingContext* shading_context) override;
 
     // Easy way to do Optix calls
     optix::Context& optix_ctx() { return m_optix_ctx; }
@@ -93,8 +93,8 @@ private:
                          OptixProgramGroup* pg);
 
     std::string m_materials_ptx;
-    std::unordered_map<OIIO::ustring, optix::TextureSampler> m_samplers;
-    std::unordered_map<OIIO::ustring, uint64_t> m_globals_map;
+    std::unordered_map<ustringhash, optix::TextureSampler> m_samplers;
+    std::unordered_map<ustringhash, uint64_t> m_globals_map;
 };
 
 

--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -441,7 +441,7 @@ SimpleRaytracer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
 
 bool
 SimpleRaytracer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
-                            ustring from, float /*time*/)
+                            ustringhash from, float /*time*/)
 {
     TransformMap::const_iterator found = m_named_xforms.find(from);
     if (found != m_named_xforms.end()) {
@@ -468,7 +468,7 @@ SimpleRaytracer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
 
 bool
 SimpleRaytracer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
-                            ustring from)
+                            ustringhash from)
 {
     // SimpleRaytracer doesn't understand motion blur, so we never fail
     // on account of time-varying transformations.
@@ -485,7 +485,7 @@ SimpleRaytracer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
 
 bool
 SimpleRaytracer::get_inverse_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
-                                    ustring to, float /*time*/)
+                                    ustringhash to, float /*time*/)
 {
     if (to == u_camera || to == u_screen || to == u_NDC || to == u_raster) {
         // clang-format off
@@ -544,15 +544,15 @@ void
 SimpleRaytracer::name_transform(const char* name, const OSL::Matrix44& xform)
 {
     std::shared_ptr<Transformation> M(new OSL::Matrix44(xform));
-    m_named_xforms[ustring(name)] = M;
+    m_named_xforms[ustringhash(name)] = M;
 }
 
 
 
 bool
 SimpleRaytracer::get_array_attribute(ShaderGlobals* sg, bool derivatives,
-                                     ustring object, TypeDesc type,
-                                     ustring name, int index, void* val)
+                                     ustringhash object, TypeDesc type,
+                                     ustringhash name, int index, void* val)
 {
     AttrGetterMap::const_iterator g = m_attr_getters.find(name);
     if (g != m_attr_getters.end()) {
@@ -572,8 +572,8 @@ SimpleRaytracer::get_array_attribute(ShaderGlobals* sg, bool derivatives,
 
 bool
 SimpleRaytracer::get_attribute(ShaderGlobals* sg, bool derivatives,
-                               ustring object, TypeDesc type, ustring name,
-                               void* val)
+                               ustringhash object, TypeDesc type,
+                               ustringhash name, void* val)
 {
     return get_array_attribute(sg, derivatives, object, type, name, -1, val);
 }
@@ -581,7 +581,7 @@ SimpleRaytracer::get_attribute(ShaderGlobals* sg, bool derivatives,
 
 
 bool
-SimpleRaytracer::get_userdata(bool derivatives, ustring name, TypeDesc type,
+SimpleRaytracer::get_userdata(bool derivatives, ustringhash name, TypeDesc type,
                               ShaderGlobals* sg, void* val)
 {
     // Just to illustrate how this works, respect s and t userdata, filled
@@ -612,8 +612,8 @@ SimpleRaytracer::get_userdata(bool derivatives, ustring name, TypeDesc type,
 
 bool
 SimpleRaytracer::get_osl_version(ShaderGlobals* /*sg*/, bool /*derivs*/,
-                                 ustring /*object*/, TypeDesc type,
-                                 ustring /*name*/, void* val)
+                                 ustringhash /*object*/, TypeDesc type,
+                                 ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeInt) {
         ((int*)val)[0] = OSL_VERSION;
@@ -625,8 +625,8 @@ SimpleRaytracer::get_osl_version(ShaderGlobals* /*sg*/, bool /*derivs*/,
 
 bool
 SimpleRaytracer::get_camera_resolution(ShaderGlobals* /*sg*/, bool /*derivs*/,
-                                       ustring /*object*/, TypeDesc type,
-                                       ustring /*name*/, void* val)
+                                       ustringhash /*object*/, TypeDesc type,
+                                       ustringhash /*name*/, void* val)
 {
     if (type == TypeIntArray2) {
         ((int*)val)[0] = camera.xres;
@@ -639,8 +639,8 @@ SimpleRaytracer::get_camera_resolution(ShaderGlobals* /*sg*/, bool /*derivs*/,
 
 bool
 SimpleRaytracer::get_camera_projection(ShaderGlobals* /*sg*/, bool /*derivs*/,
-                                       ustring /*object*/, TypeDesc type,
-                                       ustring /*name*/, void* val)
+                                       ustringhash /*object*/, TypeDesc type,
+                                       ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeString) {
         ((ustring*)val)[0] = m_projection;
@@ -652,8 +652,8 @@ SimpleRaytracer::get_camera_projection(ShaderGlobals* /*sg*/, bool /*derivs*/,
 
 bool
 SimpleRaytracer::get_camera_fov(ShaderGlobals* /*sg*/, bool derivs,
-                                ustring /*object*/, TypeDesc type,
-                                ustring /*name*/, void* val)
+                                ustringhash /*object*/, TypeDesc type,
+                                ustringhash /*name*/, void* val)
 {
     // N.B. in a real renderer, this may be time-dependent
     if (type == TypeDesc::TypeFloat) {
@@ -668,8 +668,8 @@ SimpleRaytracer::get_camera_fov(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRaytracer::get_camera_pixelaspect(ShaderGlobals* /*sg*/, bool derivs,
-                                        ustring /*object*/, TypeDesc type,
-                                        ustring /*name*/, void* val)
+                                        ustringhash /*object*/, TypeDesc type,
+                                        ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_pixelaspect;
@@ -683,8 +683,8 @@ SimpleRaytracer::get_camera_pixelaspect(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRaytracer::get_camera_clip(ShaderGlobals* /*sg*/, bool derivs,
-                                 ustring /*object*/, TypeDesc type,
-                                 ustring /*name*/, void* val)
+                                 ustringhash /*object*/, TypeDesc type,
+                                 ustringhash /*name*/, void* val)
 {
     if (type == TypeFloatArray2) {
         ((float*)val)[0] = m_hither;
@@ -699,8 +699,8 @@ SimpleRaytracer::get_camera_clip(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRaytracer::get_camera_clip_near(ShaderGlobals* /*sg*/, bool derivs,
-                                      ustring /*object*/, TypeDesc type,
-                                      ustring /*name*/, void* val)
+                                      ustringhash /*object*/, TypeDesc type,
+                                      ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_hither;
@@ -714,8 +714,8 @@ SimpleRaytracer::get_camera_clip_near(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRaytracer::get_camera_clip_far(ShaderGlobals* /*sg*/, bool derivs,
-                                     ustring /*object*/, TypeDesc type,
-                                     ustring /*name*/, void* val)
+                                     ustringhash /*object*/, TypeDesc type,
+                                     ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_yon;
@@ -730,8 +730,8 @@ SimpleRaytracer::get_camera_clip_far(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRaytracer::get_camera_shutter(ShaderGlobals* /*sg*/, bool derivs,
-                                    ustring /*object*/, TypeDesc type,
-                                    ustring /*name*/, void* val)
+                                    ustringhash /*object*/, TypeDesc type,
+                                    ustringhash /*name*/, void* val)
 {
     if (type == TypeFloatArray2) {
         ((float*)val)[0] = m_shutter[0];
@@ -746,8 +746,8 @@ SimpleRaytracer::get_camera_shutter(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRaytracer::get_camera_shutter_open(ShaderGlobals* /*sg*/, bool derivs,
-                                         ustring /*object*/, TypeDesc type,
-                                         ustring /*name*/, void* val)
+                                         ustringhash /*object*/, TypeDesc type,
+                                         ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_shutter[0];
@@ -761,8 +761,8 @@ SimpleRaytracer::get_camera_shutter_open(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRaytracer::get_camera_shutter_close(ShaderGlobals* /*sg*/, bool derivs,
-                                          ustring /*object*/, TypeDesc type,
-                                          ustring /*name*/, void* val)
+                                          ustringhash /*object*/, TypeDesc type,
+                                          ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_shutter[1];
@@ -776,8 +776,8 @@ SimpleRaytracer::get_camera_shutter_close(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRaytracer::get_camera_screen_window(ShaderGlobals* /*sg*/, bool derivs,
-                                          ustring /*object*/, TypeDesc type,
-                                          ustring /*name*/, void* val)
+                                          ustringhash /*object*/, TypeDesc type,
+                                          ustringhash /*name*/, void* val)
 {
     // N.B. in a real renderer, this may be time-dependent
     if (type == TypeFloatArray4) {

--- a/src/testrender/simpleraytracer.h
+++ b/src/testrender/simpleraytracer.h
@@ -30,23 +30,23 @@ public:
     virtual ~SimpleRaytracer() {}
 
     // RendererServices support:
-    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
-                            TransformationPtr xform, float time);
-    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result, ustring from,
-                            float time);
-    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
-                            TransformationPtr xform);
-    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result, ustring from);
-    virtual bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
-                                    ustring to, float time);
-    virtual bool get_array_attribute(ShaderGlobals* sg, bool derivatives,
-                                     ustring object, TypeDesc type,
-                                     ustring name, int index, void* val);
-    virtual bool get_attribute(ShaderGlobals* sg, bool derivatives,
-                               ustring object, TypeDesc type, ustring name,
-                               void* val);
-    virtual bool get_userdata(bool derivatives, ustring name, TypeDesc type,
-                              ShaderGlobals* sg, void* val);
+    bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                    TransformationPtr xform, float time) override;
+    bool get_matrix(ShaderGlobals* sg, Matrix44& result, ustringhash from,
+                    float time) override;
+    bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                    TransformationPtr xform) override;
+    bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                    ustringhash from) override;
+    bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result, ustringhash to,
+                            float time) override;
+    bool get_array_attribute(ShaderGlobals* sg, bool derivatives,
+                             ustringhash object, TypeDesc type,
+                             ustringhash name, int index, void* val) override;
+    bool get_attribute(ShaderGlobals* sg, bool derivatives, ustringhash object,
+                       TypeDesc type, ustringhash name, void* val) override;
+    bool get_userdata(bool derivatives, ustringhash name, TypeDesc type,
+                      ShaderGlobals* sg, void* val) override;
 
     void name_transform(const char* name, const Transformation& xform);
 
@@ -121,7 +121,7 @@ private:
     bool m_had_error = false;
 
     // Named transforms
-    typedef std::map<ustring, std::shared_ptr<Transformation>> TransformMap;
+    typedef std::map<ustringhash, std::shared_ptr<Transformation>> TransformMap;
     TransformMap m_named_xforms;
 
     // Attribute and userdata retrieval -- for fast dispatch, use a hash
@@ -130,38 +130,44 @@ private:
     // renderer, we would encourage benchmarking various methods and
     // alternate data structures.
     typedef bool (SimpleRaytracer::*AttrGetter)(ShaderGlobals* sg, bool derivs,
-                                                ustring object, TypeDesc type,
-                                                ustring name, void* val);
-    typedef std::unordered_map<ustring, AttrGetter> AttrGetterMap;
+                                                ustringhash object,
+                                                TypeDesc type, ustringhash name,
+                                                void* val);
+    typedef std::unordered_map<ustringhash, AttrGetter> AttrGetterMap;
     AttrGetterMap m_attr_getters;
 
     // Attribute getters
-    bool get_osl_version(ShaderGlobals* sg, bool derivs, ustring object,
-                         TypeDesc type, ustring name, void* val);
-    bool get_camera_resolution(ShaderGlobals* sg, bool derivs, ustring object,
-                               TypeDesc type, ustring name, void* val);
-    bool get_camera_projection(ShaderGlobals* sg, bool derivs, ustring object,
-                               TypeDesc type, ustring name, void* val);
-    bool get_camera_fov(ShaderGlobals* sg, bool derivs, ustring object,
-                        TypeDesc type, ustring name, void* val);
-    bool get_camera_pixelaspect(ShaderGlobals* sg, bool derivs, ustring object,
-                                TypeDesc type, ustring name, void* val);
-    bool get_camera_clip(ShaderGlobals* sg, bool derivs, ustring object,
-                         TypeDesc type, ustring name, void* val);
-    bool get_camera_clip_near(ShaderGlobals* sg, bool derivs, ustring object,
-                              TypeDesc type, ustring name, void* val);
-    bool get_camera_clip_far(ShaderGlobals* sg, bool derivs, ustring object,
-                             TypeDesc type, ustring name, void* val);
-    bool get_camera_shutter(ShaderGlobals* sg, bool derivs, ustring object,
-                            TypeDesc type, ustring name, void* val);
-    bool get_camera_shutter_open(ShaderGlobals* sg, bool derivs, ustring object,
-                                 TypeDesc type, ustring name, void* val);
+    bool get_osl_version(ShaderGlobals* sg, bool derivs, ustringhash object,
+                         TypeDesc type, ustringhash name, void* val);
+    bool get_camera_resolution(ShaderGlobals* sg, bool derivs,
+                               ustringhash object, TypeDesc type,
+                               ustringhash name, void* val);
+    bool get_camera_projection(ShaderGlobals* sg, bool derivs,
+                               ustringhash object, TypeDesc type,
+                               ustringhash name, void* val);
+    bool get_camera_fov(ShaderGlobals* sg, bool derivs, ustringhash object,
+                        TypeDesc type, ustringhash name, void* val);
+    bool get_camera_pixelaspect(ShaderGlobals* sg, bool derivs,
+                                ustringhash object, TypeDesc type,
+                                ustringhash name, void* val);
+    bool get_camera_clip(ShaderGlobals* sg, bool derivs, ustringhash object,
+                         TypeDesc type, ustringhash name, void* val);
+    bool get_camera_clip_near(ShaderGlobals* sg, bool derivs,
+                              ustringhash object, TypeDesc type,
+                              ustringhash name, void* val);
+    bool get_camera_clip_far(ShaderGlobals* sg, bool derivs, ustringhash object,
+                             TypeDesc type, ustringhash name, void* val);
+    bool get_camera_shutter(ShaderGlobals* sg, bool derivs, ustringhash object,
+                            TypeDesc type, ustringhash name, void* val);
+    bool get_camera_shutter_open(ShaderGlobals* sg, bool derivs,
+                                 ustringhash object, TypeDesc type,
+                                 ustringhash name, void* val);
     bool get_camera_shutter_close(ShaderGlobals* sg, bool derivs,
-                                  ustring object, TypeDesc type, ustring name,
-                                  void* val);
+                                  ustringhash object, TypeDesc type,
+                                  ustringhash name, void* val);
     bool get_camera_screen_window(ShaderGlobals* sg, bool derivs,
-                                  ustring object, TypeDesc type, ustring name,
-                                  void* val);
+                                  ustringhash object, TypeDesc type,
+                                  ustringhash name, void* val);
 
     // CPU renderer helpers
     void globals_from_hit(ShaderGlobals& sg, const Ray& r,

--- a/src/testshade/batched_simplerend.cpp
+++ b/src/testshade/batched_simplerend.cpp
@@ -195,7 +195,7 @@ template<int WidthT>
 typename BatchedSimpleRenderer<WidthT>::Mask
 BatchedSimpleRenderer<WidthT>::get_matrix(BatchedShaderGlobals* /*bsg*/,
                                           Masked<Matrix44> wresult,
-                                          ustring from,
+                                          ustringhash from,
                                           Wide<const float> /*wtime*/)
 {
     auto found = m_sr.m_named_xforms.find(from);
@@ -219,14 +219,14 @@ template<int WidthT>
 typename BatchedSimpleRenderer<WidthT>::Mask
 BatchedSimpleRenderer<WidthT>::get_matrix(BatchedShaderGlobals* /*bsg*/,
                                           Masked<Matrix44> wresult,
-                                          Wide<const ustring> wfrom,
+                                          Wide<const ustringhash> wfrom,
                                           Wide<const float> /*wtime*/)
 {
     Mask succeeded(false);
     wresult.mask().template foreach<1 /*MinOccupancyT*/>(
         [&](ActiveLane lane) -> void {
-            ustring from = wfrom[lane];
-            auto found   = m_sr.m_named_xforms.find(from);
+            ustringhash from = wfrom[lane];
+            auto found       = m_sr.m_named_xforms.find(from);
             if (found != m_sr.m_named_xforms.end()) {
                 const Matrix44& transform = *(found->second);
                 wresult[lane]             = transform;
@@ -242,7 +242,7 @@ template<int WidthT>
 template<typename RAccessorT>
 bool
 BatchedSimpleRenderer<WidthT>::impl_get_inverse_matrix(RAccessorT& result,
-                                                       ustring to) const
+                                                       ustringhash to) const
 {
     if (to == ucache().camera || to == ucache().screen || to == ucache().NDC
         || to == ucache().raster) {
@@ -304,7 +304,7 @@ template<int WidthT>
 typename BatchedSimpleRenderer<WidthT>::Mask
 BatchedSimpleRenderer<WidthT>::get_inverse_matrix(BatchedShaderGlobals* bsg,
                                                   Masked<Matrix44> result,
-                                                  ustring to,
+                                                  ustringhash to,
                                                   Wide<const float> time)
 {
     Matrix44 scalar_result;
@@ -326,7 +326,7 @@ template<int WidthT>
 typename BatchedSimpleRenderer<WidthT>::Mask
 BatchedSimpleRenderer<WidthT>::get_inverse_matrix(BatchedShaderGlobals* bsg,
                                                   Masked<Matrix44> wResult,
-                                                  Wide<const ustring> wTo,
+                                                  Wide<const ustringhash> wTo,
                                                   Wide<const float> wTime)
 
 {
@@ -334,8 +334,8 @@ BatchedSimpleRenderer<WidthT>::get_inverse_matrix(BatchedShaderGlobals* bsg,
 
     for (int i = 0; i < WidthT; ++i) {
         if (wResult.mask()[i]) {
-            ustring to  = wTo[i];
-            auto result = wResult[i];
+            ustringhash to = wTo[i];
+            auto result    = wResult[i];
             if (impl_get_inverse_matrix(result, to)) {
                 status.set_on(i);
             }
@@ -391,31 +391,32 @@ BatchedSimpleRenderer<WidthT>::trace(
 template<int WidthT>
 void
 BatchedSimpleRenderer<WidthT>::getmessage(BatchedShaderGlobals* bsg,
-                                          Masked<int> result, ustring source,
-                                          ustring name, MaskedData val)
+                                          Masked<int> result,
+                                          ustringhash source, ustringhash name,
+                                          MaskedData val)
 {
-    OSL_ASSERT(source == ustring("trace"));
+    OSL_ASSERT(source == "trace");
     for (int lane = 0; lane < WidthT; ++lane) {
         if (bsg->varying.u[lane] > 0.5) {
-            if (name == ustring("hitdist")) {
+            if (name == "hitdist") {
                 if (Masked<float>::is(val)) {
                     Masked<float> dest(val);
                     dest[lane] = 0.5;
                 }
             }
-            if (name == ustring("hit")) {
+            if (name == "hit") {
                 if (Masked<int>::is(val)) {
                     Masked<int> dest(val);
                     dest[lane] = 1;
                 }
             }
-            if (name == ustring("geom:name")) {
+            if (name == "geom:name") {
                 if (Masked<ustring>::is(val)) {
                     Masked<ustring> dest(val);
                     dest[lane] = ustring("teapot");
                 }
             }
-            if (name == ustring("N")) {
+            if (name == "N") {
                 if (Masked<Vec3>::is(val)) {
                     Masked<Vec3> dest(val);
                     dest[lane] = Vec3(1.0 - bsg->varying.v[lane], 0.25,
@@ -427,7 +428,7 @@ BatchedSimpleRenderer<WidthT>::getmessage(BatchedShaderGlobals* bsg,
 
             result[lane] = 1;
         } else {
-            if (name == ustring("hit")) {
+            if (name == "hit") {
                 if (Masked<int>::is(val)) {
                     Masked<int> dest(val);
                     dest[lane] = 0;
@@ -444,8 +445,9 @@ BatchedSimpleRenderer<WidthT>::getmessage(BatchedShaderGlobals* bsg,
 template<int WidthT>
 typename BatchedSimpleRenderer<WidthT>::Mask
 BatchedSimpleRenderer<WidthT>::get_array_attribute(BatchedShaderGlobals* bsg,
-                                                   ustring object, ustring name,
-                                                   int index, MaskedData val)
+                                                   ustringhash object,
+                                                   ustringhash name, int index,
+                                                   MaskedData val)
 {
     // Normally the common_get_attribute would be for is_attribute_uniform() == true only
     // However a name that has a uniform answer could be part of a varying name inside
@@ -551,8 +553,8 @@ BatchedSimpleRenderer<WidthT>::get_array_attribute(BatchedShaderGlobals* bsg,
 template<int WidthT>
 typename BatchedSimpleRenderer<WidthT>::Mask
 BatchedSimpleRenderer<WidthT>::get_attribute(BatchedShaderGlobals* bsg,
-                                             ustring object, ustring name,
-                                             MaskedData val)
+                                             ustringhash object,
+                                             ustringhash name, MaskedData val)
 {
     return get_array_attribute(bsg, object, name, -1, val);
 }
@@ -562,7 +564,7 @@ BatchedSimpleRenderer<WidthT>::get_attribute(BatchedShaderGlobals* bsg,
 template<int WidthT>
 bool
 BatchedSimpleRenderer<WidthT>::get_array_attribute_uniform(
-    BatchedShaderGlobals* bsg, ustring object, ustring name, int index,
+    BatchedShaderGlobals* bsg, ustringhash object, ustringhash name, int index,
     RefData val)
 {
     ASSERT(!name.empty());
@@ -617,8 +619,9 @@ BatchedSimpleRenderer<WidthT>::get_array_attribute_uniform(
 template<int WidthT>
 bool
 BatchedSimpleRenderer<WidthT>::get_attribute_uniform(BatchedShaderGlobals* bsg,
-                                                     ustring object,
-                                                     ustring name, RefData val)
+                                                     ustringhash object,
+                                                     ustringhash name,
+                                                     RefData val)
 {
     return get_array_attribute_uniform(bsg, object, name, -1, val);
 }
@@ -627,7 +630,7 @@ BatchedSimpleRenderer<WidthT>::get_attribute_uniform(BatchedShaderGlobals* bsg,
 
 template<int WidthT>
 typename BatchedSimpleRenderer<WidthT>::Mask
-BatchedSimpleRenderer<WidthT>::get_userdata(ustring name,
+BatchedSimpleRenderer<WidthT>::get_userdata(ustringhash name,
                                             BatchedShaderGlobals* bsg,
                                             MaskedData val)
 {
@@ -746,8 +749,8 @@ assign_and_zero_derivs(MaskedData<WidthT> data, const DataT& val)
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_osl_version(ustring /*object*/,
-                                               ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_osl_version(ustringhash /*object*/,
+                                               ustringhash /*name*/,
                                                RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, int(OSL_VERSION));
@@ -758,8 +761,8 @@ BatchedSimpleRenderer<WidthT>::get_osl_version(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_resolution(ustring /*object*/,
-                                                     ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_resolution(ustringhash /*object*/,
+                                                     ustringhash /*name*/,
                                                      RefOrMaskedT data)
 {
     int res[2] = { m_sr.m_xres, m_sr.m_yres };
@@ -771,8 +774,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_resolution(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_projection(ustring /*object*/,
-                                                     ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_projection(ustringhash /*object*/,
+                                                     ustringhash /*name*/,
                                                      RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, m_sr.m_projection);
@@ -783,8 +786,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_projection(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_fov(ustring /*object*/,
-                                              ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_fov(ustringhash /*object*/,
+                                              ustringhash /*name*/,
                                               RefOrMaskedT data)
 {
     // N.B. in a real renderer, this may be time-dependent
@@ -796,8 +799,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_fov(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_pixelaspect(ustring /*object*/,
-                                                      ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_pixelaspect(ustringhash /*object*/,
+                                                      ustringhash /*name*/,
                                                       RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, m_sr.m_pixelaspect);
@@ -808,8 +811,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_pixelaspect(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_clip(ustring /*object*/,
-                                               ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_clip(ustringhash /*object*/,
+                                               ustringhash /*name*/,
                                                RefOrMaskedT data)
 {
     float clip[2] = { m_sr.m_hither, m_sr.m_yon };
@@ -821,8 +824,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_clip(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_clip_near(ustring /*object*/,
-                                                    ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_clip_near(ustringhash /*object*/,
+                                                    ustringhash /*name*/,
                                                     RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, m_sr.m_hither);
@@ -833,8 +836,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_clip_near(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_clip_far(ustring /*object*/,
-                                                   ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_clip_far(ustringhash /*object*/,
+                                                   ustringhash /*name*/,
                                                    RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, m_sr.m_yon);
@@ -845,8 +848,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_clip_far(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_shutter(ustring /*object*/,
-                                                  ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_shutter(ustringhash /*object*/,
+                                                  ustringhash /*name*/,
                                                   RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, m_sr.m_shutter);
@@ -857,8 +860,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_shutter(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_shutter_open(ustring /*object*/,
-                                                       ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_shutter_open(ustringhash /*object*/,
+                                                       ustringhash /*name*/,
                                                        RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, m_sr.m_shutter[0]);
@@ -869,8 +872,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_shutter_open(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_shutter_close(ustring /*object*/,
-                                                        ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_shutter_close(ustringhash /*object*/,
+                                                        ustringhash /*name*/,
                                                         RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, m_sr.m_shutter[1]);
@@ -881,8 +884,8 @@ BatchedSimpleRenderer<WidthT>::get_camera_shutter_close(ustring /*object*/,
 template<int WidthT>
 template<typename RefOrMaskedT>
 bool
-BatchedSimpleRenderer<WidthT>::get_camera_screen_window(ustring /*object*/,
-                                                        ustring /*name*/,
+BatchedSimpleRenderer<WidthT>::get_camera_screen_window(ustringhash /*object*/,
+                                                        ustringhash /*name*/,
                                                         RefOrMaskedT data)
 {
     return assign_and_zero_derivs(data, m_sr.m_screen_window);

--- a/src/testshade/batched_simplerend.h
+++ b/src/testshade/batched_simplerend.h
@@ -37,25 +37,26 @@ public:
     }
 
     Mask get_matrix(BatchedShaderGlobals* bsg, Masked<Matrix44> result,
-                    ustring from, Wide<const float> time) override;
+                    ustringhash from, Wide<const float> time) override;
     Mask get_matrix(BatchedShaderGlobals* bsg, Masked<Matrix44> result,
-                    Wide<const ustring> from, Wide<const float> time) override;
+                    Wide<const ustringhash> from,
+                    Wide<const float> time) override;
     bool is_overridden_get_matrix_WmWsWf() const override { return true; }
 
 private:
     template<typename RAccessorT>
     OSL_FORCEINLINE bool impl_get_inverse_matrix(RAccessorT& result,
-                                                 ustring to) const;
+                                                 ustringhash to) const;
 
 public:
     Mask get_inverse_matrix(BatchedShaderGlobals* bsg, Masked<Matrix44> result,
-                            ustring to, Wide<const float> time) override;
+                            ustringhash to, Wide<const float> time) override;
     bool is_overridden_get_inverse_matrix_WmsWf() const override
     {
         return true;
     }
     Mask get_inverse_matrix(BatchedShaderGlobals* bsg, Masked<Matrix44> result,
-                            Wide<const ustring> to,
+                            Wide<const ustringhash> to,
                             Wide<const float> time) override;
     bool is_overridden_get_inverse_matrix_WmWsWf() const override
     {
@@ -65,21 +66,22 @@ public:
 
     bool is_attribute_uniform(ustring object, ustring name) override;
 
-    Mask get_array_attribute(BatchedShaderGlobals* bsg, ustring object,
-                             ustring name, int index, MaskedData amd) override;
+    Mask get_array_attribute(BatchedShaderGlobals* bsg, ustringhash object,
+                             ustringhash name, int index,
+                             MaskedData amd) override;
 
-    Mask get_attribute(BatchedShaderGlobals* bsg, ustring object, ustring name,
-                       MaskedData amd) override;
+    Mask get_attribute(BatchedShaderGlobals* bsg, ustringhash object,
+                       ustringhash name, MaskedData amd) override;
 
 
-    bool get_array_attribute_uniform(BatchedShaderGlobals* bsg, ustring object,
-                                     ustring name, int index,
-                                     RefData val) override;
+    bool get_array_attribute_uniform(BatchedShaderGlobals* bsg,
+                                     ustringhash object, ustringhash name,
+                                     int index, RefData val) override;
 
-    bool get_attribute_uniform(BatchedShaderGlobals* bsg, ustring object,
-                               ustring name, RefData val) override;
+    bool get_attribute_uniform(BatchedShaderGlobals* bsg, ustringhash object,
+                               ustringhash name, RefData val) override;
 
-    Mask get_userdata(ustring name, BatchedShaderGlobals* bsg,
+    Mask get_userdata(ustringhash name, BatchedShaderGlobals* bsg,
                       MaskedData val) override;
 
     bool is_overridden_texture() const override { return false; }
@@ -95,7 +97,8 @@ public:
                Wide<const Vec3> dRdy) override;
 
     void getmessage(BatchedShaderGlobals* bsg, Masked<int> result,
-                    ustring source, ustring name, MaskedData val) override;
+                    ustringhash source, ustringhash name,
+                    MaskedData val) override;
 
 private:
     SimpleRenderer& m_sr;
@@ -107,46 +110,56 @@ private:
     // imagine this to be fairly quick, but for a performance-critical
     // renderer, we would encourage benchmarking various methods and
     // alternate data structures.
-    typedef bool (BatchedSimpleRenderer::*VaryingAttrGetter)(ustring object,
-                                                             ustring name,
+    typedef bool (BatchedSimpleRenderer::*VaryingAttrGetter)(ustringhash object,
+                                                             ustringhash name,
                                                              MaskedData val);
-    typedef std::unordered_map<ustring, VaryingAttrGetter> VaryingAttrGetterMap;
+    typedef std::unordered_map<ustringhash, VaryingAttrGetter>
+        VaryingAttrGetterMap;
     VaryingAttrGetterMap m_varying_attr_getters;
 
-    typedef bool (BatchedSimpleRenderer::*UniformAttrGetter)(ustring object,
-                                                             ustring name,
+    typedef bool (BatchedSimpleRenderer::*UniformAttrGetter)(ustringhash object,
+                                                             ustringhash name,
                                                              RefData val);
-    typedef std::unordered_map<ustring, UniformAttrGetter> UniformAttrGetterMap;
+    typedef std::unordered_map<ustringhash, UniformAttrGetter>
+        UniformAttrGetterMap;
     UniformAttrGetterMap m_uniform_attr_getters;
 
     // Attribute getters
     template<typename RefOrMaskedT>
-    bool get_osl_version(ustring object, ustring name, RefOrMaskedT data);
+    bool get_osl_version(ustringhash object, ustringhash name,
+                         RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_resolution(ustring object, ustring name, RefOrMaskedT data);
+    bool get_camera_resolution(ustringhash object, ustringhash name,
+                               RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_projection(ustring object, ustring name, RefOrMaskedT data);
+    bool get_camera_projection(ustringhash object, ustringhash name,
+                               RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_fov(ustring object, ustring name, RefOrMaskedT data);
+    bool get_camera_fov(ustringhash object, ustringhash name,
+                        RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_pixelaspect(ustring object, ustring name,
+    bool get_camera_pixelaspect(ustringhash object, ustringhash name,
                                 RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_clip(ustring object, ustring name, RefOrMaskedT data);
+    bool get_camera_clip(ustringhash object, ustringhash name,
+                         RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_clip_near(ustring object, ustring name, RefOrMaskedT data);
+    bool get_camera_clip_near(ustringhash object, ustringhash name,
+                              RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_clip_far(ustring object, ustring name, RefOrMaskedT data);
+    bool get_camera_clip_far(ustringhash object, ustringhash name,
+                             RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_shutter(ustring object, ustring name, RefOrMaskedT data);
+    bool get_camera_shutter(ustringhash object, ustringhash name,
+                            RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_shutter_open(ustring object, ustring name,
+    bool get_camera_shutter_open(ustringhash object, ustringhash name,
                                  RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_shutter_close(ustring object, ustring name,
+    bool get_camera_shutter_close(ustringhash object, ustringhash name,
                                   RefOrMaskedT data);
     template<typename RefOrMaskedT>
-    bool get_camera_screen_window(ustring object, ustring name,
+    bool get_camera_screen_window(ustringhash object, ustringhash name,
                                   RefOrMaskedT data);
 };
 

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -684,16 +684,16 @@ OptixGridRenderer::good(TextureHandle* handle OSL_MAYBE_UNUSED)
 /// Given the name of a texture, return an opaque handle that can be
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
-OptixGridRenderer::get_texture_handle(ustring filename OSL_MAYBE_UNUSED,
-                                      ShadingContext* shading_context
-                                          OSL_MAYBE_UNUSED)
+OptixGridRenderer::get_texture_handle(ustringhash filename,
+                                      ShadingContext* /*shading_context*/)
 {
     auto itr = m_samplers.find(filename);
     if (itr == m_samplers.end()) {
         // Open image
         OIIO::ImageBuf image;
-        if (!image.init_spec(filename, 0, 0)) {
-            errhandler().errorfmt("Could not load: {}", filename);
+        if (!image.init_spec(ustring_from(filename), 0, 0)) {
+            errhandler().errorfmt("Could not load: {} (hash {})",
+                                  ustring_from(filename), filename);
             return (TextureHandle*)nullptr;
         }
 

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -28,7 +28,7 @@ public:
     uint64_t register_global(const std::string& str, uint64_t value);
     bool fetch_global(const std::string& str, uint64_t* value);
 
-    virtual int supports(string_view feature) const
+    int supports(string_view feature) const override
     {
         if (feature == "OptiX")
             return true;
@@ -38,15 +38,15 @@ public:
     std::string load_ptx_file(string_view filename);
     bool synch_attributes();
 
-    virtual void init_shadingsys(ShadingSystem* ss);
-    virtual bool init_optix_context(int xres, int yres);
-    virtual bool make_optix_materials();
-    virtual bool finalize_scene();
-    virtual void prepare_render();
-    virtual void warmup();
-    virtual void render(int xres, int yres);
-    virtual void finalize_pixel_buffer();
-    virtual void clear();
+    void init_shadingsys(ShadingSystem* ss) final;
+    bool init_optix_context(int xres, int yres);
+    bool make_optix_materials();
+    bool finalize_scene();
+    void prepare_render() final;
+    void warmup() final;
+    void render(int xres, int yres) final;
+    void finalize_pixel_buffer() final;
+    void clear() final;
 
     virtual void set_transforms(const OSL::Matrix44& object2common,
                                 const OSL::Matrix44& shader2common);
@@ -56,12 +56,12 @@ public:
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is a valid texture that can be subsequently
     /// read or sampled.
-    virtual bool good(TextureHandle* handle);
+    bool good(TextureHandle* handle) override;
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle* get_texture_handle(ustring filename,
-                                              ShadingContext* shading_context);
+    TextureHandle* get_texture_handle(ustringhash filename,
+                                      ShadingContext* shading_context) override;
 
     OptixDeviceContext optix_ctx() { return m_optix_ctx; }
     OptixDeviceContext context() { return m_optix_ctx; }
@@ -90,8 +90,8 @@ private:
     const unsigned long OSL_PRINTF_BUFFER_SIZE = 8 * 1024 * 1024;
 
     std::string m_materials_ptx;
-    std::unordered_map<OIIO::ustring, optix::TextureSampler> m_samplers;
-    std::unordered_map<OIIO::ustring, uint64_t> m_globals_map;
+    std::unordered_map<ustringhash, optix::TextureSampler> m_samplers;
+    std::unordered_map<ustringhash, uint64_t> m_globals_map;
 
     OSL::Matrix44 m_shader2common;  // "shader" space to "common" space matrix
     OSL::Matrix44 m_object2common;  // "object" space to "common" space matrix

--- a/src/testshade/simplerend.cpp
+++ b/src/testshade/simplerend.cpp
@@ -310,7 +310,7 @@ SimpleRenderer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
 
 bool
 SimpleRenderer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
-                           ustring from, float /*time*/)
+                           ustringhash from, float /*time*/)
 {
     TransformMap::const_iterator found = m_named_xforms.find(from);
     if (found != m_named_xforms.end()) {
@@ -337,7 +337,7 @@ SimpleRenderer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
 
 bool
 SimpleRenderer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
-                           ustring from)
+                           ustringhash from)
 {
     // SimpleRenderer doesn't understand motion blur, so we never fail
     // on account of time-varying transformations.
@@ -354,7 +354,7 @@ SimpleRenderer::get_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
 
 bool
 SimpleRenderer::get_inverse_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
-                                   ustring to, float /*time*/)
+                                   ustringhash to, float /*time*/)
 {
     if (to == u_camera || to == u_screen || to == u_NDC || to == u_raster) {
         Matrix44 M = m_world_to_camera;
@@ -408,15 +408,15 @@ void
 SimpleRenderer::name_transform(const char* name, const OSL::Matrix44& xform)
 {
     std::shared_ptr<Transformation> M(new OSL::Matrix44(xform));
-    m_named_xforms[ustring(name)] = M;
+    m_named_xforms[ustringhash(name)] = M;
 }
 
 
 
 bool
 SimpleRenderer::get_array_attribute(ShaderGlobals* sg, bool derivatives,
-                                    ustring object, TypeDesc type, ustring name,
-                                    int index, void* val)
+                                    ustringhash object, TypeDesc type,
+                                    ustringhash name, int index, void* val)
 {
     AttrGetterMap::const_iterator g = m_attr_getters.find(name);
     if (g != m_attr_getters.end()) {
@@ -444,8 +444,8 @@ SimpleRenderer::get_array_attribute(ShaderGlobals* sg, bool derivatives,
 
 bool
 SimpleRenderer::get_attribute(ShaderGlobals* sg, bool derivatives,
-                              ustring object, TypeDesc type, ustring name,
-                              void* val)
+                              ustringhash object, TypeDesc type,
+                              ustringhash name, void* val)
 {
     return get_array_attribute(sg, derivatives, object, type, name, -1, val);
 }
@@ -453,7 +453,7 @@ SimpleRenderer::get_attribute(ShaderGlobals* sg, bool derivatives,
 
 
 bool
-SimpleRenderer::get_userdata(bool derivatives, ustring name, TypeDesc type,
+SimpleRenderer::get_userdata(bool derivatives, ustringhash name, TypeDesc type,
                              ShaderGlobals* sg, void* val)
 {
     // Just to illustrate how this works, respect s and t userdata, filled
@@ -508,10 +508,14 @@ SimpleRenderer::trace(TraceOpt& options, ShaderGlobals* sg, const OSL::Vec3& P,
     }
 }
 
+
 bool
-SimpleRenderer::getmessage(ShaderGlobals* sg, ustring source, ustring name,
-                           TypeDesc type, void* val, bool derivatives)
+SimpleRenderer::getmessage(ShaderGlobals* sg, ustringhash source_,
+                           ustringhash name_, TypeDesc type, void* val,
+                           bool derivatives)
 {
+    ustring source = ustring_from(source_);
+    ustring name   = ustring_from(name_);
     OSL_ASSERT(source == ustring("trace"));
     // Don't have any real ray tracing results
     // so just fill in some repeatable values for testsuite
@@ -552,10 +556,11 @@ SimpleRenderer::getmessage(ShaderGlobals* sg, ustring source, ustring name,
 }
 
 
+
 bool
 SimpleRenderer::get_osl_version(ShaderGlobals* /*sg*/, bool /*derivs*/,
-                                ustring /*object*/, TypeDesc type,
-                                ustring /*name*/, void* val)
+                                ustringhash /*object*/, TypeDesc type,
+                                ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeInt) {
         ((int*)val)[0] = OSL_VERSION;
@@ -567,8 +572,8 @@ SimpleRenderer::get_osl_version(ShaderGlobals* /*sg*/, bool /*derivs*/,
 
 bool
 SimpleRenderer::get_camera_resolution(ShaderGlobals* /*sg*/, bool /*derivs*/,
-                                      ustring /*object*/, TypeDesc type,
-                                      ustring /*name*/, void* val)
+                                      ustringhash /*object*/, TypeDesc type,
+                                      ustringhash /*name*/, void* val)
 {
     if (type == TypeIntArray2) {
         ((int*)val)[0] = m_xres;
@@ -581,8 +586,8 @@ SimpleRenderer::get_camera_resolution(ShaderGlobals* /*sg*/, bool /*derivs*/,
 
 bool
 SimpleRenderer::get_camera_projection(ShaderGlobals* /*sg*/, bool /*derivs*/,
-                                      ustring /*object*/, TypeDesc type,
-                                      ustring /*name*/, void* val)
+                                      ustringhash /*object*/, TypeDesc type,
+                                      ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeString) {
         ((ustring*)val)[0] = m_projection;
@@ -594,8 +599,8 @@ SimpleRenderer::get_camera_projection(ShaderGlobals* /*sg*/, bool /*derivs*/,
 
 bool
 SimpleRenderer::get_camera_fov(ShaderGlobals* /*sg*/, bool derivs,
-                               ustring /*object*/, TypeDesc type,
-                               ustring /*name*/, void* val)
+                               ustringhash /*object*/, TypeDesc type,
+                               ustringhash /*name*/, void* val)
 {
     // N.B. in a real renderer, this may be time-dependent
     if (type == TypeDesc::TypeFloat) {
@@ -610,8 +615,8 @@ SimpleRenderer::get_camera_fov(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRenderer::get_camera_pixelaspect(ShaderGlobals* /*sg*/, bool derivs,
-                                       ustring /*object*/, TypeDesc type,
-                                       ustring /*name*/, void* val)
+                                       ustringhash /*object*/, TypeDesc type,
+                                       ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_pixelaspect;
@@ -625,8 +630,8 @@ SimpleRenderer::get_camera_pixelaspect(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRenderer::get_camera_clip(ShaderGlobals* /*sg*/, bool derivs,
-                                ustring /*object*/, TypeDesc type,
-                                ustring /*name*/, void* val)
+                                ustringhash /*object*/, TypeDesc type,
+                                ustringhash /*name*/, void* val)
 {
     if (type == TypeFloatArray2) {
         ((float*)val)[0] = m_hither;
@@ -641,8 +646,8 @@ SimpleRenderer::get_camera_clip(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRenderer::get_camera_clip_near(ShaderGlobals* /*sg*/, bool derivs,
-                                     ustring /*object*/, TypeDesc type,
-                                     ustring /*name*/, void* val)
+                                     ustringhash /*object*/, TypeDesc type,
+                                     ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_hither;
@@ -656,8 +661,8 @@ SimpleRenderer::get_camera_clip_near(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRenderer::get_camera_clip_far(ShaderGlobals* /*sg*/, bool derivs,
-                                    ustring /*object*/, TypeDesc type,
-                                    ustring /*name*/, void* val)
+                                    ustringhash /*object*/, TypeDesc type,
+                                    ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_yon;
@@ -672,8 +677,8 @@ SimpleRenderer::get_camera_clip_far(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRenderer::get_camera_shutter(ShaderGlobals* /*sg*/, bool derivs,
-                                   ustring /*object*/, TypeDesc type,
-                                   ustring /*name*/, void* val)
+                                   ustringhash /*object*/, TypeDesc type,
+                                   ustringhash /*name*/, void* val)
 {
     if (type == TypeFloatArray2) {
         ((float*)val)[0] = m_shutter[0];
@@ -688,8 +693,8 @@ SimpleRenderer::get_camera_shutter(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRenderer::get_camera_shutter_open(ShaderGlobals* /*sg*/, bool derivs,
-                                        ustring /*object*/, TypeDesc type,
-                                        ustring /*name*/, void* val)
+                                        ustringhash /*object*/, TypeDesc type,
+                                        ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_shutter[0];
@@ -703,8 +708,8 @@ SimpleRenderer::get_camera_shutter_open(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRenderer::get_camera_shutter_close(ShaderGlobals* /*sg*/, bool derivs,
-                                         ustring /*object*/, TypeDesc type,
-                                         ustring /*name*/, void* val)
+                                         ustringhash /*object*/, TypeDesc type,
+                                         ustringhash /*name*/, void* val)
 {
     if (type == TypeDesc::TypeFloat) {
         ((float*)val)[0] = m_shutter[1];
@@ -718,8 +723,8 @@ SimpleRenderer::get_camera_shutter_close(ShaderGlobals* /*sg*/, bool derivs,
 
 bool
 SimpleRenderer::get_camera_screen_window(ShaderGlobals* /*sg*/, bool derivs,
-                                         ustring /*object*/, TypeDesc type,
-                                         ustring /*name*/, void* val)
+                                         ustringhash /*object*/, TypeDesc type,
+                                         ustringhash /*name*/, void* val)
 {
     // N.B. in a real renderer, this may be time-dependent
     if (type == TypeFloatArray4) {

--- a/src/testshade/simplerend.h
+++ b/src/testshade/simplerend.h
@@ -40,35 +40,34 @@ public:
     // Ensure destructor is in .cpp
     ~SimpleRenderer();
 
-    virtual int supports(string_view feature) const;
-    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
-                            TransformationPtr xform, float time);
-    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result, ustring from,
-                            float time);
-    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
-                            TransformationPtr xform);
-    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result, ustring from);
-    virtual bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
-                                    ustring to, float time);
+    int supports(string_view feature) const override;
+    bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                    TransformationPtr xform, float time) override;
+    bool get_matrix(ShaderGlobals* sg, Matrix44& result, ustringhash from,
+                    float time) override;
+    bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                    TransformationPtr xform) override;
+    bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                    ustringhash from) override;
+    bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result, ustringhash to,
+                            float time) override;
 
     void name_transform(const char* name, const Transformation& xform);
 
-    virtual bool get_array_attribute(ShaderGlobals* sg, bool derivatives,
-                                     ustring object, TypeDesc type,
-                                     ustring name, int index, void* val);
-    virtual bool get_attribute(ShaderGlobals* sg, bool derivatives,
-                               ustring object, TypeDesc type, ustring name,
-                               void* val);
-    virtual bool get_userdata(bool derivatives, ustring name, TypeDesc type,
-                              ShaderGlobals* sg, void* val);
+    bool get_array_attribute(ShaderGlobals* sg, bool derivatives,
+                             ustringhash object, TypeDesc type,
+                             ustringhash name, int index, void* val) override;
+    bool get_attribute(ShaderGlobals* sg, bool derivatives, ustringhash object,
+                       TypeDesc type, ustringhash name, void* val) override;
+    bool get_userdata(bool derivatives, ustringhash name, TypeDesc type,
+                      ShaderGlobals* sg, void* val) override;
 
-    virtual bool trace(TraceOpt& options, ShaderGlobals* sg, const OSL::Vec3& P,
-                       const OSL::Vec3& dPdx, const OSL::Vec3& dPdy,
-                       const OSL::Vec3& R, const OSL::Vec3& dRdx,
-                       const OSL::Vec3& dRdy);
+    bool trace(TraceOpt& options, ShaderGlobals* sg, const OSL::Vec3& P,
+               const OSL::Vec3& dPdx, const OSL::Vec3& dPdy, const OSL::Vec3& R,
+               const OSL::Vec3& dRdx, const OSL::Vec3& dRdy) override;
 
-    virtual bool getmessage(ShaderGlobals* sg, ustring source, ustring name,
-                            TypeDesc type, void* val, bool derivatives);
+    bool getmessage(ShaderGlobals* sg, ustringhash source, ustringhash name,
+                    TypeDesc type, void* val, bool derivatives) override;
 
 
     // Set and get renderer attributes/options
@@ -143,11 +142,11 @@ public:
     OIIO::ParamValueList userdata;
 
 #if OSL_USE_BATCHED
-    virtual BatchedRendererServices<16>* batched(WidthOf<16>)
+    BatchedRendererServices<16>* batched(WidthOf<16>) override
     {
         return &m_batch_16_simple_renderer;
     }
-    virtual BatchedRendererServices<8>* batched(WidthOf<8>)
+    BatchedRendererServices<8>* batched(WidthOf<8>) override
     {
         return &m_batch_8_simple_renderer;
     }
@@ -172,7 +171,7 @@ protected:
     std::unique_ptr<OIIO::ErrorHandler> m_errhandler { new OIIO::ErrorHandler };
 
     // Named transforms
-    typedef std::map<ustring, std::shared_ptr<Transformation>> TransformMap;
+    typedef std::map<ustringhash, std::shared_ptr<Transformation>> TransformMap;
     TransformMap m_named_xforms;
 
     // Attribute and userdata retrieval -- for fast dispatch, use a hash
@@ -181,38 +180,44 @@ protected:
     // renderer, we would encourage benchmarking various methods and
     // alternate data structures.
     typedef bool (SimpleRenderer::*AttrGetter)(ShaderGlobals* sg, bool derivs,
-                                               ustring object, TypeDesc type,
-                                               ustring name, void* val);
-    typedef std::unordered_map<ustring, AttrGetter> AttrGetterMap;
+                                               ustringhash object,
+                                               TypeDesc type, ustringhash name,
+                                               void* val);
+    typedef std::unordered_map<ustringhash, AttrGetter> AttrGetterMap;
     AttrGetterMap m_attr_getters;
 
     // Attribute getters
-    bool get_osl_version(ShaderGlobals* sg, bool derivs, ustring object,
-                         TypeDesc type, ustring name, void* val);
-    bool get_camera_resolution(ShaderGlobals* sg, bool derivs, ustring object,
-                               TypeDesc type, ustring name, void* val);
-    bool get_camera_projection(ShaderGlobals* sg, bool derivs, ustring object,
-                               TypeDesc type, ustring name, void* val);
-    bool get_camera_fov(ShaderGlobals* sg, bool derivs, ustring object,
-                        TypeDesc type, ustring name, void* val);
-    bool get_camera_pixelaspect(ShaderGlobals* sg, bool derivs, ustring object,
-                                TypeDesc type, ustring name, void* val);
-    bool get_camera_clip(ShaderGlobals* sg, bool derivs, ustring object,
-                         TypeDesc type, ustring name, void* val);
-    bool get_camera_clip_near(ShaderGlobals* sg, bool derivs, ustring object,
-                              TypeDesc type, ustring name, void* val);
-    bool get_camera_clip_far(ShaderGlobals* sg, bool derivs, ustring object,
-                             TypeDesc type, ustring name, void* val);
-    bool get_camera_shutter(ShaderGlobals* sg, bool derivs, ustring object,
-                            TypeDesc type, ustring name, void* val);
-    bool get_camera_shutter_open(ShaderGlobals* sg, bool derivs, ustring object,
-                                 TypeDesc type, ustring name, void* val);
+    bool get_osl_version(ShaderGlobals* sg, bool derivs, ustringhash object,
+                         TypeDesc type, ustringhash name, void* val);
+    bool get_camera_resolution(ShaderGlobals* sg, bool derivs,
+                               ustringhash object, TypeDesc type,
+                               ustringhash name, void* val);
+    bool get_camera_projection(ShaderGlobals* sg, bool derivs,
+                               ustringhash object, TypeDesc type,
+                               ustringhash name, void* val);
+    bool get_camera_fov(ShaderGlobals* sg, bool derivs, ustringhash object,
+                        TypeDesc type, ustringhash name, void* val);
+    bool get_camera_pixelaspect(ShaderGlobals* sg, bool derivs,
+                                ustringhash object, TypeDesc type,
+                                ustringhash name, void* val);
+    bool get_camera_clip(ShaderGlobals* sg, bool derivs, ustringhash object,
+                         TypeDesc type, ustringhash name, void* val);
+    bool get_camera_clip_near(ShaderGlobals* sg, bool derivs,
+                              ustringhash object, TypeDesc type,
+                              ustringhash name, void* val);
+    bool get_camera_clip_far(ShaderGlobals* sg, bool derivs, ustringhash object,
+                             TypeDesc type, ustringhash name, void* val);
+    bool get_camera_shutter(ShaderGlobals* sg, bool derivs, ustringhash object,
+                            TypeDesc type, ustringhash name, void* val);
+    bool get_camera_shutter_open(ShaderGlobals* sg, bool derivs,
+                                 ustringhash object, TypeDesc type,
+                                 ustringhash name, void* val);
     bool get_camera_shutter_close(ShaderGlobals* sg, bool derivs,
-                                  ustring object, TypeDesc type, ustring name,
-                                  void* val);
+                                  ustringhash object, TypeDesc type,
+                                  ustringhash name, void* val);
     bool get_camera_screen_window(ShaderGlobals* sg, bool derivs,
-                                  ustring object, TypeDesc type, ustring name,
-                                  void* val);
+                                  ustringhash object, TypeDesc type,
+                                  ustringhash name, void* val);
 };
 
 OSL_NAMESPACE_EXIT

--- a/testsuite/example-cuda/cuda_grid_renderer.h
+++ b/testsuite/example-cuda/cuda_grid_renderer.h
@@ -10,12 +10,12 @@
 #include <OSL/rendererservices.h>
 
 
-using GlobalsMap        = std::unordered_map<OIIO::ustring, uint64_t>;
-using TextureSamplerMap = std::unordered_map<OIIO::ustring, cudaTextureObject_t>;
+using GlobalsMap        = std::unordered_map<OSL::ustringhash, uint64_t>;
+using TextureSamplerMap = std::unordered_map<OSL::ustringhash, cudaTextureObject_t>;
 
 // Just use 4x4 matrix for transformations
 typedef OSL::Matrix44 Transformation;
-typedef std::map<OIIO::ustring, std::shared_ptr<Transformation>> TransformMap;
+typedef std::map<OSL::ustringhash, std::shared_ptr<Transformation>> TransformMap;
 
 class CudaGridRenderer final : public OSL::RendererServices {
     TextureSamplerMap _samplers;
@@ -25,7 +25,7 @@ class CudaGridRenderer final : public OSL::RendererServices {
     TransformMap _named_xforms;
 
     OSL::Matrix44 _world_to_camera;
-    OIIO::ustring _projection;
+    OSL::ustring _projection;
     float _fov, _pixelaspect, _hither, _yon;
     float _shutter[2];
     float _screen_window[4];
@@ -56,21 +56,19 @@ public:
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle*
-    get_texture_handle(OIIO::ustring filename,
-                       OSL::ShadingContext* shading_context);
+    virtual TextureHandle* get_texture_handle(ustringhash filename,
+                                              ShadingContext* shading_context);
 
-    virtual bool get_matrix(OSL::ShaderGlobals* sg, OSL::Matrix44& result,
-                            OSL::TransformationPtr xform, float time);
-    virtual bool get_matrix(OSL::ShaderGlobals* sg, OSL::Matrix44& result,
-                            OIIO::ustring from, float time);
-    virtual bool get_matrix(OSL::ShaderGlobals* sg, OSL::Matrix44& result,
-                            OSL::TransformationPtr xform);
-    virtual bool get_matrix(OSL::ShaderGlobals* sg, OSL::Matrix44& result,
-                            OIIO::ustring from);
-    virtual bool get_inverse_matrix(OSL::ShaderGlobals* sg,
-                                    OSL::Matrix44& result, OIIO::ustring to,
-                                    float time);
+    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                            TransformationPtr xform, float time);
+    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                            ustringhash from, float time);
+    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                            TransformationPtr xform);
+    virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
+                            ustringhash from);
+    virtual bool get_inverse_matrix(ShaderGlobals* sg, Matrix44& result,
+                                    ustringhash to, float time);
 
     void name_transform(const char* name, const Transformation& xform);
 };


### PR DESCRIPTION
The first step of the great ustringhash conversion: This changes all RendererServices methods (i.e., callbacks to the renderer from the shader JITed code) that used to take ustring parameters, switched to take ustringhash instead.

The second step -- which I will tackle after this part is merged -- will be to fully switch the in-memory representation of strings during shading execution to ustringhash on the CPU (thus matching how we've been doing it on GPU and making a number of data stuctures and representations identical/shared for CPU and GPU).

But in the mean time, this lets renderers get started changing their RendererServices specializations. Just like with OSL's internal implementation, it may be easier for renderers to break the job into phase I (rendererservices) and phase II (in-memory rep).

Some notes and guideposts:

* In oslconfig.h, define ustringrep to alias to either ustring or ustringhash, depending on a new (but temporary) CMake variable `OSL_USTRINGREP_IS_HASH`, which is OFF for now, meaning that ustringrep is still ustring.

* Also in oslconfig.h, several helper conversion functions among ustring, ustringhash, ustringrip.

* RendererServices and BatchedRendererServices (and their various subclasses in testshade and testrender): change the method signatures from ustring to ustringhash for all methods that are reachable from shader code.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
