### PR TITLE
Expose llvm groupdata size as a shadergroup attribute

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -443,6 +443,7 @@ public:
     ///   string entry_layers[]      List of entry point layers.
     ///   string pickle              Retrieves a serialized representation
     ///                                 of the shader group declaration.
+    ///   int llvm_groupdata_size    Size of the GroupData struct.
     /// Note: the attributes referred to as "string" are actually on the app
     /// side as ustring or const char* (they have the same data layout), NOT
     /// std::string!

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -2125,6 +2125,10 @@ ShadingSystemImpl::getattribute(ShaderGroup* group, string_view name,
         *(void**)val = n ? &group->m_userdata_init_vals[0] : NULL;
         return true;
     }
+    if (name == "llvm_groupdata_size" && type == TypeDesc::TypeInt) {
+        *(int*)val = (int)group->llvm_groupdata_size();
+        return true;
+    }
 
     return false;
 }


### PR DESCRIPTION
Signed-off-by: Chris Hellmuth <chellmuth@gmail.com>

## Description

Adds the `llvm_groupdata_size` attribute so the renderer can inspect a shader group's GroupData struct size. On GPU this lets us reserve memory more efficiently.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

No changes.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [X] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project.

