### PR TITLE
build: proper warnings about LLVM 16

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ Dependencies
 OSL requires the following dependencies or tools.
 NEW or CHANGED dependencies since the last major release are **bold**.
 
-* Build system: [CMake](https://cmake.org/) 3.12 or newer (tested through 3.25)
+* Build system: [CMake](https://cmake.org/) 3.12 or newer (tested through 3.26)
 
 * A suitable C++14 or C++17 compiler to build OSL itself, which may be any of:
    - GCC 6.1 or newer (tested through gcc 12.1)
@@ -41,7 +41,8 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     DYLD_LIBRARY_PATH on OS X).
 
 * [LLVM](http://www.llvm.org) 9, 10, 11, 12, 13, 14, or 15, including
-  clang libraries.
+  clang libraries. LLVM 16 probably doesn't work yet, we need to make changes
+  on the OSL side to be compatible.
 
 * (optional) For GPU rendering on NVIDIA GPUs:
     * [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) 7.0 or higher.

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -115,6 +115,7 @@ checked_find_package (pugixml REQUIRED
 # LLVM library setup
 checked_find_package (LLVM REQUIRED
                       VERSION_MIN 9.0
+                      VERSION_MAX 15.9
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES)
 # ensure include directory is added (in case of non-standard locations
 include_directories (BEFORE SYSTEM "${LLVM_INCLUDES}")
@@ -143,6 +144,19 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 15.0
          "${ColorYellow}"
          "If you are using LLVM 15 or higher, you should also use clang version "
          "15 or higher, or you may get build errors.${ColorReset}\n")
+endif ()
+if (LLVM_VERSION VERSION_GREATER_EQUAL 16.0)
+    message (ERROR "${ColorYellow}OSL is not yet compatible with LLVM 16.${ColorReset}\n")
+    if (CMAKE_CXX_STANDARD VERSION_LESS 17)
+        message (WARNING "${ColorYellow}LLVM 16+ requires C++17 or higher. "
+            "Please set CMAKE_CXX_STANDARD to 17 or higher.${ColorReset}\n")
+    endif ()
+    if (CMAKE_COMPILER_IS_GNUCC AND (GCC_VERSION VERSION_LESS 7.0))
+        message (WARNING "${ColorYellow}LLVM 16+ requires gcc 7.0 or higher.${ColorReset}\n")
+    endif ()
+    if (CMAKE_COMPILER_IS_CLANG AND (CLANG_VERSION_STRING VERSION_LESS 5.0))
+        message (WARNING "${ColorYellow}LLVM 16+ requires clang 5.0 or higher.${ColorReset}\n")
+    endif ()
 endif ()
 
 checked_find_package (partio)


### PR DESCRIPTION
LLVM 16 was just released. I'm pretty sure we won't build properly against it because of the phase-out of typed pointers in LLVM IR, so warn prominently so that anybody building against it who has problems will know why.

Also, LLVM itself has bumped their toolchain requirements with the release of 16. Technically, I'm not sure if that extends to projects using the LLVM APIs, but warn anyway and hope for the best. If it fails, at least the warning will supply an explanation.

At a later time, we'll need to upgrade the code on our side to have the option of using opaque pointers so we can run with LLVM 16+.
