### PR TITLE
Don't insert redundant run layer calls inside a basic block

### DIFF
--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -398,12 +398,8 @@ public:
 
     /// Execute the upstream connection (if any, and if not yet run) that
     /// establishes the value of symbol sym, which has index 'symindex'
-    /// within the current layer rop.inst().  If already_run is not NULL,
-    /// it points to a vector of layer indices that are known to have been
-    /// run -- those can be skipped without dynamically checking their
-    /// execution status.
-    void llvm_run_connected_layers(Symbol& sym, int symindex, int opnum = -1,
-                                   std::set<int>* already_run = NULL);
+    /// within the current layer rop.inst().
+    void llvm_run_connected_layers(Symbol& sym, int symindex, int opnum = -1);
 
     /// Generate code for a call to the named function with the given
     /// arg list as symbols -- float & ints will be passed by value,
@@ -499,6 +495,11 @@ public:
         shadingsys().m_stat_tex_calls_codegened += 1;
         if (handle)
             shadingsys().m_stat_tex_calls_as_handles += 1;
+    }
+
+    void increment_useparam_ops()
+    {
+        shadingsys().m_stat_useparam_ops++;
     }
 
     /// Return the mapping from symbol names to GlobalVariables.

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1098,6 +1098,7 @@ BackendLLVM::build_llvm_instance(bool groupentry)
     // records for each.
     find_basic_blocks();
     find_conditionals();
+    m_call_layers_inserted.clear();
 
     build_llvm_code(inst()->maincodebegin(), inst()->maincodeend());
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -955,6 +955,8 @@ private:
     atomic_int m_stat_global_connections;   ///< Stat: global connections elim'd
     atomic_int m_stat_tex_calls_codegened;  ///< Stat: total texture calls
     atomic_int m_stat_tex_calls_as_handles;  ///< Stat: texture calls with handles
+    atomic_int m_stat_useparam_ops;  ///< Stat: pre-optimization useparam ops
+    atomic_int m_stat_call_layers_inserted;  ///< Stat: post-opt layer calls
     double m_stat_master_load_time;          ///< Stat: time loading masters
     double m_stat_optimization_time;         ///< Stat: time spent optimizing
     double m_stat_opt_locking_time;          ///<   locking time
@@ -2606,6 +2608,8 @@ protected:
     std::vector<char> m_in_conditional;  ///< Whether each op is in a cond
     std::vector<char> m_in_loop;         ///< Whether each op is in a loop
     int m_first_return;                  ///< Op number of first return or exit
+    std::set<std::pair<int, int>>
+        m_call_layers_inserted;  ///< Lookup for (bblockid, layerid)
 };
 
 };  // namespace pvt

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1093,6 +1093,8 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
     m_stat_global_connections                = 0;
     m_stat_tex_calls_codegened               = 0;
     m_stat_tex_calls_as_handles              = 0;
+    m_stat_useparam_ops                      = 0;
+    m_stat_call_layers_inserted              = 0;
     m_stat_master_load_time                  = 0;
     m_stat_optimization_time                 = 0;
     m_stat_getattribute_time                 = 0;
@@ -1768,6 +1770,8 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
     ATTR_DECODE("stat:global_connections", int, m_stat_global_connections);
     ATTR_DECODE("stat:tex_calls_codegened", int, m_stat_tex_calls_codegened);
     ATTR_DECODE("stat:tex_calls_as_handles", int, m_stat_tex_calls_as_handles);
+    ATTR_DECODE("stat:useparam_ops", int, m_stat_useparam_ops);
+    ATTR_DECODE("stat:call_layers_inserted", int, m_stat_call_layers_inserted);
     ATTR_DECODE("stat:master_load_time", float, m_stat_master_load_time);
     ATTR_DECODE("stat:optimization_time", float, m_stat_optimization_time);
     ATTR_DECODE("stat:opt_locking_time", float, m_stat_opt_locking_time);
@@ -2402,6 +2406,8 @@ ShadingSystemImpl::getstats(int level) const
                   * (double(m_stat_postopt_syms)
                          / (std::max(1, (int)m_stat_preopt_syms))
                      - 1.0));
+        print(out, "  Optimized {} useparam ops into {} llvm run layer calls\n",
+              m_stat_useparam_ops, m_stat_call_layers_inserted);
     }
     print(out, "  Constant connections eliminated: {}\n",
           (int)m_stat_const_connections);


### PR DESCRIPTION
## Description

This patch is a very simple part one of work to optimize the number of conditional run layer calls that OSL makes, which take the form:
```
if (!groupdata->run[parentlayer])
    parent_layer([...]);
```

After examining our slowest JIT’ing shaders on gpu, @tgrant-nv showed us that these run layer calls were significantly bloating our ptx and slowing down their compilation. Many of them are unnecessary because static analysis can show we are guaranteed to have already run the layer in question.

For example, reading different fields from a connected struct like below will often generate multiple conditional run layer calls:
```
struct Pair {
    float x;
    float y;
};

shader example_shader(Pair p = {})
{
    if ([…]) {
        float xx = p.x;
        float yy = p.y;
        […]
    }
}
```

Since this is not really a performance issue on cpu (runtime overhead is just checking the conditional bit), OSL doesn’t make a huge effort to optimize away these redundant cases. Each useparam op will be careful not to insert more than one per layer, and code that is called unconditionally in the main section of the shader will also not have redundant checks, but there are plenty of examples like above that are not currently removed.

----

This patch takes a basic first step, adding metrics to track run layer call counts and removing duplicate run layer calls inside a basic block, covering cases like the example above.

On my set of production test scenes, this alone removes anywhere from 20-50% of total run layer calls, with our biggest shaders seeing the most improvement. Total ptx line reduction varies between 3-20%, and optix module compilation (jit time) is reduced between 1-15%.


## Tests

I don't know how to write a test that asserts an intermediate result of an optimization (fewer run layer calls) instead of asserting that an image looks correct.

Internally, I replaced omitted run layer calls with asserts that `groupdata->run[parentlayer] == true`, and ran against several test scenes totaling around a hundred or so shaders.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

