### PR TITLE
RendererServices API for letting get_texture_handle consider colorspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.12)
 
-set (OSL_VERSION "1.13.2.1")
+set (OSL_VERSION "1.13.3.0")
 set (OSL_VERSION_OVERRIDE "" CACHE STRING
      "Version override (use with caution)!")
 mark_as_advanced (OSL_VERSION_OVERRIDE)

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -186,10 +186,13 @@ public:
     virtual bool get_userdata(bool derivatives, ustringhash name, TypeDesc type,
                               ShaderGlobals* sg, void* val);
 
-    /// Given the name of a texture, return an opaque handle that can be
-    /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle* get_texture_handle(ustringhash filename,
-                                              ShadingContext* context);
+    /// Given the name of a texture, return an opaque handle that can be used
+    /// with texture calls to avoid the name lookups. The `options`, if not
+    /// null, may be used in renderer-specific ways to specialize a handle
+    /// based on certain texture option choices.
+    virtual TextureHandle*
+    get_texture_handle(ustringhash filename, ShadingContext* context,
+                       const TextureOpt* options = nullptr);
 
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is a valid texture that can be subsequently

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -2461,7 +2461,9 @@ LLVMGEN(llvm_gen_texture)
     if (Filename.is_constant() && rop.shadingsys().opt_texture_handle()) {
         texture_handle
             = rop.renderer()->get_texture_handle(Filename.get_string(),
-                                                 rop.shadingcontext());
+                                                 rop.shadingcontext(), nullptr);
+        // FIXME(colorspace): that nullptr should be replaced by a TextureOpt*
+        // that has the colorspace set.
     }
 
     // Now call the osl_texture function, passing the options and all the
@@ -2526,7 +2528,9 @@ LLVMGEN(llvm_gen_texture3d)
     if (Filename.is_constant() && rop.shadingsys().opt_texture_handle()) {
         texture_handle
             = rop.renderer()->get_texture_handle(Filename.get_string(),
-                                                 rop.shadingcontext());
+                                                 rop.shadingcontext(), nullptr);
+        // FIXME(colorspace): that nullptr should be replaced by a TextureOpt*
+        // that has the colorspace set.
     }
 
     // Now call the osl_texture3d function, passing the options and all the
@@ -2589,7 +2593,9 @@ LLVMGEN(llvm_gen_environment)
     if (Filename.is_constant() && rop.shadingsys().opt_texture_handle()) {
         texture_handle
             = rop.renderer()->get_texture_handle(Filename.get_string(),
-                                                 rop.shadingcontext());
+                                                 rop.shadingcontext(), nullptr);
+        // FIXME(colorspace): that nullptr should be replaced by a TextureOpt*
+        // that has the colorspace set.
     }
 
     // Now call the osl_environment function, passing the options and all the
@@ -3040,7 +3046,7 @@ LLVMGEN(llvm_gen_gettextureinfo)
     if (Filename.is_constant() && rop.shadingsys().opt_texture_handle()) {
         texture_handle
             = rop.renderer()->get_texture_handle(Filename.get_string(),
-                                                 rop.shadingcontext());
+                                                 rop.shadingcontext(), nullptr);
     }
 
     std::vector<llvm::Value*> args;

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -158,10 +158,17 @@ RendererServices::get_userdata(bool derivatives, ustringhash name,
 
 RendererServices::TextureHandle*
 RendererServices::get_texture_handle(ustringhash filename,
-                                     ShadingContext* context)
+                                     ShadingContext* context,
+                                     const TextureOpt* options)
 {
+#ifdef OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE
+    return texturesys()->get_texture_handle(ustring_from(filename),
+                                            context->texture_thread_info(),
+                                            options);
+#else
     return texturesys()->get_texture_handle(ustring_from(filename),
                                             context->texture_thread_info());
+#endif
 }
 
 
