### PR TITLE
Temp workaround for botched aswftesting container yum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,11 @@ jobs:
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
             setenvs: USE_OPENVDB=0
-          - desc: icc/C++17 llvm13 py3.9 boost1.76 exr3.1 oiio-master avx2
+          - desc: icc/C++17 llvm14 py3.9 boost1.76 exr3.1 oiio-master avx2
             nametag: linux-icc
             os: ubuntu-latest
             vfxyear: 2022
-            vfxsuffix: -clang13
+            vfxsuffix: -clang14
             cc_compiler: icc
             cxx_compiler: icpc
             cxx_std: 17
@@ -131,11 +131,11 @@ jobs:
             setenvs: export OSL_CMAKE_FLAGS="-DSTOP_ON_WARNING=OFF -DEXTRA_CPP_ARGS=-fp-model=consistent"
                             OPENIMAGEIO_CMAKE_FLAGS=-DBUILD_FMT_VERSION=7.1.3
                             USE_OPENVDB=0
-          - desc: icx/C++17 llvm13 py3.9 boost1.76 exr3.1 oiio2.3 avx2
+          - desc: icx/C++17 llvm14 py3.9 boost1.76 exr3.1 oiio2.3 avx2
             nametag: linux-icx
             os: ubuntu-latest
             vfxyear: 2022
-            vfxsuffix: -clang13
+            vfxsuffix: -clang14
             cc_compiler: icx
             cxx_compiler: icpx
             cxx_std: 17

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -18,8 +18,8 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
 
     #ls /etc/yum.repos.d
 
-    sudo yum install -y giflib giflib-devel && true
-    # sudo yum install -y ffmpeg ffmpeg-devel && true
+    sudo /usr/bin/yum install -y giflib giflib-devel && true
+    # sudo /usr/bin/yum install -y ffmpeg ffmpeg-devel && true
 
     if [[ "${CONAN_LLVM_VERSION}" != "" ]] ; then
         mkdir conan
@@ -42,7 +42,7 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
 
     if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$CXX" == "icpx" || "$CC" == "icx" || "$USE_ICX" != "" ]] ; then
         sudo cp src/build-scripts/oneAPI.repo /etc/yum.repos.d
-        sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0-3768
+        sudo /usr/bin/yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0-3768
         # Because multiple (possibly newer) versions of oneAPI may be installed,
         # use a config file to specify compiler and tbb versions
         # NOTE: oneAPI components have independent version numbering.


### PR DESCRIPTION
It seems something in the latest builds of the aswftesting/ci-osl:2022 containers has changed, and explicitly running /usr/bin/yum (instead of the broken /usr/local/bin/yum) fixes it for now. This was completely breaking the icc & icx tests, which require yum to install the Intel compilers.

Also, bump up to the -clang14 containers for those tests, just to get to a more recent LLVM.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
