### PR TITLE
Make compile_report attribute an int instead of just 0/1

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -909,7 +909,7 @@ private:
     std::vector<ustring> m_renderer_outputs;  ///< Names of renderer outputs
     std::vector<SymLocationDesc> m_symlocs;
     int m_max_local_mem_KB;           ///< Local storage can a shader use
-    bool m_compile_report;            ///< Print compilation report?
+    int m_compile_report;             ///< Print compilation report?
     bool m_buffer_printf;             ///< Buffer/batch printf output?
     bool m_no_noise;                  ///< Substitute trivial noise calls
     bool m_no_pointcloud;             ///< Substitute trivial pointcloud calls

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3384,6 +3384,8 @@ RuntimeOptimizer::run()
             new_nops, old_nops,
             100.0 * double((long long)new_nops - (long long)old_nops)
                 / double(old_nops));
+    }
+    if (shadingsys().m_compile_report > 1) {
         if (does_nothing)
             shadingcontext()->infofmt("Group does nothing");
         if (m_textures_needed.size()) {

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1049,7 +1049,7 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
     , m_llvm_output_bitcode(0)
     , m_llvm_dumpasm(0)
     , m_max_local_mem_KB(2048)
-    , m_compile_report(false)
+    , m_compile_report(0)
     , m_buffer_printf(true)
     , m_no_noise(false)
     , m_no_pointcloud(false)


### PR DESCRIPTION
In particular, 1 prints a short version of the compile report (just the fact that it happened and the time), >1 prints more verbose info.
