### PR TITLE
Testing: run pointcloud tests when partio is found

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -383,7 +383,7 @@ macro (osl_add_all_tests)
     endif()
 
     # Only run pointcloud tests if Partio is found
-    if (PARTIO_FOUND)
+    if (partio_FOUND)
         TESTSUITE ( pointcloud pointcloud-fold )
     endif ()
 


### PR DESCRIPTION
Wow, this has been lurking for a while. Our Findpartio.cmake tries looking for a partio exported config, but if not found, falls back to a simple code to find it manually.

All was fine with the fallback code, which if found would set both "partio_FOUND" and "PARTIO_FOUND". But the config file, if found -- only for the newer partio versions -- only set partio_FOUND. And in that circumstance, we were not seting up the pointcloud tests!

Although the partio tests were running in CI (thankfully), I was not running them locally on my machine with a new-ish partio.
