### PR TITLE
Checkpoint to phase 2 of the great ustringhash conversion

### DIFF
--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -138,10 +138,21 @@ fmtformat(const Str& fmt, Args&&... args)
 #cmakedefine01 OSL_USTRINGREP_IS_HASH
 
 #if OSL_USTRINGREP_IS_HASH
+/// ustringrep is the class we use to represent strings in the shader.
 using ustringrep = ustringhash;
 #else
+/// ustringrep is the class we use to represent strings in the shader.
 using ustringrep = ustring;
 #endif
+
+#if OSL_USTRINGREP_IS_HASH
+/// ustring_pod is the type we use to pass string data in llvm function calls.
+using ustring_pod = size_t;
+#else
+/// ustring_pod is the type we use to pass string data in llvm function calls.
+using ustring_pod = const char*;
+#endif
+
 
 
 /// Convenience function to convert to a ustring.
@@ -156,6 +167,28 @@ inline ustring
 ustring_from(ustring u)
 {
     return u;
+}
+
+/// Convenience function to convert to a ustring.
+inline ustring
+ustring_from(string_view s)
+{
+    return ustring(s);
+}
+
+
+/// Convenience function to convert to a ustringhash.
+inline ustringhash
+ustringhash_from(ustringhash u)
+{
+    return u;
+}
+
+/// Convenience function to convert to a ustringhash.
+inline ustringhash
+ustringhash_from(ustring u)
+{
+    return u.uhash();
 }
 
 
