### PR TITLE
Expose API to add __optix_enabled__ prefix to shadeops that could call OptiX functions

### DIFF
--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -7,6 +7,7 @@
 #include <OSL/oslconfig.h>
 
 #include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 #ifdef LLVM_NAMESPACE
@@ -87,6 +88,9 @@ public:
     LLVM_Util(const PerThreadInfo& per_thread_info, int debuglevel = 0,
               int vector_width = 4);
     ~LLVM_Util();
+
+    // map of function names and prefixes that we would like prepended to these functions
+    std::unordered_map<ustring, ustring, ustringHash> m_function_prefixes;
 
     // JIT'd code needs to exist with a longer lifetime than the LLVM_Util object.
     // To enable better cleanup at shutdown, the lifetime of all JIT'd code is

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -411,6 +411,9 @@ public:
         return false;
     }
 
+    virtual void register_optix_enabled_functions (std::vector<ustring>& function_names)
+    {
+    }
 
 
     /// Options we use for noise calls.

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -85,6 +85,20 @@ BackendLLVM::BackendLLVM(ShadingSystemImpl& shadingsys, ShaderGroup& group,
     m_use_rs_bitcode = !shadingsys.m_rs_bitcode.empty();
     m_name_llvm_syms = shadingsys.m_llvm_output_bitcode;
 
+    if (m_use_optix)
+    {
+        // These internal ops we hardcode to be OptiX enabled
+        ustring __optix_enabled__("__optix_enabled__");
+        ll.m_function_prefixes[ustring("osl_prepend_matrix_from")]        = __optix_enabled__;
+        ll.m_function_prefixes[ustring("osl_get_from_to_matrix")]         = __optix_enabled__;
+        ll.m_function_prefixes[ustring("osl_transform_triple_nonlinear")] = __optix_enabled__;
+        ll.m_function_prefixes[ustring("osl_transform_triple")]           = __optix_enabled__;
+        std::vector<ustring> extra_optix_enabled_functions;
+        shadingsys.renderer()->register_optix_enabled_functions(extra_optix_enabled_functions);
+        for (auto f : extra_optix_enabled_functions)
+            ll.m_function_prefixes[f] = __optix_enabled__;
+    }
+
     // Select the appropriate ustring representation
     ll.ustring_rep(m_use_optix ? LLVM_Util::UstringRep::hash
                                : LLVM_Util::UstringRep::charptr);

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -2609,7 +2609,7 @@ public:
     std::string layer_function_name(const ShaderGroup& group,
                                     const ShaderInstance& inst)
     {
-        return fmtformat("{}_{}", group.name(), inst.layername());
+        return fmtformat("__optix_enabled__{}_{}", group.name(), inst.layername());
     }
     std::string layer_function_name()
     {

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1994,7 +1994,7 @@ ShadingSystemImpl::getattribute(ShaderGroup* group, string_view name,
         int nlayers          = group->nlayers();
         ShaderInstance* inst = (*group)[nlayers - 1];
         // This formulation mirrors OSOProcessorBase::layer_function_name()
-        *(ustring*)val = ustring::fmtformat("__direct_callable__{}_{}",
+        *(ustring*)val = ustring::fmtformat("__direct_callable____optix_enabled__{}_{}",
                                             group->name(), inst->layername());
         return true;
     }


### PR DESCRIPTION
## Description

I'm creating this PR to start a discussion on how to best solve an issue that we hit while using OptiX 7 + OSL. With the OptiX 7 changes, the way we deal with renderer specific shadops is a little different from the OptiX 6 days. Essentially, renderer specific shadeops are now just marked extern, and then when we do the OptiX JIT compile, we link the definitions in from some other OptiX compiled module. The problem comes when these shadeop definitions call `optix*` device functions (e.g. `optixTrace`, `optixDirectCall`, etc...). If you didn't already know, if you have an `optix*` call in some function, the OptiX JIT compiler will inline the whole function call stack and remove all the definitions. This is a problem with OSL, because we need these definitions to be linked into our OSL program, not removed. A problematic example would be implementing `oslTrace`. Presumably, to implement this, you would need the `osl_trace` shadeop to call `optixTrace`. Currently, if you do this, the definition will be inlined and discarded by the OptiX JIT compiler and your OSL program that calls trace will just be left with a bunch of unresolved extern function calls.

The solution that we came up with, and is demonstrated by this PR, is to use the new OptiX 7.7 `__optix_enabled__` feature. Essentially, if you add the `__optix_enabled__` prefix to your function name, it will tell the OptiX JIT compiler that although this function contains `optix*` calls, we do not want it to be inlined. The modifications in the PR exposes an API (`register_optix_enabled_functions`) for the renderer to specify to the runtime which shadops will be calling `optix*` functions and will need this prefix added. There is then logic that will add this prefix to the function call. Unfortunately, `__optix_enabled__` functions can only be called by other `__optix_enabled__` functions. Therefore, there are some places, such as some matrix shadeops, that I have had to hardcode with the `__optix_enabled__` prefix. The downside to this, is that if a renderer is not calling `optix*` functions here, they may have some worse performance due to less inlining.

I am interested to know what you guys think of this. Its a fairly specific problem, but one I'm sure other renderers will hit if creating a full OSL implementation in an OptiX renderer.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

