### PR TITLE
Make recent run-layer optimizations optional, and fix init ops-related false positive

### DIFF
--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -398,8 +398,12 @@ public:
 
     /// Execute the upstream connection (if any, and if not yet run) that
     /// establishes the value of symbol sym, which has index 'symindex'
-    /// within the current layer rop.inst().
-    void llvm_run_connected_layers(Symbol& sym, int symindex, int opnum = -1);
+    /// within the current layer rop.inst().  If already_run is not NULL,
+    /// it points to a vector of layer indices that are known to have been
+    /// run -- those can be skipped without dynamically checking their
+    /// execution status.
+    void llvm_run_connected_layers(Symbol& sym, int symindex, int opnum = -1,
+                                   std::set<int>* already_run = NULL);
 
     /// Generate code for a call to the named function with the given
     /// arg list as symbols -- float & ints will be passed by value,

--- a/src/liboslexec/batched_backendllvm.h
+++ b/src/liboslexec/batched_backendllvm.h
@@ -477,9 +477,13 @@ public:
 
     /// Execute the upstream connection (if any, and if not yet run) that
     /// establishes the value of symbol sym, which has index 'symindex'
-    /// within the current layer rop.inst().
+    /// within the current layer rop.inst().  If already_run is not NULL,
+    /// it points to a vector of layer indices that are known to have been
+    /// run -- those can be skipped without dynamically checking their
+    /// execution status.
     void llvm_run_connected_layers(const Symbol& sym, int symindex,
-                                   int opnum = -1);
+                                   int opnum                  = -1,
+                                   std::set<int>* already_run = NULL);
 
 
 

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -157,7 +157,8 @@ BatchedBackendLLVM::llvm_call_layer(int layer, bool unconditional)
 
 void
 BatchedBackendLLVM::llvm_run_connected_layers(const Symbol& sym, int symindex,
-                                              int opnum)
+                                              int opnum,
+                                              std::set<int>* already_run)
 {
     if (sym.valuesource() != Symbol::ConnectedVal)
         return;  // Nothing to do
@@ -172,6 +173,16 @@ BatchedBackendLLVM::llvm_run_connected_layers(const Symbol& sym, int symindex,
         const Connection& con(inst()->connection(c));
         // If the connection gives a value to this param
         if (con.dst.param == symindex) {
+            // already_run is a set of layers run for this particular op.
+            // Just so we don't stupidly do several consecutive checks on
+            // whether we ran this same layer. It's JUST for this op.
+            if (already_run) {
+                if (already_run->count(con.srclayer))
+                    continue;  // already ran that one on this op
+                else
+                    already_run->insert(con.srclayer);  // mark it
+            }
+
             if (inmain) {
                 // There is an instance-wide m_layers_already_run that tries
                 // to remember which earlier layers have unconditionally
@@ -190,15 +201,14 @@ BatchedBackendLLVM::llvm_run_connected_layers(const Symbol& sym, int symindex,
                 }
             }
 
-            // m_call_layers_inserted tracks if we've already run this layer either:
-            //   * inside the current basic block (opnum >= 0)
-            //   * while writing output parameters (opnum == -1)
-            const CallLayerKey key = { opnum >= 0 ? m_bblockids[opnum] : opnum,
-                                       con.srclayer };
-            if (m_call_layers_inserted.count(key)) {
-                continue;
+            if (shadingsys().m_opt_useparam && inmain) {
+                // m_call_layers_inserted tracks if we've already run this layer inside the current basic block
+                const CallLayerKey key = { m_bblockids[opnum], con.srclayer };
+                if (m_call_layers_inserted.count(key)) {
+                    continue;
+                }
+                m_call_layers_inserted.insert(key);
             }
-            m_call_layers_inserted.insert(key);
 
             // If the earlier layer it comes from has not yet been
             // executed, do so now.
@@ -224,11 +234,15 @@ LLVMGEN(llvm_gen_useparam)
         std::cout << ">>>>>>>>>>>>>>>>>>>>>llvm_gen_useparam <<<<<<<<<<<<<<<<<<<"
                   << std::endl);
 
+    // If we have multiple params needed on this statement, don't waste
+    // time checking the same upstream layer more than once.
+    std::set<int> already_run;
+
     Opcode& op(rop.inst()->ops()[opnum]);
     for (int i = 0; i < op.nargs(); ++i) {
         Symbol& sym  = *rop.opargsym(op, i);
         int symindex = rop.inst()->arg(op.firstarg() + i);
-        rop.llvm_run_connected_layers(sym, symindex, opnum);
+        rop.llvm_run_connected_layers(sym, symindex, opnum, &already_run);
         // If it's an interpolated (userdata) parameter and we're
         // initializing them lazily, now we have to do it.
         if ((sym.symtype() == SymTypeParam

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -887,6 +887,7 @@ private:
     bool m_opt_middleman;            ///< Middle-man optimization?
     bool m_opt_texture_handle;       ///< Use texture handles?
     bool m_opt_seed_bblock_aliases;  ///< Turn on basic block alias seeds
+    bool m_opt_useparam;  ///< Perform extra useparam analysis for culling run layer calls
     bool m_opt_batched_analysis;  ///< Perform extra analysis required for batched execution?
     bool m_llvm_jit_fma;         ///< Allow fused multiply/add in JIT
     bool m_llvm_jit_aggressive;  ///< Turn on llvm "aggressive" JIT

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1024,6 +1024,7 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
     , m_opt_middleman(true)
     , m_opt_texture_handle(true)
     , m_opt_seed_bblock_aliases(true)
+    , m_opt_useparam(false)
     ,
 #if OSL_USE_BATCHED
     m_opt_batched_analysis((renderer->batched(WidthOf<16>()) != nullptr)
@@ -1535,6 +1536,7 @@ ShadingSystemImpl::attribute(string_view name, TypeDesc type, const void* val)
     ATTR_SET("opt_middleman", int, m_opt_middleman);
     ATTR_SET("opt_texture_handle", int, m_opt_texture_handle);
     ATTR_SET("opt_seed_bblock_aliases", int, m_opt_seed_bblock_aliases);
+    ATTR_SET("opt_useparam", int, m_opt_useparam);
     ATTR_SET("opt_batched_analysis", int, m_opt_batched_analysis);
     ATTR_SET("llvm_jit_fma", int, m_llvm_jit_fma);
     ATTR_SET("llvm_jit_aggressive", int, m_llvm_jit_aggressive);
@@ -1704,6 +1706,7 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
     ATTR_DECODE("opt_middleman", int, m_opt_middleman);
     ATTR_DECODE("opt_texture_handle", int, m_opt_texture_handle);
     ATTR_DECODE("opt_seed_bblock_aliases", int, m_opt_seed_bblock_aliases);
+    ATTR_DECODE("opt_useparam", int, m_opt_useparam);
     ATTR_DECODE("llvm_jit_fma", int, m_llvm_jit_fma);
     ATTR_DECODE("llvm_jit_aggressive", int, m_llvm_jit_aggressive);
     ATTR_DECODE_STRING("llvm_jit_target", m_llvm_jit_target);


### PR DESCRIPTION
## Description

My initial implementation of the run layer check optimizations didn’t account for the fact that init ops for symbols have their llvm code generated before we build basic blocks from the OSL IR.

This caused the code to be wrong in two ways: 1) the set of known run layer calls was being reset between instances too late in the pipeline, so a useparam inside an init op would actually be checking the previously compiled layer’s set, and 2) even when reset earlier, it assumed valid basic block ids existed for the init ops when they did not.

So, if a layer had a useparam inside one of its init ops that generally matched the same code location as a useparam in the previously compiled layer, the run layer check could be incorrectly omitted.


I’ve updated the code so that the default optimization behavior is reverted to the way it was before #1665, and added a new option `opt_useparam` that can be turned on to enable a fixed, restricted version of the optimization that only applies to code in the main section.

## Tests

I'm working on a test that properly triggers the issue.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

