### PR TITLE
adding relaxed type-equivalency to ReParameter()

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -386,6 +386,7 @@ public:
     /// vector-like (and match their array-ness and closure-ness), or
     /// if both are structures with matching fields.
     friend bool equivalent(const TypeSpec& a, const TypeSpec& b);
+    friend bool relaxed_equivalent(const TypeSpec& a, const TypeSpec& b);
 
     /// Is type src is assignable to dst?  It is if they are the equivalent(),
     /// or if dst is a float or float-aggregate and src is a float or int.

--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -244,22 +244,7 @@ ShaderInstance::parameters(const ParamValueList& params)
                     valuetype  = TypeDesc::FLOAT;
                 }
 
-                // Relaxed rules just look to see that the types are isomorphic to each other (ie: same number of base values)
-                // Note that:
-                //   * basetypes must match exactly (int vs float vs string)
-                //   * valuetype cannot be unsized (we must know the concrete number of values)
-                //   * if paramtype is sized (or not an array) just check for the total number of entries
-                //   * if paramtype is unsized (shader writer is flexible about how many values come in) -- make sure we are a multiple of the target type
-                //   * allow a single float setting a vec3 (or equivalent)
-                if (!(valuetype.basetype == paramtype.basetype
-                      && !valuetype.is_unsized_array()
-                      && ((!paramtype.is_unsized_array()
-                           && valuetype.basevalues() == paramtype.basevalues())
-                          || (paramtype.is_unsized_array()
-                              && valuetype.basevalues() % paramtype.aggregate
-                                     == 0)
-                          || (paramtype.is_vec3()
-                              && valuetype == TypeDesc::FLOAT)))) {
+                if (!relaxed_equivalent(sm_typespec, valuetype)) {
                     // We are being very relaxed in this mode, so if the user _still_ got it wrong
                     // something more serious is at play and we should treat it as an error.
                     shadingsys().errorfmt(

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3182,7 +3182,9 @@ ShadingSystemImpl::ReParameter(ShaderGroup& group, string_view layername_,
     }
 
     // Check for mismatch versus previously-declared type
-    if (!equivalent(sym->typespec(), type))
+    if ((relaxed_param_typecheck() && !relaxed_equivalent(sym->typespec(), type))
+        || (!relaxed_param_typecheck()
+            && !relaxed_equivalent(sym->typespec(), type)))
         return false;
 
     // Can't change param value if the group has already been optimized,


### PR DESCRIPTION
Signed-off-by: Clifford Stein <cstein@imageworks.com>


## Description

Allows ShadingSystem->ReParameter() to use the same relaxed rules as SS->Parameter()

## Tests

no changes in tests

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