@@ -194,8 +201,14 @@ RendererServices::texture(ustringhash filename, TextureHandle* texture_handle,
     if (!texture_thread_info)
         texture_thread_info = context->texture_thread_info();
     if (!texture_handle)
+#ifdef OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE
+        texture_handle
+            = texturesys()->get_texture_handle(ustring_from(filename),
+                                               texture_thread_info, &options);
+#else
         texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
+#endif
     bool status = texturesys()->texture(texture_handle, texture_thread_info,
                                         options, s, t, dsdx, dtdx, dsdy, dtdy,
                                         nchannels, result, dresultds,
@@ -230,8 +243,14 @@ RendererServices::texture3d(ustringhash filename, TextureHandle* texture_handle,
     if (!texture_thread_info)
         texture_thread_info = context->texture_thread_info();
     if (!texture_handle)
+#ifdef OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE
+        texture_handle
+            = texturesys()->get_texture_handle(ustring_from(filename),
+                                               texture_thread_info, &options);
+#else
         texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
+#endif
 
     bool status = texturesys()->texture3d(texture_handle, texture_thread_info,
                                           options, P, dPdx, dPdy, dPdz,
@@ -267,8 +286,14 @@ RendererServices::environment(ustringhash filename,
     if (!texture_thread_info)
         texture_thread_info = context->texture_thread_info();
     if (!texture_handle)
+#ifdef OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE
+        texture_handle
+            = texturesys()->get_texture_handle(ustring_from(filename),
+                                               texture_thread_info, &options);
+#else
         texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
+#endif
     bool status = texturesys()->environment(texture_handle, texture_thread_info,
                                             options, R, dRdx, dRdy, nchannels,
                                             result, dresultds, dresultdt);

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -883,7 +883,8 @@ OptixRaytracer::good(TextureHandle* handle OSL_MAYBE_UNUSED)
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
 OptixRaytracer::get_texture_handle(ustringhash filename,
-                                   ShadingContext* /*shading_context*/)
+                                   ShadingContext* /*shading_context*/,
+                                   const TextureOpt* options)
 {
     auto itr = m_samplers.find(filename);
     if (itr == m_samplers.end()) {

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -55,7 +55,8 @@ public:
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
     TextureHandle* get_texture_handle(ustringhash filename,
-                                      ShadingContext* shading_context) override;
+                                      ShadingContext* shading_context,
+                                      const TextureOpt* options) override;
 
     // Easy way to do Optix calls
     optix::Context& optix_ctx() { return m_optix_ctx; }

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -685,7 +685,8 @@ OptixGridRenderer::good(TextureHandle* handle OSL_MAYBE_UNUSED)
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
 OptixGridRenderer::get_texture_handle(ustringhash filename,
-                                      ShadingContext* /*shading_context*/)
+                                      ShadingContext* /*shading_context*/,
+                                      const TextureOpt* /*options*/)
 {
     auto itr = m_samplers.find(filename);
     if (itr == m_samplers.end()) {

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -61,7 +61,8 @@ public:
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
     TextureHandle* get_texture_handle(ustringhash filename,
-                                      ShadingContext* shading_context) override;
+                                      ShadingContext* shading_context,
+                                      const TextureOpt* options) override;
 
     OptixDeviceContext optix_ctx() { return m_optix_ctx; }
     OptixDeviceContext context() { return m_optix_ctx; }

--- a/testsuite/example-cuda/cuda_grid_renderer.cpp
+++ b/testsuite/example-cuda/cuda_grid_renderer.cpp
@@ -66,7 +66,8 @@ CudaGridRenderer::good(TextureHandle* handle)
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
 CudaGridRenderer::get_texture_handle(OSL::ustringhash filename,
-                                     ShadingContext* shading_context)
+                                     ShadingContext* shading_context,
+                                     const TextureOpt* options)
 {
     auto itr = _samplers.find(filename);
     if (itr == _samplers.end()) {

--- a/testsuite/example-cuda/cuda_grid_renderer.h
+++ b/testsuite/example-cuda/cuda_grid_renderer.h
@@ -57,7 +57,8 @@ public:
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
     virtual TextureHandle* get_texture_handle(ustringhash filename,
-                                              ShadingContext* shading_context);
+                                              ShadingContext* shading_context,
+                                              const TextureOpt* options);
 
     virtual bool get_matrix(ShaderGlobals* sg, Matrix44& result,
                             TransformationPtr xform, float time);


### PR DESCRIPTION
This makes some minor changes to the RS APIs to add an additional optional parameter to get_texture_handle so it takes a `TextureOpt*` to accommodate a similar change on the OIIO TextureSystem side from https://github.com/OpenImageIO/oiio/pull/3761

The purpose here is to add color management options to texture calls. However, please note that this PR only reserves a public API change we know we'll want, but it does not fully implement the color management. Further work will be needed, as follows:

* Current calls to RS::get_texture_handle should be updated to pass the TextureOpt*. (This is a formality for future-proofing in case future TS or alternate TS implementations want to bake the color space choice into the texture handle itself. But the OIIO change doesn't currently rely on that at the moment.)

* When the texture.h symbol `OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE` exists, we are building against an OIIO that has the new int field `colortransformid` in the TextureOpt and TextureOptBatch structures. We should fill this in with a nonzero value when we want the texture call to be doing a color transformation as it reads texture tiles.

* Use the new TextureSystem:get_colortransform_id() to get that color transform ID given two named from/to color spaces. We agreed that it's a reasonable restriction that the color space names should be known by the end of runtime optimization, so that should be constant foldable.

* Recognize new optional argument(s) to the texture() call family that lets the caller specify the presumed color space of the texture, and use that value (with constant folded lookup of the ID, above) to set the value in the TextureOpt.

Signed-off-by: Larry Gritz <lg@larrygritz.com>
