### PR TITLE
Fix some windows GPU build errors

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -190,14 +190,14 @@ if (USE_CUDA OR USE_OPTIX)
         set (CUDA_LIB_FLAGS "--cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
 
         find_library(cuda_lib NAMES cudart
-                    PATHS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${CUDA_TOOLKIT_ROOT_DIR}/x64"
+                    PATHS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${CUDA_TOOLKIT_ROOT_DIR}/x64" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64"
                     REQUIRED)
         set(CUDA_LIBRARIES ${cuda_lib})
 
         # testrender & testshade need libnvrtc
         if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "10.0")
             find_library(nvrtc_lib NAMES nvrtc
-                        PATHS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${CUDA_TOOLKIT_ROOT_DIR}/x64"
+                        PATHS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${CUDA_TOOLKIT_ROOT_DIR}/x64" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64"
                         REQUIRED)
             set(CUDA_LIBRARIES ${CUDA_LIBRARIES} ${nvrtc_lib})
 

--- a/src/liboslexec/opcolor_impl.h
+++ b/src/liboslexec/opcolor_impl.h
@@ -50,7 +50,12 @@ clamp_zero(Color3& c)
 //OSL_CONSTANT_DATA const float cie_colour_match[81][3] =
 // Choose to access 1d array vs 2d to allow better code generation of gathers
 namespace {  // anon namespace to avoid duplicate OptiX symbols
-OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) = {
+#ifdef __CUDACC__
+OSL_CONSTANT_DATA const float cie_colour_match[81*3] =
+#else
+OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) =
+#endif
+{
     // clang-format off
     0.0014,0.0000,0.0065, 0.0022,0.0001,0.0105, 0.0042,0.0001,0.0201,
     0.0076,0.0002,0.0362, 0.0143,0.0004,0.0679, 0.0232,0.0006,0.1102,

--- a/src/liboslexec/opcolor_impl.h
+++ b/src/liboslexec/opcolor_impl.h
@@ -50,13 +50,13 @@ clamp_zero(Color3& c)
 //OSL_CONSTANT_DATA const float cie_colour_match[81][3] =
 // Choose to access 1d array vs 2d to allow better code generation of gathers
 namespace {  // anon namespace to avoid duplicate OptiX symbols
+// clang-format off
 #ifdef __CUDACC__
 OSL_CONSTANT_DATA const float cie_colour_match[81*3] =
 #else
 OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) =
 #endif
 {
-    // clang-format off
     0.0014,0.0000,0.0065, 0.0022,0.0001,0.0105, 0.0042,0.0001,0.0201,
     0.0076,0.0002,0.0362, 0.0143,0.0004,0.0679, 0.0232,0.0006,0.1102,
     0.0435,0.0012,0.2074, 0.0776,0.0022,0.3713, 0.1344,0.0040,0.6456,
@@ -84,8 +84,8 @@ OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) =
     0.0007,0.0002,0.0000, 0.0005,0.0002,0.0000, 0.0003,0.0001,0.0000,
     0.0002,0.0001,0.0000, 0.0002,0.0001,0.0000, 0.0001,0.0000,0.0000,
     0.0001,0.0000,0.0000, 0.0001,0.0000,0.0000, 0.0000,0.0000,0.0000
-    // clang-format on
 };
+// clang-format on
 }  // namespace
 
 


### PR DESCRIPTION
## Description

This PR fixes a couple of build failures when building `USE_OPTIX=true` on windows. Firstly, I added some search paths to correctly find the CUDA toolkit libs on windows. Secondly, this align on the array, doesn't seem to compile on windows, which is weird.
```
OSL_CONSTANT_DATA const float cie_colour_match[81 * 3] OSL_ALIGNAS(64) =
```
I get the following error when generating `opcolor_cuda.bc`
```
src/liboslexec/opcolor_impl.h(51,54): error G9BCB7FFB: 'alignas' attribute cannot be applied to types
```
Therefore, I have just ifdef'ed out the align when compiling for GPU. Correct me if I am wrong, but as I understand it the align is not really important for GPU anyway and is mainly for SIMD access on the CPU?

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

