### PR TITLE
Remove unnecessary setting of locale::global

### DIFF
--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -397,15 +397,6 @@ OSLCompilerImpl::osl_parse_buffer (const std::string &preprocessed_buffer)
     // Thread safety with the lexer/parser
     std::lock_guard<std::mutex> lock(oslcompiler_mutex);
 
-#ifndef OIIO_STRUTIL_HAS_STOF
-    // Force classic "C" locale for correct '.' decimal parsing.
-    // N.B. This is not safe in a multi-threaded program where another
-    // application thread is expecting the native locale to work properly.
-    // This is not necessary for versions of OIIO that have Strutil::stof,
-    // and we can remove it entirely when OIIO 1.9 is the minimum.
-    std::locale oldlocale = std::locale::global (std::locale::classic());
-#endif
-
     yyscan_t scanner;
     yylex_init(&scanner);
     YY_BUFFER_STATE buffer = yy_scan_string(preprocessed_buffer.c_str(), scanner);
@@ -415,9 +406,6 @@ OSLCompilerImpl::osl_parse_buffer (const std::string &preprocessed_buffer)
     yy_delete_buffer (buffer, scanner);
     yylex_destroy(scanner);
 
-#ifndef OIIO_STRUTIL_HAS_STOF
-    std::locale::global (oldlocale);  // Restore the original locale.
-#endif
     return parseerr;
 }
 

--- a/src/liboslexec/osolex.l
+++ b/src/liboslexec/osolex.l
@@ -288,7 +288,8 @@ public:
     }
 
     // TODO: This is really the only part of parsing that needs the lock still.
-    //       But the calling code setting locale complicates this.
+    //       The calling code no longer sets the global locale, so it would
+    //       likely be simple to clean this up.
     //
     bool parse(OSOReader* reader, const char* what) {
         yy_switch_to_buffer(m_buffer, m_scanner);
@@ -310,12 +311,6 @@ OSOReader::parse_file (const std::string &filename)
     // can actually be reading a .oso file at a time.
     std::lock_guard<std::mutex> guard (osoread_mutex);
 
-    // Force classic "C" locale for correct '.' decimal parsing.
-    // N.B. This is not safe in a multi-threaded program where another
-    // application thread is expecting the native locale to work properly.
-    std::locale oldlocale;   // save the previous native locale
-    std::locale::global (std::locale::classic());
-
     FILE* osoin = OIIO::Filesystem::fopen (filename, "r");
     if (! osoin) {
         m_err.errorfmt("File {} not found", filename);
@@ -326,7 +321,6 @@ OSOReader::parse_file (const std::string &filename)
     bool ok = scope.parse(this, filename.c_str());
 
     fclose (osoin);
-    std::locale::global (oldlocale);  // Restore the original locale.
 
     return ok;
 }
@@ -339,21 +333,8 @@ OSOReader::parse_memory (const std::string &buffer)
     // can actually be reading a .oso file at a time.
     std::lock_guard<std::mutex> guard (osoread_mutex);
 
-#ifndef OIIO_STRUTIL_HAS_STOF
-    // Force classic "C" locale for correct '.' decimal parsing.
-    // N.B. This is not safe in a multi-threaded program where another
-    // application thread is expecting the native locale to work properly.
-    // This is not necessary for versions of OIIO that have Strutil::stof,
-    // and we can remove it entirely when OIIO 1.9 is the minimum.
-    std::locale oldlocale = std::locale::global (std::locale::classic());
-#endif
-
     Scope scope(buffer);
     bool ok = scope.parse(this, "preloaded OSO code");
-
-#ifndef OIIO_STRUTIL_HAS_STOF
-    std::locale::global (oldlocale);  // Restore the original locale.
-#endif
 
     return ok;
 }


### PR DESCRIPTION
We used to need to set the global locale before calling something that used OIIO parsing functions.  This is no longer the case ( as of OIIO-1.9, and we now require 2.3 ), so we can now remove these calls.

It came up for me because this code seems to interact strangely with locale in Python - I think this is because something synchs the C++ locale across to Python, but if locale::global hasn't been called in C++ yet, and the locale has only been set in Python, oldlocale doesn't get set to the Python locale ... I could try to figure out more of what's going on, but the simple answer is just to remove this code that is no longer needed.  LG though it was reasonable when I asked on the dev list: https://lists.aswf.io/g/osl-dev/message/5081

A potential follow-up would be to move the lock_guard inside parse, since there's a comment indicating that the locale was the reason this hadn't been done.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

