### PR TITLE
Switch lockgeom to interpolated and interactive

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -111,7 +111,8 @@ public:
 
 
 
-/// Parameter property hint bitfield values
+/// Parameter property hint bitflag values. The enum values must be powers of
+/// two so they can be combined with bitwise operators.
 enum class ParamHints : uint32_t {
     /// `none`: No special properties
     none = 0,

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -111,6 +111,66 @@ public:
 
 
 
+/// Parameter property hint bitfield values
+enum class ParamHints : uint32_t {
+    /// `none`: No special properties
+    none = 0,
+    /// `interpolated`: This parameter may be an interpolated "user data" or
+    /// "geometric primitive" variable, and so may take on different values at
+    /// different points on the surface or on different objects that share the
+    /// same material. Any optimization of the shader should take this into
+    /// account.
+    interpolated = 1,
+    /// `interactive`: Parameter may have its value interactively modified by
+    /// subsequent ReParameter calls. Any optimization of the shader should
+    /// take this into account.
+    interactive = 2
+};
+
+inline constexpr ParamHints
+operator|(ParamHints a, ParamHints b)
+{
+    return static_cast<ParamHints>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+inline constexpr ParamHints
+operator&(ParamHints a, ParamHints b)
+{
+    return static_cast<ParamHints>(static_cast<int>(a) & static_cast<int>(b));
+}
+
+inline ParamHints&
+operator|=(ParamHints& a, ParamHints b)
+{
+    a = a | b;
+    return a;
+}
+
+inline ParamHints&
+operator&=(ParamHints& a, ParamHints b)
+{
+    a = a & b;
+    return a;
+}
+
+inline constexpr ParamHints
+operator~(ParamHints a)
+{
+    return static_cast<ParamHints>(~static_cast<int>(a));
+}
+
+inline ParamHints&
+set(ParamHints& a, ParamHints b, bool on = true)
+{
+    if (on)
+        a |= b;
+    else
+        a &= ~b;
+    return a;
+}
+
+
+
 class OSLEXECPUBLIC ShadingSystem {
 public:
     ShadingSystem(RendererServices* renderer   = NULL,
@@ -173,7 +233,7 @@ public:
     ///    int lazyerror          Run layers lazily even if they have error
     ///                              ops after optimization (1).
     ///    int lazy_userdata      Retrieve userdata lazily (0).
-    ///    int userdata_isconnected  Should lockgeom=0 params (that may
+    ///    int userdata_isconnected  Should interpolated=1 params (that may
     ///                              receive userdata) return true from
     ///                              isconnected()? (0)
     ///    int greedyjit          Optimize and compile all shaders up front,
@@ -200,6 +260,7 @@ public:
     ///                              that don't specify it (1).  Lockgeom
     ///                              means a param CANNOT be overridden by
     ///                              interpolated geometric parameters.
+    ///                              This option is slated for deprecation.
     ///    int countlayerexecs    Add extra code to count total layers run.
     ///    int allow_shader_replacement Allow shader to be specified more than
     ///                              once, replacing former definition.
@@ -531,15 +592,50 @@ public:
     bool ShaderGroupEnd(ShaderGroup& group);
 
     /// Set a parameter of the next shader that will be added to the group,
-    /// optionally setting the 'lockgeom' metadata for that parameter
-    /// (despite how it may have been set in the shader).  If lockgeom is
-    /// false, it means that this parameter should NOT be considered locked
-    /// against changes by the geometry, and therefore the shader should not
-    /// optimize assuming that the instance value (the 'val' specified by
-    /// this call) is a constant.
+    /// optionally setting or overriding properties with the `hints` argument.
+    /// Individual `hints` bits are defined and documented by the ParamHints
+    /// enum class.
     bool Parameter(ShaderGroup& group, string_view name, TypeDesc t,
-                   const void* val, bool lockgeom = true);
+                   const void* val, ParamHints hints = ParamHints::none);
+
+    /// DEPRECATED(1.13) Parameter() call: instead of a full ParamHints
+    /// argument, there is just a bool `lockgeom` that default to true, and
+    /// when set to false is the same thing as setting
+    /// `ParamHints::interpolated`.
+    bool Parameter(ShaderGroup& group, string_view name, TypeDesc t,
+                   const void* val, bool lockgeom)
+    {
+        return Parameter(group, name, t, val,
+                         lockgeom ? ParamHints::none
+                                  : ParamHints::interpolated);
+    }
+
     // Shortcuts for param passing a single int, float, or string.
+    bool Parameter(ShaderGroup& group, string_view name, int val,
+                   ParamHints hints = ParamHints::none)
+    {
+        return Parameter(group, name, TypeDesc::INT, &val, hints);
+    }
+    bool Parameter(ShaderGroup& group, string_view name, float val,
+                   ParamHints hints = ParamHints::none)
+    {
+        return Parameter(group, name, TypeDesc::FLOAT, &val, hints);
+    }
+    bool Parameter(ShaderGroup& group, string_view name, const std::string& val,
+                   ParamHints hints = ParamHints::none)
+    {
+        const char* s = val.c_str();
+        return Parameter(group, name, TypeDesc::STRING, &s, hints);
+    }
+    bool Parameter(ShaderGroup& group, string_view name, ustring val,
+                   ParamHints hints = ParamHints::none)
+    {
+        return Parameter(group, name, TypeDesc::STRING, (const char**)&val,
+                         hints);
+    }
+
+    // DEPRECATED(1.13): use the version above that takes ParamHints.
+    // This is the old version that takes `bool lockgeom`.
     bool Parameter(ShaderGroup& group, string_view name, int val,
                    bool lockgeom = true)
     {
@@ -590,10 +686,8 @@ public:
     /// Replace a parameter value in a previously-declared shader group.
     /// This is meant to called after the ShaderGroupBegin/End, but will
     /// fail if the shader has already been irrevocably optimized/compiled,
-    /// unless the particular parameter is marked as lockgeom=0 (which
-    /// indicates that it's a parameter that may be overridden by the
-    /// geometric primitive).  This call gives you a way of changing the
-    /// instance value, even if it's not a geometric override.
+    /// unless the particular parameter is marked as either interpolated=1
+    /// or interactive=1.
     bool ReParameter(ShaderGroup& group, string_view layername,
                      string_view paramname, TypeDesc type, const void* val);
     // Shortcuts for param passing a single int, float, or string.
@@ -629,12 +723,21 @@ public:
     // above that take an explicit `ShaderGroup&`, which are thread-safe
     // and re-entrant.
     bool Parameter(string_view name, TypeDesc t, const void* val,
-                   bool lockgeom = true);
+                   ParamHints hints = ParamHints::none);
     bool Shader(string_view shaderusage, string_view shadername,
                 string_view layername);
     bool ConnectShaders(string_view srclayer, string_view srcparam,
                         string_view dstlayer, string_view dstparam);
     bool ShaderGroupEnd(void);
+
+    // DEPRECATED(1.13): use the version above that takes ParamHints.
+    // This is the old version that takes `bool lockgeom`.
+    bool Parameter(string_view name, TypeDesc t, const void* val, bool lockgeom)
+    {
+        return Parameter(name, t, val,
+                         lockgeom ? ParamHints::none
+                                  : ParamHints::interpolated);
+    }
 
     /// Create a per-thread data needed for shader execution.  It's very
     /// important for the app to never use a PerThreadInfo from more than

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -478,7 +478,9 @@ public:
         , m_const_initializer(false)
         , m_connected_down(false)
         , m_initialized(false)
-        , m_lockgeom(false)
+        , m_interpolated(false)
+        , m_interactive(false)
+        , m_noninteractive(false)
         , m_allowconnect(true)
         , m_renderer_output(false)
         , m_readonly(false)
@@ -871,11 +873,36 @@ public:
 
     bool lockgeom() const
     {
-        return m_lockgeom;
+        // We can lock a value to a constant (at all places on all pieces of
+        // geometry) if it is neither interpolated nor interactively modified.
+        return !m_interpolated && !m_interactive;
     }
-    void lockgeom(bool lock)
+
+    bool interpolated() const
     {
-        m_lockgeom = lock;
+        return m_interpolated;
+    }
+    void interpolated(bool val)
+    {
+        m_interpolated = val;
+    }
+
+    bool interactive() const
+    {
+        return m_interactive;
+    }
+    void interactive(bool val)
+    {
+        m_interactive = val;
+    }
+
+    bool noninteractive() const
+    {
+        return m_noninteractive;
+    }
+    void noninteractive(bool val)
+    {
+        m_noninteractive = val;
     }
 
     bool allowconnect() const
@@ -1029,10 +1056,12 @@ protected:
     unsigned m_symtype : 4;     ///< Kind of symbol (param, local, etc.)
     unsigned m_has_derivs : 1;  ///< Step to derivs (0 == has no derivs)
     unsigned m_const_initializer : 1;  ///< initializer is a constant expression
-    unsigned m_connected_down : 1;   ///< Connected to a later/downstream layer
-    unsigned m_initialized : 1;      ///< If a param, has it been initialized?
-    unsigned m_lockgeom : 1;         ///< Is the param not overridden by geom?
-    unsigned m_allowconnect : 1;     ///< Is the param not overridden by geom?
+    unsigned m_connected_down : 1;  ///< Connected to a later/downstream layer
+    unsigned m_initialized : 1;     ///< If a param, has it been initialized?
+    unsigned m_interpolated : 1;    ///< Is the param overridden by geom?
+    unsigned m_interactive : 1;     ///< May the param change interactively?
+    unsigned m_noninteractive : 1;  ///< The param def won't modify interactively
+    unsigned m_allowconnect : 1;    ///< Is the param allowd to connect?
     unsigned m_renderer_output : 1;  ///< Is this sym a renderer output?
     unsigned m_readonly : 1;         ///< read-only symbol
     unsigned m_is_uniform : 1;  ///< symbol is uniform under batched execution

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -143,6 +143,10 @@ Symbol::print(std::ostream& out, int maxvals) const
             out << " renderer-output";
         if (symtype() == SymTypeParam && !lockgeom())
             out << " lockgeom=0";
+        if (symtype() == SymTypeParam && interactive())
+            out << " interactive=1";
+        if (symtype() == SymTypeParam && noninteractive())
+            out << " interactive=0";
     }
     out << "\n";
     if (symtype() == SymTypeConst) {

--- a/src/liboslexec/loadshader.cpp
+++ b/src/liboslexec/loadshader.cpp
@@ -171,7 +171,7 @@ OSOReaderToMaster::symbol(SymType symtype, TypeSpec typespec, const char* name_)
         sym.dataoffset (m_shadingsys.global_heap_offset (sym.name()));
     }
 #endif
-    sym.lockgeom(m_shadingsys.lockgeom_default());
+    sym.interpolated(!m_shadingsys.lockgeom_default());
     m_master->m_symbols.push_back(sym);
     m_symmap[name] = int(m_master->m_symbols.size()) - 1;
     // Start the index at which we add specified defaults
@@ -419,7 +419,13 @@ OSOReaderToMaster::hint(string_view hintstring)
             Symbol& sym(m_master->m_symbols.back());
             if (type == TypeDesc::TypeInt && ident == "lockgeom"
                 && Strutil::parse_int(h, ival) && ival >= 0)
-                sym.lockgeom(ival);
+                sym.interpolated(!ival);  // soft deprecated
+            else if (type == TypeDesc::TypeInt && ident == "interpolated"
+                     && Strutil::parse_int(h, ival) && ival >= 0)
+                sym.interpolated(ival);
+            else if (type == TypeDesc::TypeInt && ident == "interactive"
+                     && Strutil::parse_int(h, ival) && ival >= 0)
+                sym.interactive(ival);
             else if (type == TypeDesc::TypeInt && ident == "allowconnect"
                      && Strutil::parse_int(h, ival) && ival >= 0)
                 sym.allowconnect(ival);

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -521,8 +521,8 @@ OSLInput::open(const std::string& name, ImageSpec& newspec,
                                                             exprcount++);
         std::string sourcecode = OIIO::Strutil::fmt::format(
             "shader {} (\n"
-            "    float s = u [[ int lockgeom=0 ]],\n"
-            "    float t = v [[ int lockgeom=0 ]],\n"
+            "    float s = u [[ int interpolated=1 ]],\n"
+            "    float t = v [[ int interpolated=1 ]],\n"
             "    output color result = 0,\n"
             "    output float alpha = 1,\n"
             "  )\n"

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -87,7 +87,6 @@ set_shadingsys_options()
     shadingsys->attribute("llvm_optimize", llvm_opt);
 
     shadingsys->attribute("profile", int(profile));
-    shadingsys->attribute("lockgeom", 1);
     shadingsys->attribute("debug_nan", debugnan);
     shadingsys->attribute("debug_uninit", debug_uninit);
     shadingsys->attribute("userdata_isconnected", userdata_isconnected);

--- a/testsuite/layers-entry/run.py
+++ b/testsuite/layers-entry/run.py
@@ -34,17 +34,17 @@
 #
 #
 # So by the default execution rules, the execution sequence will be:
-#   A   (because it sets a global) [presuming lazyglobls == 0]
+#   A   (because it sets a global) [presuming lazyglobals == 0]
 #   D   (because it sets a renderer output)
 #   G   (because it's the last layer -- presumed group entry point)
-#   E   (because F pulls its output)
+#   E   (because G pulls its output)
 #   B   (because E pulls its output)
 #
 # But if we give explicit entry points and ask to execute layers B, F, E,
 # then the call sequence will be:
 #   B   (because we ask for it)
 #   F   (because we ask for it)
-#         (note: then B does NOT get called gain, because it already ran)
+#         (note: then B does NOT get called again, because it already ran)
 #   E   (because F asks for it)
 #   (then we should see F end)
 #   (then E does NOT get called again, because it already ran)

--- a/testsuite/testshade-expr/ref/out.txt
+++ b/testsuite/testshade-expr/ref/out.txt
@@ -1,8 +1,8 @@
 Expression-based shader text is:
 ---
 shader expr_0 (
-    float s = u [[ int lockgeom=0 ]],
-    float t = v [[ int lockgeom=0 ]],
+    float s = u [[ int interpolated=1 ]],
+    float t = v [[ int interpolated=1 ]],
     output color result = 0,
     output float alpha = 1,
   )


### PR DESCRIPTION
Establish two new metadata hints about shader parameters:

  - "interpolated" means that the parameter comes from the geometry somehow and may be bound with a different value at different points on the surfaces, or different values for different primitives that share the material. This corresponds to concepts known variously as "geometric primitive data/variables", "user data", or "vertex variables", depending on the renderer.

  - "interactive" means that the user desires the parameter to be allowed to change when the scene is interactively rerendered, without incurring a full recompile of the shader. (Variables not so marked might still be capable of being changed, but not necessarily without a re-JIT of the shaders.)

Both of these require that the parameter not be fully constant-folded or optimized away during runtime optimizeation or JIT, and thus supplant the old "lockgeom=0" hint. But their semantics may differ in other ways, so we thought it was worth introducing a separation, and at the same time, finally fixing the mis-design of "lockgeom" (which in retrospect is both a confusing name and also has the 0|1 sense backwards, thwarting even my own intuition every time I use it).

We introduce new variants of `ShadingSystem::Parameter()` that changes the optional `bool lockgeom` parameter for a new enum `ParamHints` that allows for future expansion with more hinted properties. For now, the old calls still work (lockgeom=false is the same as passing ParamHints::interpolated) and this does not introduce any break to backwards ABI compatibility at this time.

In this PR, "interpolated" is basically the replacement for the old lockgeom (though the sense is reversed). The "interactive" hint is put in place but doesn't do anything especially useful at the moment that is different from interpolated.  A few more things are coming down the pike in subsequent PRs: (1) Make interactive work and fully hook it up to ReParameter(), including on GPU. (2) Make a new global SS option that says if you're building shaders for an interactive render or an offline render. (If offline, the even "interactive" hinted params should be constant-folded.)