@@ -174,6 +207,18 @@ ustringrep_from(ustringhash h)
 inline ustringrep
 ustringrep_from(ustring u)
 {
+#if OSL_USTRINGREP_IS_HASH
+    return u.hash();
+#else
+    return u;
+#endif
+}
+
+/// Convenience function to convert to a ustringrep.
+inline ustringrep
+ustringrep_from(string_view s)
+{
+    ustring u(s);
 #if OSL_USTRINGREP_IS_HASH
     return u.hash();
 #else
@@ -279,7 +324,8 @@ OSL_NAMESPACE_EXIT
 
 namespace std {  // not necessary in C++17, then we can just say std::hash
 #ifndef OIIO_USTRING_HAS_STDHASH
-// Not a new enough OIIO to define std::hash<ustring>, so we'll do it
+// Not a new enough OIIO to define std::hash<ustring>, so we'll do it.
+// This can be removed once OIIO minimum is 2.4.5+ or >=2.5.0.1
 template<> struct hash<OSL::ustring> {
     std::size_t operator()(OSL::ustring u) const noexcept { return u.hash(); }
 };
@@ -293,7 +339,8 @@ template<> struct hash<OSL::ustringhash> {
 };
 #endif
 
-// Not necessary once minimum OIIO defines operator< for ustringhash
+// Not necessary once minimum OIIO defines operator< for ustringhash.
+// This can be removed once OIIO minimum is 2.4.5+ or >=2.5.0.1
 template<> struct less<OSL::ustringhash> {
     OSL_HOSTDEVICE constexpr bool operator()(OSL::ustringhash u,
                                              OSL::ustringhash v) const noexcept
@@ -302,3 +349,21 @@ template<> struct less<OSL::ustringhash> {
     }
 };
 }  // namespace std
+
+
+#ifndef OIIO_HAS_USTRINGHASH_FORMATTER
+// OIIO is too old to have fmt custom formatter for ustringhash.
+// This can be removed once OIIO minimum is 2.4.5+ or >=2.5.0.1
+FMT_BEGIN_NAMESPACE
+template<> struct formatter<OIIO::ustringhash> : formatter<fmt::string_view, char> {
+    template<typename FormatContext>
+    auto format(const OIIO::ustringhash& h, FormatContext& ctx)
+        -> decltype(ctx.out()) const
+    {
+        OIIO::ustring u(h);
+        return formatter<fmt::string_view, char>::format({ u.data(), u.size() },
+                                                         ctx);
+    }
+};
+FMT_END_NAMESPACE
+#endif

--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -204,13 +204,13 @@ DECL(osl_dict_next, "iXi")
 DECL(osl_dict_value, "iXiXLX")
 DECL(osl_raytype_name, "iXs")
 #ifdef OSL_LLVM_NO_BITCODE
-DECL(osl_range_check, "iiiXXXiXiXX")
+DECL(osl_range_check, "iiisXsisiss")
 #endif
-DECL(osl_range_check_err, "iiiXXXiXiXX")
-DECL(osl_naninf_check, "xiXiXXiXiiX")
-DECL(osl_uninit_check, "xLXXXiXiXXiXiXii")
-DECL(osl_get_attribute, "iXiXXiiLX")
-DECL(osl_bind_interpolated_param, "iXXLiXiXiXi")
+DECL(osl_range_check_err, "iiisXsisiss")
+DECL(osl_naninf_check, "xiXiXsisiis")
+DECL(osl_uninit_check, "xLXXsisissisisii")
+DECL(osl_get_attribute, "iXissiiLX")
+DECL(osl_bind_interpolated_param, "iXsLiXiXiXi")
 DECL(osl_get_texture_options, "XX");
 DECL(osl_get_noise_options, "XX");
 DECL(osl_get_trace_options, "XX");
@@ -338,8 +338,8 @@ DECL(osl_substr_ssii, "ssii")
 DECL(osl_regex_impl, "iXsXisi")
 
 // Used by wide code generator, but are uniform calls
-DECL(osl_texture_decode_wrapmode, "iX");
-DECL(osl_texture_decode_interpmode, "iX");
+DECL(osl_texture_decode_wrapmode, "is");
+DECL(osl_texture_decode_interpmode, "is");
 
 DECL(osl_texture_set_firstchannel, "xXi")
 DECL(osl_texture_set_swrap, "xXs")

--- a/src/liboslexec/builtindecl_wide_xmacro.h
+++ b/src/liboslexec/builtindecl_wide_xmacro.h
@@ -315,7 +315,7 @@ DECL(__OSL_MASKED_OP(pointcloud_get), "iXsXiXsLXi")
 DECL(__OSL_MASKED_OP(pointcloud_write), "iXsXiXXXi")
 
 DECL(__OSL_MASKED_OP(getmessage), "xXXssLXiisii")
-DECL(__OSL_MASKED_OP2(setmessage, s, WX), "xXXLXisii")
+DECL(__OSL_MASKED_OP2(setmessage, s, WX), "xXsLXisii")
 DECL(__OSL_MASKED_OP2(setmessage, Ws, WX), "xXXLXisii")
 
 DECL(__OSL_OP(blackbody_vf), "xXXf")
@@ -362,24 +362,24 @@ DECL(__OSL_OP(dict_value), "iXiXLX")
 DECL(__OSL_MASKED_OP(dict_value), "xXXXXLXi")
 
 
-DECL(__OSL_OP(raytype_name), "iXX")
+DECL(__OSL_OP(raytype_name), "iXs")
 DECL(__OSL_MASKED_OP(raytype_name), "xXXXi")
-DECL(__OSL_OP(naninf_check), "xiXiXXiXiiX")
-DECL(__OSL_MASKED_OP1(naninf_check_offset, i), "xiiXiXXiXiiX")
-DECL(__OSL_MASKED_OP1(naninf_check_offset, Wi), "xiiXiXXiXXiX")
-DECL(__OSL_OP(range_check), "iiiXXXiXiXX")
-DECL(__OSL_MASKED_OP(range_check), "xXiiXXXiXiXX")
-DECL(__OSL_OP2(uninit_check_values_offset, X, i), "xLXXXiXiXXiXiXii")
-DECL(__OSL_MASKED_OP2(uninit_check_values_offset, X, Wi), "xiLXXXiXiXXiXiXXi")
-DECL(__OSL_MASKED_OP2(uninit_check_values_offset, WX, i), "xiLXXXiXiXXiXiXii")
-DECL(__OSL_MASKED_OP2(uninit_check_values_offset, WX, Wi), "xiLXXXiXiXXiXiXXi")
+DECL(__OSL_OP(naninf_check), "xiXiXsisiis")
+DECL(__OSL_MASKED_OP1(naninf_check_offset, i), "xiiXiXsisiis")
+DECL(__OSL_MASKED_OP1(naninf_check_offset, Wi), "xiiXiXsisXis")
+DECL(__OSL_OP(range_check), "iiisXsisiss")
+DECL(__OSL_MASKED_OP(range_check), "xXiisXsisiss")
+DECL(__OSL_OP2(uninit_check_values_offset, X, i), "xLXXsisissisisii")
+DECL(__OSL_MASKED_OP2(uninit_check_values_offset, X, Wi), "xiLXXsisissisisXi")
+DECL(__OSL_MASKED_OP2(uninit_check_values_offset, WX, i), "xiLXXsisissisisii")
+DECL(__OSL_MASKED_OP2(uninit_check_values_offset, WX, Wi), "xiLXXsisissisisXi")
 
-DECL(__OSL_OP1(get_attribute, s), "iXiXXiiXXi")
-DECL(__OSL_MASKED_OP1(get_attribute, Ws), "iXiXXiiXXi")
-DECL(__OSL_OP(get_attribute_uniform), "iXiXXiiXX")
+DECL(__OSL_OP1(get_attribute, s), "iXissiiXXi")
+DECL(__OSL_MASKED_OP1(get_attribute, Ws), "iXisXiiXXi")
+DECL(__OSL_OP(get_attribute_uniform), "iXissiiXX")
 
 // TODO:  shouldn't bind_interpolated_param be MASKED?  change name to reflect
-DECL(__OSL_OP(bind_interpolated_param), "iXXLiXiXiXii")
+DECL(__OSL_OP(bind_interpolated_param), "iXsLiXiXiXii")
 
 //DECL (osl_get_texture_options, "XX") // unneeded
 DECL(__OSL_OP(get_noise_options), "XX")

--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -625,8 +625,8 @@ ShadingContext::find_regex(ustring r)
 
 bool
 ShadingContext::osl_get_attribute(ShaderGlobals* sg, void* objdata,
-                                  int dest_derivs, ustring obj_name,
-                                  ustring attr_name, int array_lookup,
+                                  int dest_derivs, ustringhash obj_name,
+                                  ustringhash attr_name, int array_lookup,
                                   int index, TypeDesc attr_type,
                                   void* attr_dest)
 {

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1296,8 +1296,13 @@ BackendLLVM::initialize_llvm_group()
         TypeSpec rettype = OSLCompilerImpl::type_from_code(types, &advance);
         types += advance;
         std::vector<llvm::Type*> params;
+        // bool debug = OIIO::Strutil::contains(funcname, "range");
+        // if (debug)
+        //     print("defining func {}:\n", funcname);
         while (*types) {
             TypeSpec t = OSLCompilerImpl::type_from_code(types, &advance);
+            // if (debug)
+            //     print("\t{}\n", t);
             if (t.simpletype().basetype == TypeDesc::UNKNOWN) {
                 OSL_DASSERT(*types == '*');
                 if (*types == '*')

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1296,13 +1296,8 @@ BackendLLVM::initialize_llvm_group()
         TypeSpec rettype = OSLCompilerImpl::type_from_code(types, &advance);
         types += advance;
         std::vector<llvm::Type*> params;
-        // bool debug = OIIO::Strutil::contains(funcname, "range");
-        // if (debug)
-        //     print("defining func {}:\n", funcname);
         while (*types) {
             TypeSpec t = OSLCompilerImpl::type_from_code(types, &advance);
-            // if (debug)
-            //     print("\t{}\n", t);
             if (t.simpletype().basetype == TypeDesc::UNKNOWN) {
                 OSL_DASSERT(*types == '*');
                 if (*types == '*')

--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -43,32 +43,31 @@ osl_texture_set_firstchannel(void* opt, int x)
 }
 
 OSL_SHADEOP int
-osl_texture_decode_wrapmode(void* name)
+osl_texture_decode_wrapmode(ustring_pod name)
 {
-    const ustring& uname = USTR(name);
-    return OIIO::TextureOpt::decode_wrapmode(uname);
+    return OIIO::TextureOpt::decode_wrapmode(ustring_from(USTR(name)));
 }
 
 OSL_SHADEOP void
-osl_texture_set_swrap(void* opt, const char* x)
+osl_texture_set_swrap(void* opt, ustring_pod x)
 {
     ((TextureOpt*)opt)->swrap = TextureOpt::decode_wrapmode(USTR(x));
 }
 
 OSL_SHADEOP void
-osl_texture_set_twrap(void* opt, const char* x)
+osl_texture_set_twrap(void* opt, ustring_pod x)
 {
     ((TextureOpt*)opt)->twrap = TextureOpt::decode_wrapmode(USTR(x));
 }
 
 OSL_SHADEOP void
-osl_texture_set_rwrap(void* opt, const char* x)
+osl_texture_set_rwrap(void* opt, ustring_pod x)
 {
     ((TextureOpt*)opt)->rwrap = TextureOpt::decode_wrapmode(USTR(x));
 }
 
 OSL_SHADEOP void
-osl_texture_set_stwrap(void* opt, const char* x)
+osl_texture_set_stwrap(void* opt, ustring_pod x)
 {
     TextureOpt::Wrap code     = TextureOpt::decode_wrapmode(USTR(x));
     ((TextureOpt*)opt)->swrap = code;
@@ -163,16 +162,15 @@ osl_texture_set_time(void* opt, float x)
 }
 
 OSL_SHADEOP int
-osl_texture_decode_interpmode(void* name)
+osl_texture_decode_interpmode(ustring_pod name)
 {
-    const ustring& uname = USTR(name);
-    return tex_interp_to_code(uname);
+    return tex_interp_to_code(ustring_from(USTR(name)));
 }
 
 OSL_SHADEOP void
-osl_texture_set_interp(void* opt, const char* modename)
+osl_texture_set_interp(void* opt, ustring_pod modename)
 {
-    int mode = tex_interp_to_code(USTR(modename));
+    int mode = tex_interp_to_code(ustring_from(USTR(modename)));
     if (mode >= 0)
         ((TextureOpt*)opt)->interpmode = (TextureOpt::InterpMode)mode;
 }
@@ -191,9 +189,9 @@ osl_texture_set_subimage(void* opt, int subimage)
 
 
 OSL_SHADEOP void
-osl_texture_set_subimagename(void* opt, const char* subimagename)
+osl_texture_set_subimagename(void* opt, ustring_pod subimagename)
 {
-    ((TextureOpt*)opt)->subimagename = USTR(subimagename);
+    ((TextureOpt*)opt)->subimagename = ustring_from(USTR(subimagename));
 }
 
 OSL_SHADEOP void

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -4313,8 +4313,8 @@ OSL::OSLQuery::init(const ShaderGroup* group, int layernum)
 // firstcheck,nchecks are used to check just one element of an array.
 OSL_SHADEOP void
 osl_naninf_check(int ncomps, const void* vals_, int has_derivs, void* sg,
-                 const void* sourcefile, int sourceline, void* symbolname,
-                 int firstcheck, int nchecks, const void* opname)
+                 ustring_pod sourcefile, int sourceline, ustring_pod symbolname,
+                 int firstcheck, int nchecks, ustring_pod opname)
 {
     ShadingContext* ctx = (ShadingContext*)((ShaderGlobals*)sg)->context;
     const float* vals   = (const float*)vals_;
@@ -4345,10 +4345,10 @@ osl_naninf_check(int ncomps, const void* vals_, int has_derivs, void* sg,
 // element of an array.
 OSL_SHADEOP void
 osl_uninit_check(long long typedesc_, void* vals_, void* sg,
-                 const void* sourcefile, int sourceline, const char* groupname,
-                 int layer, const char* layername, const char* shadername,
-                 int opnum, const char* opname, int argnum, void* symbolname,
-                 int firstcheck, int nchecks)
+                 ustring_pod sourcefile, int sourceline, ustring_pod groupname_,
+                 int layer, ustring_pod layername_, ustring_pod shadername,
+                 int opnum, ustring_pod opname, int argnum,
+                 ustring_pod symbolname, int firstcheck, int nchecks)
 {
     TypeDesc typedesc   = TYPEDESC(typedesc_);
     ShadingContext* ctx = (ShadingContext*)((ShaderGlobals*)sg)->context;
@@ -4378,30 +4378,34 @@ osl_uninit_check(long long typedesc_, void* vals_, void* sg,
             }
     }
     if (uninit) {
+        ustringrep groupname = USTR(groupname_);
+        ustringrep layername = USTR(layername_);
         ctx->errorfmt(
             "Detected possible use of uninitialized value in {} {} at {}:{} (group {}, layer {} {}, shader {}, op {} '{}', arg {})",
-            typedesc.c_str(), USTR(symbolname), USTR(sourcefile), sourceline,
-            (groupname && groupname[0]) ? groupname : "<unnamed group>", layer,
-            (layername && layername[0]) ? layername : "<unnamed layer>",
-            shadername, opnum, USTR(opname), argnum);
+            typedesc, USTR(symbolname), USTR(sourcefile), sourceline,
+            groupname.empty() ? "<unnamed group>" : groupname.c_str(), layer,
+            layername.empty() ? "<unnamed layer>" : layername.c_str(),
+            USTR(shadername), opnum, USTR(opname), argnum);
     }
 }
 
 
 
 OSL_SHADEOP int
-osl_range_check_err(int indexvalue, int length, const char* symname, void* sg,
-                    const void* sourcefile, int sourceline,
-                    const char* groupname, int layer, const char* layername,
-                    const char* shadername)
+osl_range_check_err(int indexvalue, int length, ustring_pod symname, void* sg,
+                    ustring_pod sourcefile, int sourceline,
+                    ustring_pod groupname_, int layer, ustring_pod layername_,
+                    ustring_pod shadername)
 {
+    ustringrep groupname = USTR(groupname_);
+    ustringrep layername = USTR(layername_);
     if (indexvalue < 0 || indexvalue >= length) {
         ShadingContext* ctx = (ShadingContext*)((ShaderGlobals*)sg)->context;
         ctx->errorfmt(
             "Index [{}] out of range {}[0..{}]: {}:{} (group {}, layer {} {}, shader {})",
             indexvalue, USTR(symname), length - 1, USTR(sourcefile), sourceline,
-            (groupname && groupname[0]) ? groupname : "<unnamed group>", layer,
-            (layername && layername[0]) ? layername : "<unnamed layer>",
+            groupname.empty() ? "<unnamed group>" : groupname.c_str(), layer,
+            layername.empty() ? "<unnamed layer>" : layername.c_str(),
             USTR(shadername));
         if (indexvalue >= length)
             indexvalue = length - 1;
@@ -4415,7 +4419,7 @@ osl_range_check_err(int indexvalue, int length, const char* symname, void* sg,
 
 // Asked if the raytype is a name we can't know until mid-shader.
 OSL_SHADEOP int
-osl_raytype_name(void* sg_, const char* name)
+osl_raytype_name(void* sg_, ustring_pod name)
 {
     ShaderGlobals* sg = (ShaderGlobals*)sg_;
     int bit           = sg->context->shadingsys().raytype_bit(USTR(name));
@@ -4424,24 +4428,21 @@ osl_raytype_name(void* sg_, const char* name)
 
 
 OSL_SHADEOP int
-osl_get_attribute(void* sg_, int dest_derivs, void* obj_name_, void* attr_name_,
-                  int array_lookup, int index, long long attr_type,
-                  void* attr_dest)
+osl_get_attribute(void* sg_, int dest_derivs, ustring_pod obj_name,
+                  ustring_pod attr_name, int array_lookup, int index,
+                  long long attr_type, void* attr_dest)
 {
-    ShaderGlobals* sg        = (ShaderGlobals*)sg_;
-    const ustring& obj_name  = USTR(obj_name_);
-    const ustring& attr_name = USTR(attr_name_);
-
+    ShaderGlobals* sg = (ShaderGlobals*)sg_;
     return sg->context->osl_get_attribute(sg, sg->objdata, dest_derivs,
-                                          obj_name, attr_name, array_lookup,
-                                          index, TYPEDESC(attr_type),
-                                          attr_dest);
+                                          USTR(obj_name), USTR(attr_name),
+                                          array_lookup, index,
+                                          TYPEDESC(attr_type), attr_dest);
 }
 
 
 
 OSL_SHADEOP int
-osl_bind_interpolated_param(void* sg_, const void* name, long long type,
+osl_bind_interpolated_param(void* sg_, ustring_pod name, long long type,
                             int userdata_has_derivs, void* userdata_data,
                             int /*symbol_has_derivs*/, void* symbol_data,
                             int symbol_data_size, char* userdata_initialized,

--- a/src/liboslexec/wide/wide_opmatrix.cpp
+++ b/src/liboslexec/wide/wide_opmatrix.cpp
@@ -1020,9 +1020,9 @@ __OSL_MASKED_OP3(get_from_to_matrix, Wm, Ws,
 // Also zeroing of derivatives is left to the code generator.
 
 OSL_BATCHOP int
-__OSL_MASKED_OP3(build_transform_matrix, Wm, s, s)(void* bsg_, void* WM_,
-                                                   void* from_, void* to_,
-                                                   unsigned int mask_value)
+__OSL_MASKED_OP3(build_transform_matrix, Wm, s,
+                 s)(void* bsg_, void* WM_, ustring_pod from_, ustring_pod to_,
+                    unsigned int mask_value)
 {
     auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
 
@@ -1056,9 +1056,9 @@ __OSL_MASKED_OP3(build_transform_matrix, Wm, s, s)(void* bsg_, void* WM_,
 
 
 OSL_BATCHOP int
-__OSL_MASKED_OP3(build_transform_matrix, Wm, Ws, s)(void* bsg_, void* WM_,
-                                                    void* wfrom_, void* to_,
-                                                    unsigned int mask_value)
+__OSL_MASKED_OP3(build_transform_matrix, Wm, Ws,
+                 s)(void* bsg_, void* WM_, void* wfrom_, ustring_pod to_,
+                    unsigned int mask_value)
 {
     auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
 
@@ -1092,9 +1092,9 @@ __OSL_MASKED_OP3(build_transform_matrix, Wm, Ws, s)(void* bsg_, void* WM_,
 
 
 OSL_BATCHOP int
-__OSL_MASKED_OP3(build_transform_matrix, Wm, s, Ws)(void* bsg_, void* WM_,
-                                                    void* from_, void* wto_,
-                                                    unsigned int mask_value)
+__OSL_MASKED_OP3(build_transform_matrix, Wm, s,
+                 Ws)(void* bsg_, void* WM_, ustring_pod from_, void* wto_,
+                     unsigned int mask_value)
 {
     auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
 

--- a/src/liboslexec/wide/wide_opmessage.cpp
+++ b/src/liboslexec/wide/wide_opmessage.cpp
@@ -200,18 +200,19 @@ impl_setmessage(BatchedShaderGlobals* bsg, ustring sourcefile, int sourceline,
 
 
 OSL_BATCHOP void
-__OSL_MASKED_OP2(setmessage, s, WX)(BatchedShaderGlobals* bsg_, void* wname,
-                                    long long type, void* wvalue, int layeridx,
-                                    const char* sourcefile_, int sourceline,
+__OSL_MASKED_OP2(setmessage, s, WX)(BatchedShaderGlobals* bsg_,
+                                    ustring_pod name_, long long type,
+                                    void* wvalue, int layeridx,
+                                    ustring_pod sourcefile_, int sourceline,
                                     unsigned int mask_value)
 {
     Mask mask(mask_value);
     OSL_ASSERT(mask.any_on());
 
-    ustring name = USTR(wname);
+    ustringrep name = USTR(name_);
     MaskedData wsrcval(TYPEDESC(type), false /*has_derivs*/, mask, wvalue);
 
-    const ustring& sourcefile(USTR(sourcefile_));
+    ustringrep sourcefile = USTR(sourcefile_);
 
     auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
 
@@ -237,16 +238,16 @@ __OSL_MASKED_OP2(setmessage, s, WX)(BatchedShaderGlobals* bsg_, void* wname,
 OSL_BATCHOP void
 __OSL_MASKED_OP2(setmessage, Ws, WX)(BatchedShaderGlobals* bsg_, void* wname,
                                      long long type, void* wvalue, int layeridx,
-                                     const char* sourcefile_, int sourceline,
+                                     ustring_pod sourcefile_, int sourceline,
                                      unsigned int mask_value)
 {
     Mask mask(mask_value);
     OSL_ASSERT(mask.any_on());
 
-    Wide<const ustring> wName(wname);
+    Wide<const ustringrep> wName(wname);
     MaskedData wsrcval(TYPEDESC(type), false /*has_derivs*/, mask, wvalue);
 
-    const ustring& sourcefile(USTR(sourcefile_));
+    ustringrep sourcefile = USTR(sourcefile_);
 
     auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
 
@@ -274,14 +275,14 @@ __OSL_MASKED_OP2(setmessage, Ws, WX)(BatchedShaderGlobals* bsg_, void* wname,
 
 
 OSL_BATCHOP void
-__OSL_MASKED_OP(getmessage)(void* bsg_, void* result, char* source_,
-                            char* name_, long long type_, void* val, int derivs,
-                            int layeridx, const char* sourcefile_,
+__OSL_MASKED_OP(getmessage)(void* bsg_, void* result, ustring_pod source_,
+                            ustring_pod name_, long long type_, void* val,
+                            int derivs, int layeridx, ustring_pod sourcefile_,
                             int sourceline, unsigned int mask_value)
 {
-    const ustring& source(USTR(source_));
-    const ustring& name(USTR(name_));
-    const ustring& sourcefile(USTR(sourcefile_));
+    ustringrep source     = USTR(source_);
+    ustringrep name       = USTR(name_);
+    ustringrep sourcefile = USTR(sourcefile_);
 
     Mask mask(mask_value);
 

--- a/src/liboslexec/wide/wide_oppointcloud.cpp
+++ b/src/liboslexec/wide/wide_oppointcloud.cpp
@@ -494,7 +494,7 @@ dispatch_pointcloud_write(BatchedShaderGlobals* bsg, ustringhash filename,
 
 OSL_BATCHOP void
 __OSL_MASKED_OP(pointcloud_search)(
-    BatchedShaderGlobals* bsg, void* wout_num_points_, const char* filename,
+    BatchedShaderGlobals* bsg, void* wout_num_points_, ustring_pod filename,
     const void* wcenter_, void* wradius_, int max_points, int sort,
     void* wout_indices_, int indices_array_length, void* wout_distances_,
     int distances_array_length, int distances_has_derivs, int mask_value,
@@ -509,9 +509,8 @@ __OSL_MASKED_OP(pointcloud_search)(
                                    mask_value };
 
     ShadingContext* ctx = bsg->uniform.context;
-    if (ctx->shadingsys()
-            .no_pointcloud())  // Debug mode to skip pointcloud expense
-    {
+    if (ctx->shadingsys().no_pointcloud()) {
+        // Debug mode to skip pointcloud expense
         assign_all(pcsr.wnum_points(), 0);
         return;  // mask_value;
     }
@@ -528,11 +527,9 @@ __OSL_MASKED_OP(pointcloud_search)(
         va_list args;
         va_start(args, nattrs);
         for (int i = 0; i < nattrs; i++) {
-            ustring attr_name = ustring::from_unique(
-                (const char*)va_arg(args, const char*));
-            long long lltype   = va_arg(args, long long);
-            TypeDesc attr_type = TYPEDESC(lltype);
-            void* out_data     = va_arg(args, void*);
+            ustringrep attr_name = USTREP(va_arg(args, ustring_pod));
+            TypeDesc attr_type   = TYPEDESC(va_arg(args, long long));
+            void* out_data       = va_arg(args, void*);
             dispatch_pointcloud_get(
                 bsg, USTR(filename), windices, wnum_points, attr_name,
                 MaskedData { attr_type, false, Mask { mask_value }, out_data });
@@ -547,9 +544,9 @@ __OSL_MASKED_OP(pointcloud_search)(
 
 
 OSL_BATCHOP int
-__OSL_MASKED_OP(pointcloud_get)(BatchedShaderGlobals* bsg, const char* filename,
+__OSL_MASKED_OP(pointcloud_get)(BatchedShaderGlobals* bsg, ustring_pod filename,
                                 void* windices_, int indices_array_length,
-                                void* wnum_points_, const char* attr_name,
+                                void* wnum_points_, ustring_pod attr_name,
                                 long long attr_type_, void* wout_data_,
                                 int mask_value)
 {
@@ -574,7 +571,7 @@ __OSL_MASKED_OP(pointcloud_get)(BatchedShaderGlobals* bsg, const char* filename,
 
 OSL_BATCHOP int
 __OSL_MASKED_OP(pointcloud_write)(BatchedShaderGlobals* bsg,
-                                  const char* filename, const void* wpos_,
+                                  ustring_pod filename, const void* wpos_,
                                   int nattribs, const ustringrep* attr_names,
                                   const TypeDesc* attr_types,
                                   const void** ptrs_to_wide_attr_value,

--- a/src/liboslexec/wide/wide_opspline.cpp
+++ b/src/liboslexec/wide/wide_opspline.cpp
@@ -456,7 +456,7 @@ spline_evaluate_wide(RAccessorT wR, ustring spline_basis, XAccessorT wX,
                 true /*is_basis_u_constant */, 1 /* basis_step */,
                 ConstantWeights, RAccessorT, XAccessorT, KAccessor_T> };
 
-    unsigned int basis_type = Spline::basis_type_of(USTR(spline_basis));
+    unsigned int basis_type = Spline::basis_type_of(spline_basis);
 
     OSL_DASSERT(basis_type < Spline::kNumSplineTypes
                 && "unsupported spline basis");
@@ -539,7 +539,7 @@ splineinverse_evaluate_wide(RAccessorT wR, ustring spline_basis, XAccessorT wX,
                 true /*is_basis_u_constant */, 1 /* basis_step */,
                 ConstantWeights, RAccessorT, XAccessorT, KAccessor_T> };
 
-    unsigned int basis_type = Spline::basis_type_of(USTR(spline_basis));
+    unsigned int basis_type = Spline::basis_type_of(spline_basis);
 
     OSL_DASSERT(basis_type < Spline::kNumSplineTypes
                 && "unsupported spline basis");

--- a/src/liboslexec/wide/wide_opstring.cpp
+++ b/src/liboslexec/wide/wide_opstring.cpp
@@ -354,7 +354,7 @@ __OSL_MASKED_OP(regex_impl)(void* bsg_, void* wsuccess_ptr, void* wsubject_ptr,
 
         const std::string& subject = usubject.string();
         std::match_results<std::string::const_iterator> mresults;
-        const std::regex& regex(ctx->find_regex(USTR(pattern)));
+        const std::regex& regex(ctx->find_regex(pattern));
         if (nresults > 0) {
             std::string::const_iterator start = subject.begin();
             int res = fullmatch ? std::regex_match(subject, mresults, regex)
@@ -366,7 +366,7 @@ __OSL_MASKED_OP(regex_impl)(void* bsg_, void* wsuccess_ptr, void* wsubject_ptr,
                     else
                         results[r] = mresults[r / 2].second - start;
                 } else {
-                    results[r] = USTR(pattern).length();
+                    results[r] = pattern.length();
                 }
             }
             wsuccess[lane] = res;

--- a/src/liboslexec/wide/wide_shadingsys.cpp
+++ b/src/liboslexec/wide/wide_shadingsys.cpp
@@ -29,9 +29,9 @@ using WidthTag = OSL::WidthOf<__OSL_WIDTH>;
 // firstcheck,nchecks are used to check just one element of an array.
 OSL_BATCHOP void
 __OSL_OP(naninf_check)(int ncomps, const void* vals_, int has_derivs,
-                       void* bsg_, const void* sourcefile, int sourceline,
-                       void* symbolname, int firstcheck, int nchecks,
-                       const void* opname)
+                       void* bsg_, ustring_pod sourcefile, int sourceline,
+                       ustring_pod symbolname, int firstcheck, int nchecks,
+                       ustring_pod opname)
 {
     auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
     ShadingContext* ctx = bsg->uniform.context;
@@ -56,9 +56,9 @@ __OSL_OP(naninf_check)(int ncomps, const void* vals_, int has_derivs,
 OSL_BATCHOP void
 __OSL_MASKED_OP1(naninf_check_offset,
                  i)(int mask_value, int ncomps, const void* vals_,
-                    int has_derivs, void* bsg_, const void* sourcefile,
-                    int sourceline, void* symbolname, int firstcheck,
-                    int nchecks, const void* opname)
+                    int has_derivs, void* bsg_, ustring_pod sourcefile,
+                    int sourceline, ustring_pod symbolname, int firstcheck,
+                    int nchecks, ustring_pod opname)
 {
     auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
     ShadingContext* ctx = bsg->uniform.context;
@@ -88,12 +88,12 @@ __OSL_MASKED_OP1(naninf_check_offset,
 
 // Wide vals + mask + varying index
 OSL_BATCHOP void
-__OSL_MASKED_OP1(naninf_check_offset, Wi)(int mask_value, int ncomps,
-                                          const void* vals_, int has_derivs,
-                                          void* bsg_, const void* sourcefile,
-                                          int sourceline, void* symbolname,
-                                          const void* wide_offsets_ptr,
-                                          int nchecks, const void* opname)
+__OSL_MASKED_OP1(naninf_check_offset,
+                 Wi)(int mask_value, int ncomps, const void* vals_,
+                     int has_derivs, void* bsg_, ustring_pod sourcefile,
+                     int sourceline, ustring_pod symbolname,
+                     const void* wide_offsets_ptr, int nchecks,
+                     ustring_pod opname)
 {
     auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
     ShadingContext* ctx = bsg->uniform.context;
@@ -129,9 +129,9 @@ __OSL_MASKED_OP1(naninf_check_offset, Wi)(int mask_value, int ncomps,
 OSL_BATCHOP void
 __OSL_OP2(uninit_check_values_offset, X,
           i)(long long typedesc_, void* vals_, void* bsg_,
-             const void* sourcefile, int sourceline, const char* groupname,
-             int layer, const char* layername, const char* shadername,
-             int opnum, const char* opname, int argnum, void* symbolname,
+             ustring_pod sourcefile, int sourceline, ustring_pod groupname_,
+             int layer, ustring_pod layername_, ustring_pod shadername,
+             int opnum, ustring_pod opname, int argnum, ustring_pod symbolname,
              int firstcheck, int nchecks)
 {
     TypeDesc typedesc   = TYPEDESC(typedesc_);
@@ -163,12 +163,14 @@ __OSL_OP2(uninit_check_values_offset, X,
             }
     }
     if (uninit) {
+        ustringrep groupname = USTR(groupname_);
+        ustringrep layername = USTR(layername_);
         ctx->errorfmt(
             "Detected possible use of uninitialized value in {} {} at {}:{} (group {}, layer {} {}, shader {}, op {} '{}', arg {})",
-            typedesc, USTR(symbolname), USTR(sourcefile), sourceline,
-            (groupname && groupname[0]) ? groupname : "<unnamed group>", layer,
-            (layername && layername[0]) ? layername : "<unnamed layer>",
-            shadername, opnum, USTR(opname), argnum);
+            typedesc, symbolname, sourcefile, sourceline,
+            groupname.empty() ? "<unnamed group>" : groupname.c_str(), layer,
+            layername.empty() ? "<unnamed layer>" : layername.c_str(),
+            shadername, opnum, opname, argnum);
     }
 }
 
@@ -179,10 +181,11 @@ __OSL_OP2(uninit_check_values_offset, X,
 OSL_BATCHOP void
 __OSL_MASKED_OP2(uninit_check_values_offset, WX,
                  i)(int mask_value, long long typedesc_, void* vals_,
-                    void* bsg_, const void* sourcefile, int sourceline,
-                    const char* groupname, int layer, const char* layername,
-                    const char* shadername, int opnum, const char* opname,
-                    int argnum, void* symbolname, int firstcheck, int nchecks)
+                    void* bsg_, ustring_pod sourcefile, int sourceline,
+                    ustring_pod groupname_, int layer, ustring_pod layername_,
+                    ustring_pod shadername, int opnum, ustring_pod opname,
+                    int argnum, ustring_pod symbolname, int firstcheck,
+                    int nchecks)
 {
     TypeDesc typedesc   = TYPEDESC(typedesc_);
     auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
@@ -224,12 +227,14 @@ __OSL_MASKED_OP2(uninit_check_values_offset, WX,
             });
     }
     if (lanes_uninit.any_on()) {
+        ustringrep groupname = USTR(groupname_);
+        ustringrep layername = USTR(layername_);
         ctx->errorfmt(
             "Detected possible use of uninitialized value in {} {} at {}:{} (group {}, layer {} {}, shader {}, op {} '{}', arg {}) for lanes({:x}) of batch",
-            typedesc, USTR(symbolname), USTR(sourcefile), sourceline,
-            (groupname && groupname[0]) ? groupname : "<unnamed group>", layer,
-            (layername && layername[0]) ? layername : "<unnamed layer>",
-            shadername, opnum, USTR(opname), argnum, lanes_uninit.value());
+            typedesc, symbolname, sourcefile, sourceline,
+            groupname.empty() ? "<unnamed group>" : groupname.c_str(), layer,
+            layername.empty() ? "<unnamed layer>" : layername.c_str(),
+            shadername, opnum, opname, argnum, lanes_uninit.value());
     }
 }
 
@@ -240,11 +245,11 @@ __OSL_MASKED_OP2(uninit_check_values_offset, WX,
 OSL_BATCHOP void
 __OSL_MASKED_OP2(uninit_check_values_offset, X,
                  Wi)(int mask_value, long long typedesc_, void* vals_,
-                     void* bsg_, const void* sourcefile, int sourceline,
-                     const char* groupname, int layer, const char* layername,
-                     const char* shadername, int opnum, const char* opname,
-                     int argnum, void* symbolname, const void* wide_offsets_ptr,
-                     int nchecks)
+                     void* bsg_, ustring_pod sourcefile, int sourceline,
+                     ustring_pod groupname_, int layer, ustring_pod layername_,
+                     ustring_pod shadername, int opnum, ustring_pod opname,
+                     int argnum, ustring_pod symbolname,
+                     const void* wide_offsets_ptr, int nchecks)
 {
     TypeDesc typedesc   = TYPEDESC(typedesc_);
     auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
@@ -288,12 +293,14 @@ __OSL_MASKED_OP2(uninit_check_values_offset, X,
     }
 
     if (lanes_uninit.any_on()) {
+        ustringrep groupname = USTR(groupname_);
+        ustringrep layername = USTR(layername_);
         ctx->errorfmt(
             "Detected possible use of uninitialized value in {} {} at {}:{} (group {}, layer {} {}, shader {}, op {} '{}', arg {}) for lanes({:x}) of batch",
-            typedesc, USTR(symbolname), USTR(sourcefile), sourceline,
-            (groupname && groupname[0]) ? groupname : "<unnamed group>", layer,
-            (layername && layername[0]) ? layername : "<unnamed layer>",
-            shadername, opnum, USTR(opname), argnum, lanes_uninit.value());
+            typedesc, symbolname, sourcefile, sourceline,
+            groupname.empty() ? "<unnamed group>" : groupname.c_str(), layer,
+            layername.empty() ? "<unnamed layer>" : layername.c_str(),
+            shadername, opnum, opname, argnum, lanes_uninit.value());
     }
 }
 
@@ -304,11 +311,11 @@ __OSL_MASKED_OP2(uninit_check_values_offset, X,
 OSL_BATCHOP void
 __OSL_MASKED_OP2(uninit_check_values_offset, WX,
                  Wi)(int mask_value, long long typedesc_, void* vals_,
-                     void* bsg_, const void* sourcefile, int sourceline,
-                     const char* groupname, int layer, const char* layername,
-                     const char* shadername, int opnum, const char* opname,
-                     int argnum, void* symbolname, const void* wide_offsets_ptr,
-                     int nchecks)
+                     void* bsg_, ustring_pod sourcefile, int sourceline,
+                     ustring_pod groupname_, int layer, ustring_pod layername_,
+                     ustring_pod shadername, int opnum, ustring_pod opname,
+                     int argnum, ustring_pod symbolname,
+                     const void* wide_offsets_ptr, int nchecks)
 {
     TypeDesc typedesc   = TYPEDESC(typedesc_);
     auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
@@ -354,33 +361,38 @@ __OSL_MASKED_OP2(uninit_check_values_offset, WX,
     }
 
     if (lanes_uninit.any_on()) {
+        ustringrep groupname = USTR(groupname_);
+        ustringrep layername = USTR(layername_);
         ctx->errorfmt(
             "Detected possible use of uninitialized value in {} {} at {}:{} (group {}, layer {} {}, shader {}, op {} '{}', arg {}) for lanes({:x}) of batch",
-            typedesc, USTR(symbolname), USTR(sourcefile), sourceline,
-            (groupname && groupname[0]) ? groupname : "<unnamed group>", layer,
-            (layername && layername[0]) ? layername : "<unnamed layer>",
-            shadername, opnum, USTR(opname), argnum, lanes_uninit.value());
+            typedesc, symbolname, sourcefile, sourceline,
+            groupname.empty() ? "<unnamed group>" : groupname.c_str(), layer,
+            layername.empty() ? "<unnamed layer>" : layername.c_str(),
+            shadername, opnum, opname, argnum, lanes_uninit.value());
     }
 }
 
 
 
 OSL_BATCHOP int
-__OSL_OP(range_check)(int indexvalue, int length, const char* symname,
-                      void* bsg_, const void* sourcefile, int sourceline,
-                      const char* groupname, int layer, const char* layername,
-                      const char* shadername)
+__OSL_OP(range_check)(int indexvalue, int length, ustring_pod symname,
+                      void* bsg_, ustring_pod sourcefile, int sourceline,
+                      ustring_pod groupname_, int layer, ustring_pod layername_,
+                      ustring_pod shadername)
 {
     if (indexvalue < 0 || indexvalue >= length) {
-        auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
-        ShadingContext* ctx = bsg->uniform.context;
-        ctx->errorfmt(
-            "Index [{}] out of range {}[0..{}]: {}:{}"
-            " (group {}, layer {} {}, shader {})",
-            indexvalue, USTR(symname), length - 1, USTR(sourcefile), sourceline,
-            (groupname && groupname[0]) ? groupname : "<unnamed group>", layer,
-            (layername && layername[0]) ? layername : "<unnamed layer>",
-            USTR(shadername));
+        ustringrep groupname = USTR(groupname_);
+        ustringrep layername = USTR(layername_);
+        auto* bsg            = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+        ShadingContext* ctx  = bsg->uniform.context;
+        ctx->errorfmt("Index [{}] out of range {}[0..{}]: {}:{}"
+                      " (group {}, layer {} {}, shader {})",
+                      indexvalue, USTR(symname), length - 1, USTR(sourcefile),
+                      sourceline,
+                      groupname.empty() ? "<unnamed group>" : groupname.c_str(),
+                      layer,
+                      layername.empty() ? "<unnamed layer>" : layername.c_str(),
+                      USTR(shadername));
         if (indexvalue >= length)
             indexvalue = length - 1;
         else
@@ -393,12 +405,14 @@ __OSL_OP(range_check)(int indexvalue, int length, const char* symname,
 
 OSL_BATCHOP void
 __OSL_MASKED_OP(range_check)(void* wide_indexvalue, unsigned int mask_value,
-                             int length, const char* symname, void* bsg_,
-                             const void* sourcefile, int sourceline,
-                             const char* groupname, int layer,
-                             const char* layername, const char* shadername)
+                             int length, ustring_pod symname, void* bsg_,
+                             ustring_pod sourcefile, int sourceline,
+                             ustring_pod groupname_, int layer,
+                             ustring_pod layername_, ustring_pod shadername)
 {
-    auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ustringrep groupname = USTR(groupname_);
+    ustringrep layername = USTR(layername_);
+    auto* bsg            = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
     Masked<int> wIndexValue(wide_indexvalue, Mask(mask_value));
     wIndexValue.mask().foreach ([=](ActiveLane lane) -> void {
         int indexvalue = wIndexValue[lane];
@@ -408,9 +422,9 @@ __OSL_MASKED_OP(range_check)(void* wide_indexvalue, unsigned int mask_value,
                 "Index [{}] out of range {}[0..{}]: {}:{} (group {}, layer {} {}, shader {})",
                 indexvalue, USTR(symname), length - 1, USTR(sourcefile),
                 sourceline,
-                (groupname && groupname[0]) ? groupname : "<unnamed group>",
+                groupname.empty() ? "<unnamed group>" : groupname.c_str(),
                 layer,
-                (layername && layername[0]) ? layername : "<unnamed layer>",
+                layername.empty() ? "<unnamed layer>" : layername.c_str(),
                 USTR(shadername));
             if (indexvalue >= length)
                 indexvalue = length - 1;
@@ -425,17 +439,17 @@ __OSL_MASKED_OP(range_check)(void* wide_indexvalue, unsigned int mask_value,
 
 
 OSL_BATCHOP int
-__OSL_OP1(get_attribute, s)(void* bsg_, int dest_derivs, void* obj_name_,
-                            void* attr_name_, int array_lookup, int index,
+__OSL_OP1(get_attribute, s)(void* bsg_, int dest_derivs, ustring_pod obj_name_,
+                            ustring_pod attr_name_, int array_lookup, int index,
                             const void* attr_type, void* wide_attr_dest,
                             int mask_)
 {
     Mask mask(mask_);
     ASSERT(mask.any_on());
 
-    auto* bsg                = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
-    const ustring& obj_name  = USTR(obj_name_);
-    const ustring& attr_name = USTR(attr_name_);
+    auto* bsg            = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ustringrep obj_name  = USTR(obj_name_);
+    ustringrep attr_name = USTR(attr_name_);
 
     // Ignoring m_next_failed_attrib cache for now,
     // might be faster
@@ -457,16 +471,16 @@ __OSL_OP1(get_attribute, s)(void* bsg_, int dest_derivs, void* obj_name_,
 
 OSL_BATCHOP int
 __OSL_MASKED_OP1(get_attribute,
-                 Ws)(void* bsg_, int dest_derivs, void* obj_name_,
-                     void* wattr_name_, int array_lookup, int index,
+                 Ws)(void* bsg_, int dest_derivs, ustring_pod obj_name_,
+                     ustring_pod* wattr_name_, int array_lookup, int index,
                      const void* attr_type, void* wide_attr_dest, int mask_)
 {
     Mask mask(mask_);
     ASSERT(mask.any_on());
 
-    auto* bsg               = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
-    const ustring& obj_name = USTR(obj_name_);
-    Wide<const ustring> wAttrName(wattr_name_);
+    auto* bsg           = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ustringrep obj_name = USTR(obj_name_);
+    Wide<const ustringrep> wAttrName(wattr_name_);
     auto* renderer = bsg->uniform.context->batched<__OSL_WIDTH>().renderer();
 
     Mask retVal(false);
@@ -504,13 +518,14 @@ __OSL_MASKED_OP1(get_attribute,
 
 
 OSL_BATCHOP bool
-__OSL_OP(get_attribute_uniform)(void* bsg_, int dest_derivs, void* obj_name_,
-                                void* attr_name_, int array_lookup, int index,
+__OSL_OP(get_attribute_uniform)(void* bsg_, int dest_derivs,
+                                ustring_pod obj_name_, ustring_pod attr_name_,
+                                int array_lookup, int index,
                                 const void* attr_type, void* attr_dest)
 {
-    auto* bsg                = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
-    const ustring& obj_name  = USTR(obj_name_);
-    const ustring& attr_name = USTR(attr_name_);
+    auto* bsg            = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
+    ustringrep obj_name  = USTR(obj_name_);
+    ustringrep attr_name = USTR(attr_name_);
 
     auto* renderer = bsg->uniform.context->batched<__OSL_WIDTH>().renderer();
 
@@ -530,7 +545,7 @@ __OSL_OP(get_attribute_uniform)(void* bsg_, int dest_derivs, void* obj_name_,
 
 
 OSL_BATCHOP int
-__OSL_OP(bind_interpolated_param)(void* bsg_, const void* name, long long type,
+__OSL_OP(bind_interpolated_param)(void* bsg_, ustring_pod name, long long type,
                                   int userdata_has_derivs, void* userdata_data,
                                   int symbol_has_derivs, void* symbol_data,
                                   int symbol_data_size,
@@ -580,7 +595,7 @@ __OSL_OP(raytype_bit)(void* bsg_, int bit)
 
 // Asked if the raytype is a name we can't know until mid-shader.
 OSL_BATCHOP int
-__OSL_OP(raytype_name)(void* bsg_, void* name)
+__OSL_OP(raytype_name)(void* bsg_, ustring_pod name)
 {
     auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
     int bit   = bsg->uniform.context->shadingsys().raytype_bit(USTR(name));
@@ -590,11 +605,11 @@ __OSL_OP(raytype_name)(void* bsg_, void* name)
 
 
 OSL_BATCHOP void
-__OSL_MASKED_OP(raytype_name)(void* bsg_, void* r_, void* name_,
+__OSL_MASKED_OP(raytype_name)(void* bsg_, void* r_, ustringrep* name_,
                               unsigned int mask_value)
 {
     auto* bsg = reinterpret_cast<BatchedShaderGlobals*>(bsg_);
-    Wide<const ustring> wname(name_);
+    Wide<const ustringrep> wname(name_);
     Mask mask(mask_value);
 
     foreach_unique(wname, mask, [=](ustring name, Mask matching_lanes) -> void {

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -265,7 +265,7 @@ rend_get_userdata(OSL::StringParam name, void* data, int data_size,
 
 
 __device__ int
-osl_bind_interpolated_param(void* sg_, const void* name, long long type,
+osl_bind_interpolated_param(void* sg_, OSL::StringParam name, long long type,
                             int userdata_has_derivs, void* userdata_data,
                             int symbol_has_derivs, void* symbol_data,
                             int symbol_data_size, char* userdata_initialized,
@@ -411,10 +411,10 @@ osl_texture(void* sg_, const char* name, void* handle, void* opt_, float s,
 
 
 __device__ int
-osl_range_check_err(int indexvalue, int length, const char* symname, void* sg,
-                    const void* sourcefile, int sourceline,
-                    const char* groupname, int layer, const char* layername,
-                    const char* shadername)
+osl_range_check_err(int indexvalue, int length, OSL::ustring_pod symname,
+                    void* sg, OSL::ustring_pod sourcefile, int sourceline,
+                    OSL::ustring_pod groupname, int layer,
+                    OSL::ustring_pod layername, OSL::ustring_pod shadername)
 {
     if (indexvalue < 0 || indexvalue >= length) {
         return indexvalue < 0 ? 0 : length - 1;
@@ -425,9 +425,10 @@ osl_range_check_err(int indexvalue, int length, const char* symname, void* sg,
 
 
 __device__ int
-osl_range_check(int indexvalue, int length, const char* symname, void* sg,
-                const void* sourcefile, int sourceline, const char* groupname,
-                int layer, const char* layername, const char* shadername)
+osl_range_check(int indexvalue, int length, OSL::ustring_pod symname, void* sg,
+                OSL::ustring_pod sourcefile, int sourceline,
+                OSL::ustring_pod groupname, int layer,
+                OSL::ustring_pod layername, OSL::ustring_pod shadername)
 {
     if (indexvalue < 0 || indexvalue >= length) {
         indexvalue = osl_range_check_err(indexvalue, length, symname, sg,

--- a/testsuite/example-cuda/rend_lib.cu
+++ b/testsuite/example-cuda/rend_lib.cu
@@ -221,7 +221,7 @@ rend_get_userdata(OSL::StringParam name, void* data, int data_size,
 #undef IS_PTR
 
 __device__ int
-osl_bind_interpolated_param(void* sg_, const void* name, long long type,
+osl_bind_interpolated_param(void* sg_, OSL::ustring_pod name, long long type,
                             int userdata_has_derivs, void* userdata_data,
                             int symbol_has_derivs, void* symbol_data,
                             int symbol_data_size, char* userdata_initialized,
@@ -336,10 +336,10 @@ osl_texture(void* sg_, const char* name, void* handle, void* opt_, float s,
 }
 
 __device__ int
-osl_range_check_err(int indexvalue, int length, const char* symname, void* sg,
-                    const void* sourcefile, int sourceline,
-                    const char* groupname, int layer, const char* layername,
-                    const char* shadername)
+osl_range_check_err(int indexvalue, int length, OSL::ustring_pod symname,
+                    void* sg, OSL::ustring_pod sourcefile, int sourceline,
+                    OSL::ustring_pod groupname, int layer,
+                    OSL::ustring_pod layername, OSL::ustring_pod shadername)
 {
     if (indexvalue < 0 || indexvalue >= length) {
         return indexvalue < 0 ? 0 : length - 1;
@@ -348,9 +348,10 @@ osl_range_check_err(int indexvalue, int length, const char* symname, void* sg,
 }
 
 __device__ int
-osl_range_check(int indexvalue, int length, const char* symname, void* sg,
-                const void* sourcefile, int sourceline, const char* groupname,
-                int layer, const char* layername, const char* shadername)
+osl_range_check(int indexvalue, int length, OSL::ustring_pod symname, void* sg,
+                OSL::ustring_pod sourcefile, int sourceline,
+                OSL::ustring_pod groupname, int layer,
+                OSL::ustring_pod layername, OSL::ustring_pod shadername)
 {
     if (indexvalue < 0 || indexvalue >= length) {
         indexvalue = osl_range_check_err(indexvalue, length, symname, sg,


### PR DESCRIPTION
Reminder: phase 1 changed the RendererServices APIs to be based completely on ustringhash for public method calls, not ustring.

This PR starts along the path of phase 2.

In oslconfig.h, I define a new type `ustringrep` which is the in-memory/in-shader CPU-side representation of a ustring. Currently, it's still equivalent to a ustring.

I also define a type called `ustring_pod`, which is the "plain old data" representation inside a ustringrep (i.e., a const char* when it's a ustring, and a uint64_t when it's a ustringhash). For reasons not important, it's exceedingly hard to pass a true ustring/ustringhash as parameters to or from LLVM-jitted code without running afoul of LLVM's type checking, so it's just easier to pass the underlying data type.

So the main work of phase 2 is to change everything related to shader data from a ustring into a ustringrep, and things passed as const char* into passing a ustring_pod. In some sense, it's just renaming and type conversion plumbing.  When that's done, phase 3 is to throw the switch and change the definition of ustringrep to ustringhash (and of course fix everything that's broken).

This PR does not complete phase 2, but takes a big bite out of it. It's an arbitrary bite, not much rhyme or reason to which specific parts I did so far. Just working on it piece by piece and felt that this was a place where much has been done, everything still works, and it's a reviewable chunk without getting too much out of control.

Areas I worked on are related to range_check, raytype, getattribute, bind_interpolated_param, uninit_check, naninf_check, getmessage/setmessage, some texture setup, pointcloud.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
