### PR TITLE
Improve testing coverage

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: sonary gcc9/C++14 llvm13 py3.9 boost1.76 exr3.1 oiio2.3 avx2
+          - desc: sonar gcc9/C++14 llvm13 py3.9 boost1.76 exr3.1 oiio2.3 avx2
             nametag: static-analysis-sonar
             os: ubuntu-latest
             vfxyear: 2022
@@ -40,7 +40,7 @@ jobs:
             python_ver: 3.9
             pybind11_ver: v2.9.0
             simd: avx2,f16c
-            batched: b8_AVX2
+            batched: b8_AVX2,b16_AVX512
             coverage: 1
             # skip_tests: 1
             sonar: 1

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -155,15 +155,6 @@ public:
     void debug_set_location(OIIO::ustring sourcefile, int sourceline);
 
     /// Create a new function (that will later be populated with
-    /// instructions) with up to 4 args.
-    OSL_DEPRECATED("Use make_function flavor that takes a cspan (1.12)")
-    llvm::Function* make_function(const std::string& name, bool fastcall,
-                                  llvm::Type* rettype, llvm::Type* arg1 = NULL,
-                                  llvm::Type* arg2 = NULL,
-                                  llvm::Type* arg3 = NULL,
-                                  llvm::Type* arg4 = NULL);
-
-    /// Create a new function (that will later be populated with
     /// instructions) with a cspan of args.
     llvm::Function* make_function(const std::string& name, bool fastcall,
                                   llvm::Type* rettype,

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -42,6 +42,7 @@ static bool saveptx              = false;
 static bool warmup               = false;
 static bool profile              = false;
 static bool O0 = false, O1 = false, O2 = false;
+static int llvm_opt              = 1;  // LLVM optimization level
 static bool debugnan             = false;
 static bool debug_uninit         = false;
 static bool userdata_isconnected = false;
@@ -76,6 +77,15 @@ set_shadingsys_options()
     if (const char* opt_env = getenv("TESTSHADE_OPT"))  // overrides opt
         opt = atoi(opt_env);
     shadingsys->attribute("optimize", opt);
+
+    // The cost of more optimization passes usually pays for itself by
+    // reducing the number of instructions JIT ultimately has to lower to
+    // the target ISA.
+    if (const char* llvm_opt_env = getenv(
+            "TESTSHADE_LLVM_OPT"))  // overrides llvm_opt
+        llvm_opt = atoi(llvm_opt_env);
+    shadingsys->attribute("llvm_optimize", llvm_opt);
+
     shadingsys->attribute("profile", int(profile));
     shadingsys->attribute("lockgeom", 1);
     shadingsys->attribute("debug_nan", debugnan);
@@ -149,6 +159,8 @@ getargs(int argc, const char* argv[])
       .help("Do a little runtime shader optimization");
     ap.arg("-O2", &O2)
       .help("Do lots of runtime shader optimization");
+    ap.arg("--llvm_opt %d:LEVEL", &llvm_opt)
+      .help("LLVM JIT optimization level");
     ap.arg("--debugnan", &debugnan)
       .help("Turn on 'debugnan' mode");
     ap.arg("--path SEARCHPATH", &shaderpath)

--- a/testsuite/render-bumptest/run.py
+++ b/testsuite/render-bumptest/run.py
@@ -5,4 +5,6 @@
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 outputs = [ "out.exr" ]
-command = testrender("-r 256 256 -aa 4 bumptest.xml out.exr")
+command = testrender("-r 256 256 -aa 4 --llvm_opt 13 bumptest.xml out.exr")
+
+# Note: we pick this test arbitrarily as the one to verify llvm_opt=13 works

--- a/testsuite/render-cornell/run.py
+++ b/testsuite/render-cornell/run.py
@@ -7,4 +7,6 @@
 failthresh = 0.01
 failpercent = 1
 outputs = [ "out.exr" ]
-command = testrender("-r 256 256 -aa 4 cornell.xml out.exr")
+command = testrender("-r 256 256 -aa 4 --llvm_opt 12 cornell.xml out.exr")
+
+# Note: we pick this test arbitrarily as the one to verify llvm_opt=12 works


### PR DESCRIPTION
Looking at the code coverage report and trying to get a higher coverage amount, employing two strategies: (a) remove unused code that is not covered because it's... unused; and (b) test things that are used but aren't in the test run. Details follow.

Remove deprecated version of LLVM_Util::make_function.

Disable contents of dump_struct_data_layout when OSL_DEV is not defined, it will never be called in any other circumstances -- it's strictly a debugging tool, not part of the shipping library.

When OSL_USE_OPTIX is not enabled, exclude compiling contents of ptx_compile_group.

get_alignment can also be OSL_DEV only as well as simplified

Arbitrarily pick a couple of render tests to use llvm_opt levels 12 and 13 to verify that they work correctly. (That's a couple hundred lines of pass setup code that wouldn't otherwise be included in the coverage analysis, nor tested in the testsuite.) This also required us to add the --llvm_opt command to testrender, as it is in testshade.

Make the analysis run build for avx512 as well for more code coverage.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
