### PR TITLE
fix for ReParameterization corner case

### DIFF
--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -660,10 +660,14 @@ ShaderInstance::mergeable(const ShaderInstance& b,
             continue;
         if (sym->typespec().is_closure())
             continue;  // Closures can't have instance override values
+        // Even if the symbols' values match now, they might not in the
+        // future with 'interactive' parameters.
+        const Symbol* b_sym = optimized ? b.symbol(i) : b.mastersymbol(i);
         if ((sym->valuesource() == Symbol::InstanceVal
              || sym->valuesource() == Symbol::DefaultVal)
-            && memcmp(param_storage(i), b.param_storage(i),
-                      sym->typespec().simpletype().size())) {
+            && (memcmp(param_storage(i), b.param_storage(i),
+                       sym->typespec().simpletype().size())
+                || b_sym->interactive())) {
             return false;
         }
     }


### PR DESCRIPTION

## Description

This proposed patch fixes a corner case we were seeing during live rendering with ReParameterization.

We were experiencing a problem when `ss->ReParameterize()` wasn't successfully applying parameter changes for us.

In our situation, a shader's parameter, "A",  was marked with lockgeom=0 (ie. "live" or "editable") and was set via `ss->Parameter()`.  This parameter was connected (through a series of copies and network links) to another shader's parameter, "B", downstream whose initialized value (ie. the one specified in the .osl/.oso file) matched A's set value.  When this happened, A's shading layer was getting marked as "mergeable" and deleted, and we wouldn't see any updates to A via "reparameterization" take effect.

## Tests

We are using  v3.13.2.3 locally and a similar fix (with `b_sym->lockgeom() == 0` in lieu of this PR's `b_sym->interactive()`) resolved the issue.  I can port my fix to the v3.12.3 branch if desired.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

