### PR TITLE
Fix constant float values being converted to ints

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -705,7 +705,8 @@ OSLCompilerImpl::write_oso_const_value(const ConstantSymbol* sym) const
     else if (equivalent(elemtype, TypeDesc::TypeVector))
         for (int i = 0; i < nelements; ++i) {
             Vec3 v = sym->get_vec3(i);
-            osofmt("{:.9g} {:.9g} {:.9g}{}", v.x, v.y, v.z, nelements > 1 ? " " : "");
+            osofmt("{:.9g} {:.9g} {:.9g}{}", v.x, v.y, v.z,
+                   nelements > 1 ? " " : "");
         }
     else {
         OSL_ASSERT(0 && "Don't know how to output this constant type");

--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -701,11 +701,11 @@ OSLCompilerImpl::write_oso_const_value(const ConstantSymbol* sym) const
             osofmt("{}{}", sym->get_int(i), nelements > 1 ? " " : "");
     else if (elemtype == TypeDesc::FLOAT)
         for (int i = 0; i < nelements; ++i)
-            osofmt("{}{}", sym->floatval(i), nelements > 1 ? " " : "");
+            osofmt("{:.9g}{}", sym->floatval(i), nelements > 1 ? " " : "");
     else if (equivalent(elemtype, TypeDesc::TypeVector))
         for (int i = 0; i < nelements; ++i) {
             Vec3 v = sym->get_vec3(i);
-            osofmt("{} {} {}{}", v.x, v.y, v.z, nelements > 1 ? " " : "");
+            osofmt("{:.9g} {:.9g} {:.9g}{}", v.x, v.y, v.z, nelements > 1 ? " " : "");
         }
     else {
         OSL_ASSERT(0 && "Don't know how to output this constant type");


### PR DESCRIPTION
## Description

This issue was caused by https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/commit/8c52d48965db74f56daa59c4a668b34daf32b220 . The problem is that the constant float values are being turned into ints. The PR restores the previous behavior and preserves the float format.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

