### PR TITLE
Enable userdata derivatives for interpolated params on GPU

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -279,14 +279,10 @@ BackendLLVM::llvm_type_groupdata()
         ++order;
         for (int i = 0; i < nuserdata; ++i) {
             TypeDesc type = types[i];
-            // NB: Userdata derivs are not currently supported in OptiX, since
-            //     making room for them in the GroupData struct can result in a
-            //     large per-thread memory allocation, which could negatively
-            //     impact performance.
-            int n         = (!use_optix()) ? type.numelements()
-                                         * 3  // make room for derivs by default
-                                           : type.numelements();
-            type.arraylen = n;
+            // make room for float derivs only
+            type.arraylen = type.basetype == TypeDesc::FLOAT
+                                ? type.numelements() * 3
+                                : type.numelements();
             fields.push_back(llvm_type(type));
             m_groupdata_field_names.emplace_back(
                 fmtformat("userdata{}_{}_", i, names[i]));


### PR DESCRIPTION
## Description

Enable userdata derivatives for interpolated parameters on the GPU.

When generating calls to `osl_bind_interpolated_param` in llvm_instance.cpp, the `userdata_has_derivs` field is set to true if the parameter's derivatives are needed, but the code does not take into account that on gpu there is no space allocated for these derivatives.

This leads to an incorrect derivatives pointer getting passed into the renderer, which the renderer will use to write into unrelated groupdata fields.

For our renders, getting the correct image was worth the 1-2% inflation of groupdata struct size that we observed by simply re-enabling gpu userdata derivatives. If desired, adding an option to turn them on/off is straightforward, but I didn't want to preemptively bloat the code if it's not necessary.


<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

