### PR TITLE
Fix ptx symbol visibility regression

### DIFF
--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -39,7 +39,7 @@ namespace pvt {
 #define IlluminantACES 0.32168, 0.33767        /* For ACES, approximate D60 */
 
 namespace {  // anon namespace to avoid duplicate OptiX symbols
-OSL_CONSTANT_DATA const static ColorSystem::Chroma k_color_systems[13] = {
+OSL_CONSTANT_DATA const ColorSystem::Chroma k_color_systems[13] = {
    // Index, Name        xRed    yRed   xGreen  yGreen   xBlue   yBlue    White point
    /* 0  Rec709     */ { 0.64,   0.33,   0.30,   0.60,   0.15,   0.06,   IlluminantD65 },
    /* 1  sRGB       */ { 0.64,   0.33,   0.30,   0.60,   0.15,   0.06,   IlluminantD65 },

--- a/src/liboslexec/opcolor_impl.h
+++ b/src/liboslexec/opcolor_impl.h
@@ -50,7 +50,7 @@ clamp_zero(Color3& c)
 //OSL_CONSTANT_DATA const float cie_colour_match[81][3] =
 // Choose to access 1d array vs 2d to allow better code generation of gathers
 namespace {  // anon namespace to avoid duplicate OptiX symbols
-static OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) = {
+OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) = {
     // clang-format off
     0.0014,0.0000,0.0065, 0.0022,0.0001,0.0105, 0.0042,0.0001,0.0201,
     0.0076,0.0002,0.0362, 0.0143,0.0004,0.0679, 0.0232,0.0006,0.1102,

--- a/src/liboslexec/splineimpl.h
+++ b/src/liboslexec/splineimpl.h
@@ -42,7 +42,7 @@ enum {
 
 // clang-format off
 namespace {  // anon namespace to avoid duplicate OptiX symbols
-OSL_CONSTANT_DATA const static SplineBasis gBasisSet[kNumSplineTypes] = {
+OSL_CONSTANT_DATA const SplineBasis gBasisSet[kNumSplineTypes] = {
 //
 // catmullrom
 //

--- a/src/liboslnoise/simplexnoise.cpp
+++ b/src/liboslnoise/simplexnoise.cpp
@@ -67,11 +67,11 @@ scramble(uint32_t v0, uint32_t v1 = 0, uint32_t v2 = 0)
 // clang-format off
 
 namespace {  // anon namespace to avoid duplicate OptiX symbols
-static OSL_CONSTANT_DATA float zero[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+OSL_CONSTANT_DATA float zero[] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
 // Gradient table for 2D. These could be programmed the Ken Perlin way with
 // some clever bit-twiddling, but this is more clear, and not really slower.
-static OSL_CONSTANT_DATA float grad2lut[8][2] = {
+OSL_CONSTANT_DATA float grad2lut[8][2] = {
     { -1.0f, -1.0f }, { 1.0f,  0.0f }, { -1.0f, 0.0f }, { 1.0f,  1.0f },
     { -1.0f,  1.0f }, { 0.0f, -1.0f }, {  0.0f, 1.0f }, { 1.0f, -1.0f }
 };
@@ -82,7 +82,7 @@ static OSL_CONSTANT_DATA float grad2lut[8][2] = {
 // but these 12 (including 4 repeats to make the array length a power
 // of two) work better. They are not random, they are carefully chosen
 // to represent a small, isotropic set of directions.
-static OSL_CONSTANT_DATA float grad3lut[16][3] = {
+OSL_CONSTANT_DATA float grad3lut[16][3] = {
     {  1.0f,  0.0f,  1.0f }, {  0.0f,  1.0f,  1.0f }, // 12 cube edges
     { -1.0f,  0.0f,  1.0f }, {  0.0f, -1.0f,  1.0f },
     {  1.0f,  0.0f, -1.0f }, {  0.0f,  1.0f, -1.0f },
@@ -94,7 +94,7 @@ static OSL_CONSTANT_DATA float grad3lut[16][3] = {
 };
 
 // Gradient directions for 4D
-static OSL_CONSTANT_DATA float grad4lut[32][4] = {
+OSL_CONSTANT_DATA float grad4lut[32][4] = {
   { 0.0f, 1.0f, 1.0f, 1.0f }, { 0.0f, 1.0f, 1.0f, -1.0f }, { 0.0f, 1.0f, -1.0f, 1.0f }, { 0.0f, 1.0f, -1.0f, -1.0f }, // 32 tesseract edges
   { 0.0f, -1.0f, 1.0f, 1.0f }, { 0.0f, -1.0f, 1.0f, -1.0f }, { 0.0f, -1.0f, -1.0f, 1.0f }, { 0.0f, -1.0f, -1.0f, -1.0f },
   { 1.0f, 0.0f, 1.0f, 1.0f }, { 1.0f, 0.0f, 1.0f, -1.0f }, { 1.0f, 0.0f, -1.0f, 1.0f }, { 1.0f, 0.0f, -1.0f, -1.0f },
@@ -108,7 +108,7 @@ static OSL_CONSTANT_DATA float grad4lut[32][4] = {
 // A lookup table to traverse the simplex around a given point in 4D.
 // Details can be found where this table is used, in the 4D noise method.
 /* TODO: This should not be required, backport it from Bill's GLSL code! */
-static OSL_CONSTANT_DATA unsigned char simplex[64][4] = {
+OSL_CONSTANT_DATA unsigned char simplex[64][4] = {
   {0,1,2,3},{0,1,3,2},{0,0,0,0},{0,2,3,1},{0,0,0,0},{0,0,0,0},{0,0,0,0},{1,2,3,0},
   {0,2,1,3},{0,0,0,0},{0,3,1,2},{0,3,2,1},{0,0,0,0},{0,0,0,0},{0,0,0,0},{1,3,2,0},
   {0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},{0,0,0,0},

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -25,8 +25,8 @@ public:
     OptixRaytracer();
     virtual ~OptixRaytracer();
 
-    uint64_t register_global(const std::string& str, uint64_t value);
-    bool fetch_global(const std::string& str, uint64_t* value);
+    uint64_t register_global(const std::string& str, uint64_t value) override;
+    bool fetch_global(const std::string& str, uint64_t* value) override;
 
     int supports(string_view feature) const override
     {

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -25,8 +25,8 @@ public:
     OptixGridRenderer();
     virtual ~OptixGridRenderer();
 
-    uint64_t register_global(const std::string& str, uint64_t value);
-    bool fetch_global(const std::string& str, uint64_t* value);
+    uint64_t register_global(const std::string& str, uint64_t value) override;
+    bool fetch_global(const std::string& str, uint64_t* value) override;
 
     int supports(string_view feature) const override
     {


### PR DESCRIPTION
LLVM 14 introduced two ptx regressions to our file-scoped static variables:
1) They gained the .visible directive
2) They stopped being optimized out when unused

This lead to duplicate symbol errors when building an OptiX pipeline with multiple shaders.

We attempted a fix using anonymous namespaces in #1561, but kept the static keyword, resulting in a partial solution.

Removing static generates ptx that matches LLVM 12 for the affected variable definitions.

-----

Here's a section of `group_0.ptx` from `testoptix-noise`, before and after:
```
Before:
.visible .const .align 4 .b8 _ZN11OSL_v1_13_23pvt6Spline12_GLOBAL__N_19gBasisSetE[408] = {...};
.visible .const .align 64 .b8 _ZN11OSL_v1_13_23pvt12_GLOBAL__N_112_GLOBAL__N_116cie_colour_matchE[972] = {...};
.visible .const .align 4 .b8 _ZN11OSL_v1_13_23pvt12_GLOBAL__N_115k_color_systemsE[416] = {...};
.visible .const .align 4 .b8 _ZN11OSL_v1_13_23pvt12_GLOBAL__N_14zeroE[16];
.visible .const .align 4 .b8 _ZN11OSL_v1_13_23pvt12_GLOBAL__N_18grad2lutE[64] = {...};
.visible .const .align 4 .b8 _ZN11OSL_v1_13_23pvt12_GLOBAL__N_18grad3lutE[192] = {...};
.visible .const .align 4 .b8 _ZN11OSL_v1_13_23pvt12_GLOBAL__N_18grad4lutE[512] = {...};
.visible .const .align 1 .b8 _ZN11OSL_v1_13_23pvt12_GLOBAL__N_17simplexE[256] = {...};


After:
.const .align 4 .b8 _ZN11OSL_v1_13_13pvt12_GLOBAL__N_18grad2lutE[64] = {...};
```

-----

Also included: Fix a clang warning that was breaking my `-Werror` build, although I'm confused why CI didn't catch it previously.