### PR TITLE
Fix mismatched strides when calling OCIO for transformc with derivs

### DIFF
--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -4165,7 +4165,8 @@ ShadingContext::ocio_transform(StringParam fromspace, StringParam tospace,
         const float eps = 0.001f;
         Color3 CC[3]    = { C.val(), C.val() + eps * C.dx(),
                             C.val() + eps * C.dy() };
-        cp->apply((float*)&CC, 3, 1, 3, sizeof(float), sizeof(Color3), 0);
+        cp->apply((float*)&CC, 3, 1, 3, sizeof(float), sizeof(Color3),
+                  3 * sizeof(Color3));
         Cout.set(CC[0], (CC[1] - CC[0]) * (1.0f / eps),
                  (CC[2] - CC[0]) * (1.0f / eps));
         return true;


### PR DESCRIPTION
We were getting an exception thrown on the OCIO side, because we were passing 0 for the y stride (which, us humans know, should have been fine since there was only one row, so the stride shouldn't have mattered). Now pass the right stride even though we don't need to step from row to row.
