### PR TITLE
Build: Fix cuda compilation flags for LLVM 15

### DIFF
--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -21,6 +21,12 @@ function ( NVCC_COMPILE cuda_src extra_headers ptx_generated extra_nvcc_args )
     list (TRANSFORM OpenImageIO_INCLUDES PREPEND -I
           OUTPUT_VARIABLE ALL_OpenImageIO_INCLUDES)
 
+    if (${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
+        # Until we fully support opaque pointers, we need to disable
+        # them when using LLVM 15.
+        list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)
+    endif ()
+
     add_custom_command ( OUTPUT ${cuda_ptx}
         COMMAND ${CUDA_NVCC_EXECUTABLE}
             "-I${OPTIX_INCLUDES}"


### PR DESCRIPTION
For LLVM 15+, we need to disable opaque pointers. We did this for regular bitcode generation in llvm_macros.cmake, but neglected to make the corresponding change for compiling to ptx in cuda_macros.cmake.
