### PR TITLE
CI: No longer add the ppa:ubuntu-toolchain-r/test repository

### DIFF
--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -61,7 +61,7 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
 else
     # Using native Ubuntu runner
 
-    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    # sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     time sudo apt-get update
 
     time sudo apt-get -q install -y \


### PR DESCRIPTION
Lately, it has been experiencing intermittent availability problems that causes our CI to fail while setting up dependencies.

What happens if we don't use the problematic ubuntu-toolchain-r at all?

Nothing, it seems. So eliminate it.

I think that once upon a time, it was necessary to add this repo to get certain new packages? But maybe they are mainstream enough now that it's not necessary to add this repo? In any case, it doesn't seem to hurt anything, it's one less moving part that can't fail if it's not there.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
