### PR TITLE
Add clangSupport as dependency to fix linker error

### DIFF
--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -121,7 +121,7 @@ endif ()
 
 foreach (COMPONENT clangFrontend clangDriver clangSerialization
                    clangParse clangSema clangAnalysis clangAST clangBasic
-                   clangEdit clangLex)
+                   clangEdit clangLex clangSupport)
     find_library ( _CLANG_${COMPONENT}_LIBRARY
                   NAMES ${COMPONENT}
                   PATHS ${LLVM_LIB_DIR})


### PR DESCRIPTION
## Description

This PR fixes a linker error that happens when building for windows
Linker errors where (similar to):
```
clangSema.lib(SemaRISCVVectorLookup.obj) : error LNK2019: unresolved external symbol "public: static class llvm::Optio
nal<class std::vector<class clang::RISCV::RVVType *,class std::allocator<class clang::RISCV::RVVType *> > > __cdecl cl
ang::RISCV::RVVType::computeTypes(enum clang::RISCV::BasicType,int,unsigned int,class llvm::ArrayRef<struct clang::RIS
CV::PrototypeDescriptor>)" (?computeTypes@RVVType@RISCV@clang@@SA?AV?$Optional@V?$vector@PEAVRVVType@RISCV@clang@@V?$a
llocator@PEAVRVVType@RISCV@clang@@@std@@@std@@@llvm@@W4BasicType@23@HIV?$ArrayRef@UPrototypeDescriptor@RISCV@clang@@@5
@@Z) referenced in function "private: void __cdecl `anonymous namespace'::RISCVIntrinsicManagerImpl::InitIntrinsicList
(void)" (?InitIntrinsicList@RISCVIntrinsicManagerImpl@?A0x7f5fba13@@AEAAXXZ) [<snip>\OpenShadingLanguage\cmBuild
\src\liboslexec\oslexec.vcxproj]
clangSema.lib(SemaRISCVVectorLookup.obj) : error LNK2019: unresolved external symbol "public: static class std::basic_
string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl clang::RISCV::RVVIntrinsic::getSuffixSt
r(enum clang::RISCV::BasicType,int,class llvm::ArrayRef<struct clang::RISCV::PrototypeDescriptor>)" (?getSuffixStr@RVV
Intrinsic@RISCV@clang@@SA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4BasicType@23@HV?$ArrayRef@U
PrototypeDescriptor@RISCV@clang@@@llvm@@@Z) referenced in function "private: void __cdecl `anonymous namespace'::RISCV
IntrinsicManagerImpl::InitIntrinsicList(void)" (?InitIntrinsicList@RISCVIntrinsicManagerImpl@?A0x7f5fba13@@AEAAXXZ) [<snip>\OpenShadingLanguage\cmBuild\src\liboslexec\oslexec.vcxproj]
clangSema.lib(SemaRISCVVectorLookup.obj) : error LNK2019: unresolved external symbol "public: static class llvm::Small
Vector<struct clang::RISCV::PrototypeDescriptor,13> __cdecl clang::RISCV::RVVIntrinsic::computeBuiltinTypes(class llvm
::ArrayRef<struct clang::RISCV::PrototypeDescriptor>,bool,bool,bool,unsigned int)" (?computeBuiltinTypes@RVVIntrinsic@
RISCV@clang@@SA?AV?$SmallVector@UPrototypeDescriptor@RISCV@clang@@$0N@@llvm@@V?$ArrayRef@UPrototypeDescriptor@RISCV@cl
ang@@@5@_N11I@Z) referenced in function "private: void __cdecl `anonymous namespace'::RISCVIntrinsicManagerImpl::InitI
ntrinsicList(void)" (?InitIntrinsicList@RISCVIntrinsicManagerImpl@?A0x7f5fba13@@AEAAXXZ) [<snip>\OpenShadingLang
uage\cmBuild\src\liboslexec\oslexec.vcxproj]
<snip>\OpenShadingLanguage\cmBuild\bin\Release\oslexec.dll : fatal error LNK1120: 3 unresolved externals [<snip>\OpenShadingLanguage\cmBuild\src\liboslexec\oslexec.vcxproj]
```
This was using VS2022 + LVMM15. 
I have not tested other combinations.

## Tests

Building now works, otherwise it does not


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

