### PR TITLE
Changed snprintf formatting to satisfy some compilers.

### DIFF
--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -1072,7 +1072,7 @@ OptixRaytracer::processPrintfBuffer(void* buffer_data, size_t buffer_size)
                     switch (format[j]) {
                     case '%':
                         // seems like a silly to print a '%', but it keeps the logic parallel with the other cases
-                        dst += snprintf(&buffer[dst], BufferSize - dst,
+                        dst += snprintf(&buffer[dst], BufferSize - dst, "%s",
                                         fmt_string.c_str());
                         format_end_found = true;
                         break;

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -874,7 +874,7 @@ OptixGridRenderer::processPrintfBuffer(void* buffer_data, size_t buffer_size)
                     switch (format[j]) {
                     case '%':
                         // seems like a silly to print a '%', but it keeps the logic parallel with the other cases
-                        dst += snprintf(&buffer[dst], BufferSize - dst,
+                        dst += snprintf(&buffer[dst], BufferSize - dst, "%s",
                                         fmt_string.c_str());
                         format_end_found = true;
                         break;


### PR DESCRIPTION
Signed-off-by: Peter Ellerington <elleringtonp@gmail.com>


## Description

When building OSL my compiler (GCC 11.3 on Ubuntu) was complaining about these snprintfs format strings not being a string literal.
Writing them to a "%s" seems to satisfy it and should produce the same result.

## Tests

no changes in tests


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

