### PR TITLE
Remove dependency on OptiX SDK for building core OSL with OptiX support

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -167,44 +167,46 @@ endif ()
 
 # CUDA setup
 if (USE_CUDA OR USE_OPTIX)
-    if (NOT CUDA_TOOLKIT_ROOT_DIR AND NOT $ENV{CUDA_TOOLKIT_ROOT_DIR} STREQUAL "")
-        set (CUDA_TOOLKIT_ROOT_DIR $ENV{CUDA_TOOLKIT_ROOT_DIR})
-    endif ()
+    if (USE_LLVM_BITCODE)
+        if (NOT CUDA_TOOLKIT_ROOT_DIR AND NOT $ENV{CUDA_TOOLKIT_ROOT_DIR} STREQUAL "")
+            set (CUDA_TOOLKIT_ROOT_DIR $ENV{CUDA_TOOLKIT_ROOT_DIR})
+        endif ()
 
-    if (NOT CUDA_FIND_QUIETLY OR NOT OptiX_FIND_QUIETLY)
-        message (STATUS "CUDA_TOOLKIT_ROOT_DIR = ${CUDA_TOOLKIT_ROOT_DIR}")
-    endif ()
+        if (NOT CUDA_FIND_QUIETLY OR NOT OptiX_FIND_QUIETLY)
+            message (STATUS "CUDA_TOOLKIT_ROOT_DIR = ${CUDA_TOOLKIT_ROOT_DIR}")
+        endif ()
 
-    checked_find_package (CUDA REQUIRED
-                          VERSION_MIN 8.0
-                          PRINT CUDA_INCLUDES)
-    set (CUDA_INCLUDES ${CUDA_TOOLKIT_ROOT_DIR}/include)
-    include_directories (BEFORE "${CUDA_INCLUDES}")
+        checked_find_package (CUDA REQUIRED
+                            VERSION_MIN 8.0
+                            PRINT CUDA_INCLUDES)
+        set (CUDA_INCLUDES ${CUDA_TOOLKIT_ROOT_DIR}/include)
+        include_directories (BEFORE "${CUDA_INCLUDES}")
 
-    STRING (FIND ${LLVM_TARGETS} "NVPTX" nvptx_index)
-    if (NOT ${nvptx_index} GREATER -1)
-        message (FATAL_ERROR "NVPTX target is not available in the provided LLVM build")
-    endif()
+        STRING (FIND ${LLVM_TARGETS} "NVPTX" nvptx_index)
+        if (NOT ${nvptx_index} GREATER -1)
+            message (FATAL_ERROR "NVPTX target is not available in the provided LLVM build")
+        endif()
 
-    set (CUDA_LIB_FLAGS "--cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
+        set (CUDA_LIB_FLAGS "--cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
 
-    find_library(cuda_lib NAMES cudart
-                 PATHS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${CUDA_TOOLKIT_ROOT_DIR}/x64"
-                 REQUIRED)
-    set(CUDA_LIBRARIES ${cuda_lib})
+        find_library(cuda_lib NAMES cudart
+                    PATHS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${CUDA_TOOLKIT_ROOT_DIR}/x64"
+                    REQUIRED)
+        set(CUDA_LIBRARIES ${cuda_lib})
 
-    # testrender & testshade need libnvrtc
-    if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "10.0")
-        find_library(nvrtc_lib NAMES nvrtc
-                     PATHS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${CUDA_TOOLKIT_ROOT_DIR}/x64"
-                     REQUIRED)
-        set(CUDA_LIBRARIES ${CUDA_LIBRARIES} ${nvrtc_lib})
+        # testrender & testshade need libnvrtc
+        if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "10.0")
+            find_library(nvrtc_lib NAMES nvrtc
+                        PATHS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${CUDA_TOOLKIT_ROOT_DIR}/x64"
+                        REQUIRED)
+            set(CUDA_LIBRARIES ${CUDA_LIBRARIES} ${nvrtc_lib})
 
-        set(CUDA_EXTRA_LIBS ${CUDA_EXTRA_LIBS} dl)
+            set(CUDA_EXTRA_LIBS ${CUDA_EXTRA_LIBS} dl)
+        endif()
     endif()
 
     # OptiX setup
-    if (USE_OPTIX)
+    if (USE_OPTIX AND OSL_BUILD_TESTS)
         checked_find_package (OptiX REQUIRED
                               VERSION_MIN 7.0)
         include_directories (BEFORE "${OPTIX_INCLUDES}")
