### PR TITLE
ci: Fix broken Mac CI

### DIFF
--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -26,6 +26,8 @@ if (LLVM_DIRECTORY)
     set (LLVM_CONFIG_PATH_HINTS "${LLVM_DIRECTORY}/bin")
 endif ()
 list (APPEND LLVM_CONFIG_PATH_HINTS
+        "${LLVM_ROOT}/bin"
+        "$ENV{LLVM_ROOT}/bin"
         "/usr/local/opt/llvm/${LLVM_VERSION}/bin/"
         "/usr/local/opt/llvm/bin/")
 find_program (LLVM_CONFIG


### PR DESCRIPTION
Make sure LLVM_ROOT/bin (either as a cmake var or as an env var) end up in the hints list when searching for llvm-config.

Without this, one of our Mac CI jobs was ending up with clang 14 and llvm 15, and that was causing problems. The particular test was supposed to be using 14 for both.
