### PR TITLE
CI: Disabling dso testshade to fix coverage missing testshade.cpp

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.links.issue=https://github.com/AcademySoftwareFoundation/OpenShadingLangua
 # Source properties
 sonar.sources=src
 sonar.sourceEncoding=UTF-8
-sonar.exclusions=src/include/OSL/Imath/*.h
+sonar.exclusions=src/include/OSL/Imath/*.h,src/build-scripts/*
 
 # C/C++ analyzer properties
 sonar.cfamily.build-wrapper-output=build/bw_output

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -62,33 +62,42 @@ target_link_libraries (testshade
                        PRIVATE
                            oslexec oslquery)
 
-
 install (TARGETS testshade RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
-# The 'libtestshade' library
-add_library ( "libtestshade" ${testshade_srcs} )
-
-set_target_properties (libtestshade
-                       PROPERTIES
-                       VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
-                       SOVERSION ${SOVERSION}
-                       OUTPUT_NAME libtestshade${OSL_LIBNAME_SUFFIX}
-                       )
-
-target_link_libraries (libtestshade
-                       PRIVATE
-                           oslexec oslquery)
-set_target_properties (libtestshade PROPERTIES PREFIX "")
-
-install_targets ( libtestshade )
-
-# The 'testshade_dso' executable
-add_executable ( testshade_dso testshade_dso.cpp )
-target_link_libraries (testshade_dso
-                       PRIVATE
-                           OpenImageIO::OpenImageIO
-                           ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} )
-install (TARGETS testshade_dso RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
-
 osl_optix_target(testshade)
-osl_optix_target(libtestshade)
+
+
+# As explained in PR #39, problems were reported with calling OSL from a
+# Houdini plugin.  So this section sets up a version of testshade as a DSO, to
+# be sure we can link it into an executable properly.
+#
+# But the fact that we use testshade.cpp twice -- once for regular testshade,
+# once for the DSO version -- is throwing off the code coverage test, so at
+# least for now, disable the dso version entirely when CODECOV is on.
+if (NOT CODECOV)
+    # The 'libtestshade' library
+    add_library ( "libtestshade" ${testshade_srcs} )
+
+    set_target_properties (libtestshade
+                           PROPERTIES
+                           VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
+                           SOVERSION ${SOVERSION}
+                           OUTPUT_NAME libtestshade${OSL_LIBNAME_SUFFIX}
+                           )
+
+    target_link_libraries (libtestshade
+                           PRIVATE
+                               oslexec oslquery)
+    set_target_properties (libtestshade PROPERTIES PREFIX "")
+
+    install_targets ( libtestshade )
+
+    # The 'testshade_dso' executable
+    add_executable ( testshade_dso testshade_dso.cpp )
+    target_link_libraries (testshade_dso
+                           PRIVATE
+                               OpenImageIO::OpenImageIO
+                               ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} )
+    install (TARGETS testshade_dso RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+    osl_optix_target(libtestshade)
+endif ()


### PR DESCRIPTION
We compile testshade.cpp twice -- one for a special "does it compile as a DSO" check but that isn't run from the testsuite. This was causing the coverage analysis to think nothing in testshade.cpp (at least one copy of it) was getting run, which is technically true, and counting all of its lines as untested for the coverage analysis. Just exclude that funny dso build from the coverage case.

Also exclude anything in src/build-scripts from coverage analysis, that's not code that ships, so to speak.

We're trying to chip away at untested code bit by bit to get our coverage to over 80% of lines. We're getting close.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
