### PR TITLE
CI: Fix Mac CI breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,7 @@ jobs:
             python_ver: "3.10"
             aclang: 13
             setenvs: export LLVMBREWVER="@14" DO_BREW_UPDATE=1
+                            OPENIMAGEIO_VERSION=release
           - desc: MacOS-12
             os: macos-12
             nametag: macos11-p310
@@ -443,6 +444,7 @@ jobs:
             python_ver: "3.10"
             aclang: 13
             setenvs: export LLVMBREWVER="@15" DO_BREW_UPDATE=1
+                            OPENIMAGEIO_VERSION=master
     runs-on: ${{matrix.os}}
     env:
       CXX: ${{matrix.cxx_compiler}}


### PR DESCRIPTION
To save build time, we had OSL's Mac CI tests use the homebrew installation of openimageio. But... Homebrew recently switched its default python to 3.11, which didn't match the versions we're testing OSL against here and broke the python bindings, so need to make a few adjustments so it builds OIIO from scratch against the same python dependencies that OSL is using in these tests.

Signed-off-by: Larry Gritz <lg@larrygritz.com>

