### PR TITLE
Fix Batched Mode Crash When Adding A Default Initialized Closure

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -236,7 +236,8 @@ macro (osl_add_all_tests)
                 bug-array-heapoffsets bug-locallifetime bug-outputinit
                 bug-param-duplicate bug-peep bug-return
                 calculatenormal-reg
-                cellnoise closure closure-array closure-parameters color color-reg colorspace comparison
+                cellnoise closure closure-array closure-parameters closure-zero
+                color color-reg colorspace comparison
                 complement-reg compile-buffer compassign-reg
                 component-range
                 control-flow-reg connect-components

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -2303,6 +2303,17 @@ struct Analyzer {
         }
     }
 
+    void make_closures_varying()
+    {
+        // We assume that closures are always stored as varying pointers
+        FOREACH_PARAM(Symbol & s, inst())
+        {
+            if (s.typespec().is_closure()) {
+                recursively_mark_varying(&s);
+            }
+        }
+    }
+
     void push_varying_of_upstream_connections()
     {
         OSL_DEV_ONLY(std::cout << "connections to layer begin" << std::endl);
@@ -2395,6 +2406,7 @@ BatchedAnalysis::analyze_layer(ShaderInstance* inst)
     analyzer.push_varying_of_shader_globals();
     analyzer.make_interpolated_parameters_varying();
     analyzer.make_renderer_outputs_varying();
+    analyzer.make_closures_varying();
     analyzer.push_varying_of_upstream_connections();
     analyzer.push_varying_of_implicitly_varying_ops();
 

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -1263,6 +1263,7 @@ LLVMGEN(llvm_gen_add)
     OSL_ASSERT(!A.typespec().is_array() && !B.typespec().is_array());
     if (Result.typespec().is_closure()) {
         OSL_ASSERT(A.typespec().is_closure() && B.typespec().is_closure());
+        OSL_ASSERT(!A.is_uniform() && !B.is_uniform() && !result_is_uniform);
         llvm::Value* valargs[] = { rop.sg_void_ptr(), rop.llvm_void_ptr(Result),
                                    rop.llvm_void_ptr(A), rop.llvm_void_ptr(B),
                                    rop.ll.mask_as_int(rop.ll.current_mask()) };

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -1813,6 +1813,7 @@ BatchedBackendLLVM::build_llvm_init()
         FOREACH_PARAM(Symbol & sym, gi)
         {
             if (sym.typespec().is_closure_based()) {
+                OSL_ASSERT(sym.is_varying());
                 int arraylen     = std::max(1, sym.typespec().arraylength());
                 llvm::Value* val = ll.constant_ptr(NULL, ll.type_void_ptr());
                 if (!sym.is_uniform())

--- a/testsuite/closure-zero/a.osl
+++ b/testsuite/closure-zero/a.osl
@@ -1,0 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader a (output closure color output_closure = 0)
+{
+    output_closure = debug( "test" );
+}

--- a/testsuite/closure-zero/b.osl
+++ b/testsuite/closure-zero/b.osl
@@ -1,0 +1,9 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader b (closure color in0 = 0, closure color in1 = 0)
+{
+    closure color out = in0 + in1;
+    printf( " out =  %s\n", out );
+}

--- a/testsuite/closure-zero/ref/out.txt
+++ b/testsuite/closure-zero/ref/out.txt
@@ -1,0 +1,6 @@
+Compiled a.osl -> a.oso
+Compiled b.osl -> b.oso
+Connect a.output_closure to b.in0
+ out =  (1, 1, 1) * debug ("test")
+ out =  (1, 1, 1) * debug ("test")
+

--- a/testsuite/closure-zero/run.py
+++ b/testsuite/closure-zero/run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command += testshade ("-layer a a -layer b b -connect a output_closure b in0 -g 2 1" )


### PR DESCRIPTION
## Description

This is another fix I'm attempting without really understanding all this LLVM stuff.

I started by adding a simple test case that attempts to add two closure parameters, where one has not been set.  This crashes or returns random values from uninitialized memory, matching a problem I ran into while trying to get batched mode working in Gaffer.

I investigated some, and found that add_closure_closure is assuming closure pointers are stored with the width of the current batch, but build_llvm_init is creating uniform closures.  I checked with @sfriedmapixar, who confirmed that all the batched closure code is assuming wide closures, so it seems build_llvm_init is what needs fixing.

Adding a `sym.make_varying();` to build_llvm_init appears to fix the problem ... I really don't know enough about the overall structure to know if this is the right place to make this fix, or if it could have other consequences, but it's enough to get this test passing, so hopefully someone who does know the background can review it.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

