### PR TITLE
include the immintrin.h header only when needed

### DIFF
--- a/src/include/OSL/mask.h
+++ b/src/include/OSL/mask.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <immintrin.h>
 #include <type_traits>
 
 #include <OSL/oslconfig.h>
@@ -22,6 +21,8 @@ using std::popcount;
 using std::countr_zero;
 
 #elif OSL_INTEL_CLASSIC_COMPILER_VERSION
+
+#include <immintrin.h>
 
 OSL_FORCEINLINE int popcount(uint32_t x) noexcept { return _mm_popcnt_u32(x);}
 OSL_FORCEINLINE int popcount(uint64_t x) noexcept { return _mm_popcnt_u64(x); }


### PR DESCRIPTION
## Description

The immintrin.h header is required for the implementation of the popcount and coutr_zero functions only when the Intel compiler is used. Move the inclusion accordingly. The current state breaks build on platforms that don't provide the header, but provide the alternative means (gcc/clang built-ins, etc).

## Tests

N/A

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

This is not a copyrightable work.