### PR TITLE
Fully deprecate LLVM_Util::internalize_module_functions

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -289,12 +289,7 @@ public:
         Linkage default_linkage = Linkage::Internal,
         std::string* out_err    = nullptr);
 
-    // OLD, might deprecate later
-    /// Change symbols in the module that are marked as having external
-    /// linkage to an alternate linkage that allows them to be discarded if
-    /// not used within the module. Only do this for functions that start
-    /// with prefix, and that DON'T match anything in the two exceptions
-    /// lists.
+    OSL_DEPRECATED("prune_and_internalize_module is better (1.13)")
     void internalize_module_functions(
         const std::string& prefix, const std::vector<std::string>& exceptions,
         const std::vector<std::string>& moreexceptions);

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -231,8 +231,7 @@ public:
     ///                              for debugging. (0)
     ///    int llvm_dumpasm       Print the CPU assembly code from the JIT (0)
     ///    string llvm_prune_ir_strategy  Strategy for pruning unnecessary
-    ///                              IR (choices: "prune" [default],
-    ///                              "internalize", or "none").
+    ///                              IR (choices: "prune" [default], or "none").
     ///    int max_local_mem_KB   Error if shader group needs more than this
     ///                              much local storage to execute (1024K)
     ///    string debug_groupname Name of shader group -- debug only this one

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -2691,21 +2691,9 @@ BatchedBackendLLVM::run()
     // entry points, as well as for all the external functions that are
     // just declarations (not definitions) in the module (which we have
     // conveniently stashed in external_function_names).
-#if 0
-    std::vector<std::string> entry_function_names;
-    entry_function_names.push_back (ll.func_name(init_func));
-    for (int layer = 0; layer < nlayers; ++layer) {
-        // set_inst (layer);
-        llvm::Function* f = funcs[layer];
-        if (f && group().is_entry_layer(layer))
-            entry_function_names.push_back (ll.func_name(f));
-    }
-    ll.internalize_module_functions ("osl_", external_function_names, entry_function_names);
-#else
     std::unordered_set<llvm::Function*> external_functions;
     external_functions.insert(init_func);
     for (int layer = 0; layer < nlayers; ++layer) {
-        // set_inst (layer);
         llvm::Function* f = funcs[layer];
         // If we plan to call bitcode_string of a layer's function after optimization
         // it may not exist after optimization unless we treat it as external.
@@ -2714,7 +2702,6 @@ BatchedBackendLLVM::run()
         }
     }
     ll.prune_and_internalize_module(external_functions);
-#endif
 
     // Debug code to dump the pre-optimized bitcode to a file
     if (llvm_debug() >= 2 || shadingsys().llvm_output_bitcode()) {

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1502,21 +1502,6 @@ BackendLLVM::run()
     if (shadingsys().llvm_prune_ir_strategy() == "none") {
         // Do nothing! This is only useful for testing how much we reduce
         // optimization and JIT time with the other strategies.
-    } else if (shadingsys().llvm_prune_ir_strategy() == "internalize") {
-        // Mark as 'internal' all functions that start with "osl_" but are
-        // but are not among the known entry points. LLVM can then quickly
-        // realize that any 'internal' functions not called can be
-        // discarded. This was our original stab at this strategy.
-        std::vector<std::string> entry_function_names;
-        entry_function_names.push_back(ll.func_name(init_func));
-        for (int layer = 0; layer < nlayers; ++layer) {
-            // set_inst (layer);
-            llvm::Function* f = funcs[layer];
-            if (f && group().is_entry_layer(layer))
-                entry_function_names.push_back(ll.func_name(f));
-        }
-        ll.internalize_module_functions("osl_", external_function_names,
-                                        entry_function_names);
     } else /* if (shadingsys().llvm_prune_ir_strategy() == "prune") */ {
         // New (2020) and default behavior, from Alex Wells:
         // Full prune of uncalled functions, and marking as 'internal' to

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -2439,70 +2439,12 @@ LLVM_Util::validate_global_mappings(
 
 
 
-// Soon to be deprecated
+// DEPRECATED(1.13)
 void
 LLVM_Util::internalize_module_functions(
     const std::string& prefix, const std::vector<std::string>& exceptions,
     const std::vector<std::string>& moreexceptions)
 {
-    for (llvm::Function& func : module()->getFunctionList()) {
-        llvm::Function* sym = &func;
-        std::string symname = sym->getName().str();
-        if (prefix.size() && !OIIO::Strutil::starts_with(symname, prefix))
-            continue;
-        bool needed = false;
-        for (size_t i = 0, e = exceptions.size(); i < e; ++i)
-            if (sym->getName() == exceptions[i]) {
-                needed = true;
-                // std::cout << "    necessary LLVM module function "
-                //           << sym->getName().str() << "\n";
-                break;
-            }
-        for (size_t i = 0, e = moreexceptions.size(); i < e; ++i)
-            if (sym->getName() == moreexceptions[i]) {
-                needed = true;
-                // std::cout << "    necessary LLVM module function "
-                //           << sym->getName().str() << "\n";
-                break;
-            }
-        if (!needed) {
-            llvm::GlobalValue::LinkageTypes linkage = sym->getLinkage();
-            // std::cout << "    unnecessary LLVM module function "
-            //           << sym->getName().str() << " linkage " << int(linkage) << "\n";
-            if (linkage == llvm::GlobalValue::ExternalLinkage)
-                sym->setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
-            // ExternalLinkage means it's potentially externally callable,
-            // and so will definitely have code generated.
-            // LinkOnceODRLinkage keeps one copy so it can be inlined or
-            // called internally to the module, but allows it to be
-            // discarded otherwise.
-        }
-    }
-#if 0
-    // I don't think we need to worry about linkage of global symbols, but
-    // here is an example of how to iterate over the globals anyway.
-    for (llvm::Module::global_iterator iter = module()->global_begin(); iter != module()->global_end(); iter++) {
-        llvm::GlobalValue *sym = llvm::dyn_cast<llvm::GlobalValue>(iter);
-        if (!sym)
-            continue;
-        std::string symname = sym->getName();
-        if (prefix.size() && ! OIIO::Strutil::starts_with(symname, prefix))
-            continue;
-        bool needed = false;
-        for (size_t i = 0, e = exceptions.size(); i < e; ++i)
-            if (sym->getName() == exceptions[i]) {
-                needed = true;
-                break;
-            }
-        if (! needed) {
-            llvm::GlobalValue::LinkageTypes linkage = sym->getLinkage();
-            // std::cout << "    unnecessary LLVM global " << sym->getName().str()
-            //           << " linkage " << int(linkage) << "\n";
-            if (linkage == llvm::GlobalValue::ExternalLinkage)
-                f->setLinkage (llvm::GlobalValue::LinkOnceODRLinkage);
-        }
-    }
-#endif
 }
 
 


### PR DESCRIPTION
Signed-off-by: Larry Gritz <lg@larrygritz.com>
