### PR TITLE
Fix builds when USE_PYTHON=OFF

### DIFF
--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -20,12 +20,9 @@ macro (find_python)
 
     # Attempt to find the desired version, but fall back to other
     # additional versions.
-    unset (_req)
-    if (USE_PYTHON)
-        set (_req REQUIRED)
-        if (PYTHON_VERSION)
-            list (APPEND _req EXACT)
-        endif ()
+    set (_req REQUIRED)
+    if (PYTHON_VERSION)
+        list (APPEND _req EXACT)
     endif ()
     checked_find_package (Python ${PYTHON_VERSION}
                           ${_req}


### PR DESCRIPTION
## Description
This issue was caused by https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/commit/5efe15a79eb2d29a0f526f4c7e43c6f483b39d15. Essentially, we now use `Python_EXECUTABLE` to execute the `serialize-bc.py` script. Therefore, we have to run `find_package(python)` so that the `Python_EXECUTABLE` variable gets setup.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

