### PR TITLE
testrender: Don't use the cached background map on the first bounce

### DIFF
--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -863,7 +863,7 @@ SimpleRaytracer::subpixel_radiance(float x, float y, Sampler& sampler,
         if (!scene.intersect(r, t, id)) {
             // we hit nothing? check background shader
             if (backgroundShaderID >= 0) {
-                if (backgroundResolution > 0) {
+                if (b > 0 && backgroundResolution > 0) {
                     float bg_pdf = 0;
                     Vec3 bg      = background.eval(r.direction, bg_pdf);
                     path_radiance

--- a/src/testrender/simpleraytracer.h
+++ b/src/testrender/simpleraytracer.h
@@ -109,7 +109,7 @@ private:
     float m_screen_window[4];
 
     int backgroundShaderID   = -1;
-    int backgroundResolution = 0;
+    int backgroundResolution = 1024;
     int aa                   = 1;
     int max_bounces          = 1000000;
     int rr_depth             = 5;


### PR DESCRIPTION
This lets users customize the behavior of the background for camera rays (requested by the MaterialX team). Without this, you always get the cached copy which is only valid for one raytype (and has limited resolution) or you don't get any importance sampling of the environment.