### PR TITLE
Batched Mode : Issue with Conditional Assignment of Closure With Varying Weight

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -236,7 +236,7 @@ macro (osl_add_all_tests)
                 bug-array-heapoffsets bug-locallifetime bug-outputinit
                 bug-param-duplicate bug-peep bug-return
                 calculatenormal-reg
-                cellnoise closure closure-array closure-parameters closure-zero
+                cellnoise closure closure-array closure-parameters closure-zero closure-conditional
                 color color-reg colorspace comparison
                 complement-reg compile-buffer compassign-reg
                 component-range

--- a/testsuite/closure-conditional/ref/out.txt
+++ b/testsuite/closure-conditional/ref/out.txt
@@ -1,0 +1,7 @@
+Compiled test.osl -> test.oso
+  Ci = (1, 0, 0) * emission ()
+  Ci = (1, 0, 0) * emission ()
+  Ci = (1, 0, 0) * emission ()
+  Ci = (0.75, 0.75, 0.75) * emission ()
+  Ci = (1, 1, 1) * emission ()
+

--- a/testsuite/closure-conditional/run.py
+++ b/testsuite/closure-conditional/run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command = testshade("-g 5 1 test")

--- a/testsuite/closure-conditional/test.osl
+++ b/testsuite/closure-conditional/test.osl
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader
+test()
+{
+    if (u > 0.5) {
+        Ci = u * emission();
+    } else {
+        Ci = color(1, 0, 0) * emission();
+    }
+
+    printf("  Ci = %s\n", Ci);
+}


### PR DESCRIPTION
I might need some help again to actually fix this one.

I've added a test where Ci is set to an emission closure with a varying weight on one side of a conditional, and a uniform weight on the other.  In batched execution with optimization on, this results in corrupted closure pointers.

I've tracked the trigger down to the final case in RuntimeOptimizer::peephole2, which converts from a closure multiplied to a weight to a closure-with-scale constructor.  If I comment out this one optimization, the tests pass, but I don't think the bug is in this function ... as far as I can tell, this optimization is the only way to call the closure-with-scale constructor, so the optimization is probably fine, but something else is failing to handle the closure-with-scale constructor - or the resulting wide closure pointer, where half of it points closures with uniform weights and half points to closures with varying weights?

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

