### PR TITLE
CMake: Adjust how version overrides work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,14 @@
 
 cmake_minimum_required (VERSION 3.12)
 
-set (OSL_VERSION "1.13.2.0" CACHE STRING "Version")
+set (OSL_VERSION "1.13.2.0")
+set (OSL_VERSION_OVERRIDE "" CACHE STRING
+     "Version override (use with caution)!")
+mark_as_advanced (OSL_VERSION_OVERRIDE)
+if (OSL_VERSION_OVERRIDE)
+    set (OSL_VERSION ${OSL_VERSION_OVERRIDE})
+endif ()
+
 project (OSL VERSION ${OSL_VERSION}
          LANGUAGES CXX C
          HOMEPAGE_URL "https://github.com/AcademySoftwareFoundation/OpenShadingLanguage")


### PR DESCRIPTION
Related to https://github.com/OpenImageIO/oiio/pull/3653

Kai Pastor (@dg0yt) points out that the recent change I made both in OIIO and OSL to make the version a cache variable has some unexpected side effects that can lead to unexpeted behavior by inadvertently retaining a version number upon recompiles if the cache itself was not cleared, and this can happen unexpectedly even when the user isn't trying to override the version.

This patch changes the behavior as follows:

You must use the special `-DOSL_VERSION_OVERRIDE=...` to override the version.

  * if you do so, you are playing with fire and get what you deserve if you misuse it or change branches and don't remember to clear the cache.

If you do a normal build (without trying to override the version),

  * you will get the real version number because it IS NOT cached
  * if you switch branches, you'll always get the right version number
  * ...but switching branches without clearing the cache can still, as always, have other subtle behavior differences versus doing a truly fresh build from scratch.

So in short, it still allows a way to override the version if you really want to, but if you are not trying to do that, you can no longer get yourself inadvertently into unexpected trouble.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