@@ -219,7 +221,6 @@ if (USE_CUDA OR USE_OPTIX)
         target_compile_definitions (${TARGET} PRIVATE "-DPTX_PATH=\"${OSL_PTX_INSTALL_DIR}\"")
         target_link_libraries (${TARGET} PRIVATE ${CUDA_LIBRARIES} ${CUDA_EXTRA_LIBS} ${OPTIX_LIBRARIES} ${OPTIX_EXTRA_LIBS})
     endfunction()
-
 else ()
     function (osl_optix_target TARGET)
     endfunction()

--- a/src/include/OSL/device_string.h
+++ b/src/include/OSL/device_string.h
@@ -6,10 +6,6 @@
 
 #include <OSL/oslconfig.h>
 
-#ifdef __CUDA_ARCH__
-#    include <optix.h>
-#endif
-
 // USAGE NOTES:
 //
 // To define a "standard" DeviceString, add a STRDECL to <OSL/strdecls.h>

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -6,10 +6,6 @@
 #include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/strutil.h>
 
-#ifdef OSL_USE_OPTIX
-#    include <optix.h>
-#endif
-
 #include "oslexec_pvt.h"
 #include "backendllvm.h"
 

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -6,11 +6,6 @@
 
 #include <OpenImageIO/fmath.h>
 
-#ifdef OSL_USE_OPTIX
-#    include <optix.h>
-#endif
-
-
 #include "oslexec_pvt.h"
 #include <OSL/genclosure.h>
 #include "backendllvm.h"

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -92,10 +92,6 @@
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/SymbolRewriter.h>
 
-#ifdef OSL_USE_OPTIX
-#    include <optix.h>
-#endif
-
 OSL_NAMESPACE_ENTER
 
 

--- a/src/liboslexec/opcolor.cpp
+++ b/src/liboslexec/opcolor.cpp
@@ -18,10 +18,6 @@
 
 #include <OpenImageIO/fmath.h>
 
-#ifdef __CUDACC__
-#    include <optix.h>
-#endif
-
 #include "opcolor.h"
 
 #include "opcolor_impl.h"

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -19,10 +19,6 @@
 // Pull in the modified Imath headers and the OSL_HOSTDEVICE macro
 #ifdef __CUDACC__
 #    include <OSL/oslconfig.h>
-#    include <optix.h>
-#endif
-
-#ifdef __CUDACC__
 #    include "string_hash.h"
 #endif
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -19,6 +19,9 @@
 // Pull in the modified Imath headers and the OSL_HOSTDEVICE macro
 #ifdef __CUDACC__
 #    include <OSL/oslconfig.h>
+#endif
+
+#ifdef __CUDACC__
 #    include "string_hash.h"
 #endif
 


### PR DESCRIPTION
OSL currently includes the OptiX header in several places, but without actually making any use of its contents. OptiX support is implemented soly using LLVM and its NVPTX backend, without any types or functions used from the OptiX SDK, making these includes superfluous. The only part of the codebase that does need them are the tests, so this patch makes finding the SDK dependent on whether tests are enabled or not.
Avoiding including the OptiX headers in the core makes it possible still to build OSL with OptiX support (`USE_OPTIX=ON;OSL_BUILD_TESTS=OFF;`), but without needing the OptiX SDK in the process, simplifying the build process on build systems where having the OptiX SDK installed is a challenge.

Additionally this patch also makes it possible to use OSL in OptiX without pre-built LLVM bitcode containing OSL intrinsics (`USE_LLVM_BITCODE=OFF;`). Building that bitcode module requires the CUDA toolkit, which too can be a challenge to have available on build systems, but it's not technically needed if the renderer implementing OSL does provide an implementation for all the OSL intrinsics declared in `builtindecl.h` itself (and it already had to do so for some of them right now anyway). In that case only have to initialize the now empty LLVM module OSL creates with a proper target and data layout (which would normally be inherited from the pre-built bitcode), otherwise compiling shader groups will later fail, as the NVPTX backend is looked up based on the target triple set on the module (see implementation of `LLVM_Util::ptx_compile_group()`).

CMake previously errored when attempting to build with OptiX support and without the LLVM bitcode, but due to the previous change it only does that when tests are enabled too now, making the following a valid combination of build options when no CUDA/OptiX SDK is available, but OptiX support is still desired: `USE_OPTIX=ON;USE_LLVM_BITCODE=OFF;OSL_BUILD_TESTS=OFF;`. This is e.g. the case with Blender (more discussion regarding this on https://developer.blender.org/D15902).

Note: The change to externalpackages.cmake looks larger than it is due whitespace changes caused by the new if clause.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary). [Existing tests build and run]
- [x] My code follows the prevailing code style of this project.

