### PR TITLE
Remove SonarCloud cache setup as it is now offered by default

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -23,6 +23,3 @@ sonar.exclusions=src/include/OSL/Imath/*.h,src/build-scripts/*
 # C/C++ analyzer properties
 sonar.cfamily.build-wrapper-output=build/bw_output
 sonar.cfamily.gcov.reportsPath=_coverage
-
-sonar.cfamily.cache.enabled=true
-sonar.cfamily.cache.path=/tmp/sonarcache


### PR DESCRIPTION
No need to configure the cache anymore, SonarCloud now has an automatic analysis caching. See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.