### PR TITLE
CI: Adjust when jobs are run to cut needless CI

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -19,6 +19,11 @@ on:
 
 permissions: read-all
 
+# Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ on:
       - '**.rst'
       - '**.tex'
   schedule:
-    # Full nightly build
+    # Full nightly build, for the main project repo (not for forks)
     - cron: "0 6 * * *"
+      if: github.repository == 'AcademySoftwareFoundation/OpenShadingLanguage'
+
 
 permissions: read-all
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -10,18 +10,23 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+# Allow subsequent pushes to the same PR or REF to cancel any previous jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   analysis:
     name: Scorecards analysis
+    if: |
+      github.repository == 'AcademySoftwareFoundation/OpenShadingLanguage'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Used to receive a badge. (Upcoming feature)
       id-token: write
-      # Needs for private repositories.
-      contents: read
-      actions: read
     
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
Changes:
* Scorecards and analysis -- allow new submissions to cancel running old jobs
* Scorecard only runs on main repo, no need to run on forks
* Nightly CI only runs on main repo, no need to run on forks

Signed-off-by: Larry Gritz <lg@larrygritz.com>

