### PR TITLE
platform.h: fully define bitcast template

### DIFF
--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -144,12 +144,7 @@ inline OSL_HOSTDEVICE float bits_to_01 (unsigned int bits) {
 OSL_FORCEINLINE OSL_HOSTDEVICE int
 bitcast_to_uint (float x)
 {
-#if OPENIMAGEIO_VERSION >= 20500
-    return OIIO::bitcast<unsigned int, float>(x);
-#else
-    // obsolete call
-    return OIIO::bit_cast<float, unsigned int>(x);
-#endif
+    return OSL::bitcast<unsigned int, float>(x);
 }
 
 

--- a/src/include/OSL/wide.h
+++ b/src/include/OSL/wide.h
@@ -980,12 +980,7 @@ template<int WidthT> struct alignas(VecReg<WidthT>) Block<ustringhash, WidthT> {
 #ifdef OIIO_USTRING_HAS_CTR_FROM_USTRINGHASH
         return ustringhash::from_hash(str[lane]);
 #else
-        // Dumb workaround if we are on old OIIO
-#    if OPENIMAGEIO_VERSION >= 20500
-        return OIIO::bitcast<ustringhash>(str[lane]);
-#    else
-        return OIIO::bit_cast<size_t, ustringhash>(str[lane]);
-#    endif
+        return OSL::bitcast<ustringhash>(str[lane]);
 #endif
     }
 

--- a/src/liboslexec/wide/wide_ophash.cpp
+++ b/src/liboslexec/wide/wide_ophash.cpp
@@ -28,12 +28,7 @@ namespace {
 OSL_FORCEINLINE OSL_HOSTDEVICE int
 bitcast_to_uint(float x)
 {
-#if OPENIMAGEIO_VERSION >= 20500
-    return OIIO::bitcast<unsigned int, float>(x);
-#else
-    // obsolete call
-    return OIIO::bit_cast<float, unsigned int>(x);
-#endif
+    return OSL::bitcast<unsigned int>(x);
 }
 
 


### PR DESCRIPTION
Ported from OIIO. This lets us not have to depend on the specific definition in OIIO's fmath.h, and in particular not worry about whether it's a new enough version of OIIO that the old bit_cast is now marked as deprecated.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
