### PR TITLE
ci: update runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             pybind11_ver: v2.4.2
           - desc: clang9/C++14 llvm9 oiio-release boost1.66 avx2 exr2.3 py2.7
             nametag: linux-clang9-llvm9
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             vfxyear: 2019
             vfxsuffix: -clang9
             cc_compiler: clang
@@ -290,7 +290,7 @@ jobs:
         include:
           - desc: Debug gcc7/C++14 llvm9 py2.7 oiio2.3 exr2.4 sse4 boost1.65 exr2.4
             nametag: linux-debug-gcc7-llvm9
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             cxx_compiler: g++-7
             cxx_std: 14
             openexr_ver: v2.4.3
@@ -304,7 +304,7 @@ jobs:
                             CTEST_TEST_TIMEOUT=240
           - desc: gcc10/C++17 llvm10 oiio-release boost1.65 exr2.5 avx2
             nametag: linux-2021ish-gcc10-llvm10
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             cxx_compiler: g++-10
             cxx_std: 17
             fmt_ver: 7.0.1
@@ -322,7 +322,7 @@ jobs:
             cxx_compiler: g++-11
             cxx_std: 17
             fmt_ver: 9.1.0
-            openexr_ver: v3.1.5
+            openexr_ver: v3.1.6
             openimageio_ver: master
             pybind11_ver: v2.10.0
             python_ver: 3.9
@@ -331,7 +331,7 @@ jobs:
             setenvs: export LLVM_VERSION=13.0.0
                             LLVM_DISTRO_NAME=ubuntu-20.04
                             OPENCOLORIO_VERSION=v2.2.0
-                            PUGIXML_VERSION=v1.11.4
+                            PUGIXML_VERSION=v1.13
           - desc: bleeding edge gcc12/C++17 llvm14 oiio/ocio/exr/pybind-master boost1.71 py3.10 avx2 batch-b16avx512
             nametag: linux-bleeding-edge
             os: ubuntu-22.04

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ Dependencies
 OSL requires the following dependencies or tools.
 NEW or CHANGED dependencies since the last major release are **bold**.
 
-* Build system: [CMake](https://cmake.org/) 3.12 or newer (tested through 3.24)
+* Build system: [CMake](https://cmake.org/) 3.12 or newer (tested through 3.25)
 
 * A suitable C++14 or C++17 compiler to build OSL itself, which may be any of:
    - GCC 6.1 or newer (tested through gcc 12.1)
@@ -47,7 +47,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     * [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) 7.0 or higher.
     * [Cuda](https://developer.nvidia.com/cuda-downloads) 8.0 or higher.
 
-* [Boost](https://www.boost.org) 1.55 or newer (tested through boost 1.80)
+* [Boost](https://www.boost.org) 1.55 or newer (tested through boost 1.81)
 * [Ilmbase or Imath](https://github.com/AcademySoftwareFoundation/openexr) 2.3
    or newer (recommended: 2.4 or higher; tested through 3.1)
 * [Flex](https://github.com/westes/flex) 2.5.35 or newer and
@@ -55,7 +55,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
   Note that on some MacOS/xcode releases, the system-installed Bison is too
   old, and it's better to install a newer Bison (via Homebrew is one way to
   do this easily).
-* [PugiXML](http://pugixml.org/)
+* [PugiXML](http://pugixml.org/) >= 1.8 (we have tested through 1.13).
 * (optional) [Partio](https://www.disneyanimation.com/technology/partio.html)
   If it is not found at build time, the OSL `pointcloud` functions will not
   be operative.


### PR DESCRIPTION
* Stop using the deprecated, soon to be removed, ubuntu-18.04 runners and switch to 20.04.
* Bump the "latest" test openexr to 3.1.6
* Update INSTALL.md to document some things we're already testing and are known to work.
