### PR TITLE
Build: verify that OSL can build with clang16

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 
 * A suitable C++14 or C++17 compiler to build OSL itself, which may be any of:
    - GCC 6.1 or newer (tested through gcc 12.1)
-   - Clang 3.4 or newer (tested through clang 15)
+   - Clang 3.4 or newer (tested through clang 16)
    - Microsoft Visual Studio 2017 or newer
    - Intel C++ compiler icc version 17 or newer or LLVM-based icx compiler
      version 2022 or newer.
@@ -41,7 +41,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     DYLD_LIBRARY_PATH on OS X).
 
 * [LLVM](http://www.llvm.org) 9, 10, 11, 12, 13, 14, or 15, including
-  clang libraries. LLVM 16 probably doesn't work yet, we need to make changes
+  clang libraries. LLVM 16 doesn't work yet, we need to make changes
   on the OSL side to be compatible.
 
 * (optional) For GPU rendering on NVIDIA GPUs:

--- a/site/spi/Makefile-bits
+++ b/site/spi/Makefile-bits
@@ -189,6 +189,10 @@ else ifeq (${platform}, macosx)
         MY_CMAKE_FLAGS += \
             -DCMAKE_C_COMPILER=/usr/local/opt/llvm@15/bin/clang \
             -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@15/bin/clang++
+    else ifeq (${COMPILER},clang16)
+        MY_CMAKE_FLAGS += \
+                -DCMAKE_C_COMPILER=/usr/local/opt/llvm@16/bin/clang \
+                -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm@16/bin/clang++
     else ifeq (${COMPILER},clang)
         MY_CMAKE_FLAGS += -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     else ifeq (${COMPILER},gcc)
@@ -196,13 +200,13 @@ else ifeq (${platform}, macosx)
     else ifeq (${COMPILER},)
         # default compiler is clang, taken from the LLVM directory
         MY_CMAKE_FLAGS += \
-           -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang \
-           -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
+           -DCMAKE_C_COMPILER=${LLVM_ROOT}/bin/clang \
+           -DCMAKE_CXX_COMPILER=${LLVM_ROOT}/bin/clang++
     else ifeq (${COMPILER},llvm)
         # "llvm" means "use the clang from our llvm"
         MY_CMAKE_FLAGS += \
-            -DCMAKE_C_COMPILER=${LLVM_DIRECTORY}/bin/clang \
-            -DCMAKE_CXX_COMPILER=${LLVM_DIRECTORY}/bin/clang++
+            -DCMAKE_C_COMPILER=${LLVM_ROOT}/bin/clang \
+            -DCMAKE_CXX_COMPILER=${LLVM_ROOT}/bin/clang++
     endif
 
     # end generic OSX

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -14,7 +14,7 @@ uname
 
 
 if [[ `uname` == "Linux" ]] ; then
-    LLVM_VERSION=${LLVM_VERSION:=13.0.0}
+    LLVM_VERSION=${LLVM_VERSION:=14.0.0}
     LLVM_INSTALL_DIR=${LLVM_INSTALL_DIR:=${PWD}/llvm-install}
     if [[ "$GITHUB_WORKFLOW" != "" ]] ; then
         LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-18.04}


### PR DESCRIPTION
But note: OSL does not yet work with LLVM 16.

Because homebrew recently upgraded its default llvm to 16.0, there may be users for whom builds now break. The solution is:

    brew install llvm@14
    cmake ... -DLLVM_ROOT=/usr/local/opt/llvm@14

