### PR TITLE
OptiX PTX pipeline overhaul

### DIFF
--- a/doc/app_integration/OptiX-Inlining-Options.md
+++ b/doc/app_integration/OptiX-Inlining-Options.md
@@ -61,7 +61,7 @@ In addition to the `ShadingSystem` attributes, individual functions can be
 registered with the `ShadingSystem` as `inline` or `noinline`. Functions can
 be unregistered to restore the default inlining behavior. This registration
 takes precedence over the `ShadingSystem` inlining attributes, which allows
-very fine-grained control when needed
+very fine-grained control when needed.
 
 ```C++
 // Register
@@ -108,5 +108,5 @@ An example tuning workflow might include the following steps:
    
    In particular, be on the lookout for trivial functions (e.g., `osl_floor_ff`)
    which have not been inlined. If such functions appear, that might be a sign
-   that the inline threshold need to be adjusted, or that it might be beneficial
-   to register specific functions.
+   that the inline thresholds need to be adjusted, or that it might be
+   beneficial to register specific functions.

--- a/doc/app_integration/OptiX-Inlining-Options.md
+++ b/doc/app_integration/OptiX-Inlining-Options.md
@@ -1,0 +1,112 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Open Shading Language Project. -->
+
+Inlining Options for OptiX and CUDA
+===================================
+
+When compiling shaders for OptiX and CUDA (and in general), there is a tradeoff
+between compile speed and shade-time performance. The LLVM optimizer generally
+does a good job of balancing these concerns, but there might be cases where a
+renderer can give additional hints to the optimizer to tip the balance one way
+or the other.
+
+Aggressive inlining can increase the run-time performance, but can negatively
+impact the compile speed. Inlining can be very helpful with small functions
+where the function call overhead tends to dwarf the useful instructions, so it
+is important to inline such functions when possible.
+
+Choosing to __not__ inline certain functions (e.g., very large noise functions)
+allows them to be excluded from the module prior to running the LLVM optimizer
+and JIT engine, which can greatly improve the compile time. This is particularly
+beneficial when a function is not likely to be inlined anyway; removing such
+large functions from the module prior to optimization can speed up compilation
+considerably without affecting the generated PTX.
+
+ShadingSystem Attributes
+------------------------
+
+There are a number of `ShadingSystem` attributes to help control the inlining
+behavior. The default settings should work well in most circumstances, but they
+can be adjusted to favor compile speed over shade-time performance, or vice
+versa.
+
+* `optix_no_inline_thresh`: Don't inline functions greater-than or equal-to the
+threshold. This allows them to be excluded from the module prior to
+optimization, which reduces the size of module and can greatly speed up the
+optimization and JIT stages.
+
+* `optix_force_inline_thresh`: Force inline functions less-than or equal-to the
+threshold. This tends to be most helpful with relatively low values, < 30.
+
+* `optix_no_inline`: Don't inline any functions. Offers the best compile times
+at the expense of shade-time performance. This option is not recommended, but is
+included for benchmarking and tuning purposes.
+    
+* `optix_no_inline_layer_funcs`: Don't inline the shader layer functions. This
+can moderately improve compile times at the expense of shade-time performance.
+    
+* `optix_merge_layer_funcs`: Allow layer functions that are only called once to
+be merged into their caller, even if `optix_no_inline_layer_funcs` is set. This
+can help restore some of the shade-time performance lost by enabling
+`optix_no_inline_layer_funcs`.
+    
+* `optix_no_inline_rend_lib`: Don't inline any functions defined in the
+renderer-supplied `rend_lib` module. As an alternative, the renderer can simply
+not supply the LLVM bitcode for the `rend_lib` module to the `ShadingSystem`.
+
+Inline/Noinline Function Registration
+-------------------------------------
+
+In addition to the `ShadingSystem` attributes, individual functions can be
+registered with the `ShadingSystem` as `inline` or `noinline`. Functions can
+be unregistered to restore the default inlining behavior. This registration
+takes precedence over the `ShadingSystem` inlining attributes, which allows
+very fine-grained control when needed
+
+```C++
+// Register
+shadingsys->register_inline_function(ustring("osl_abs_ff"));
+shadingsys->register_noinline_function(ustring("osl_gabornoise_dfdfdf"));
+
+// Unregister
+shadingsys->unregister_inline_function(ustring("osl_abs_ff"));
+shadingsys->unregister_noinline_function(ustring("osl_gabornoise_dfdfdf"));
+```
+
+It might be best to prefer the `ShadingSystem` attributes to control the inlining
+behavior, and to strategically register functions when it is known to be
+beneficial through benchmarking and profiling.
+
+Tuning and Analysis
+-------------------
+
+We have added a Python script (`src/build-scripts/analyze-ptx.py`) to help
+identify functions that might be good candidates for inlining/noinling. This
+script will generate a summary of the functions in the input PTX file, with a
+list of all functions and their sizes in CSV format. It will also generate a
+graphical reprensentation of the callgraph in DOT and PDF format.
+
+An example tuning workflow might include the following steps:
+
+1. Run `analyze-ptx.py` on the "shadeops" and "rend_lib" PTX files to generate
+   a list of the functions contained in those modules.
+   
+   ```bash
+   $ analyze_ptx.py shadeop_cuda.ptx
+   $ analyze_ptx.py rend_lib_myrender.ptx
+   ```
+
+2. Run `analyze-ptx.py` on the generated PTX for a representative shader:
+
+    ```bash
+    $ analyze_ptx.py myshader.ptx
+    ```
+    
+3. View the summary file (`myshader-summary.txt`) and the callgraph
+   (`myshader-callgraph.gv`) to deterimine which library functions were _not_
+   inlined. They will appear as boxes with a dashed outline in the callgraph.
+   
+   In particular, be on the lookout for trivial functions (e.g., `osl_floor_ff`)
+   which have not been inlined. If such functions appear, that might be a sign
+   that the inline threshold need to be adjusted, or that it might be beneficial
+   to register specific functions.

--- a/src/build-scripts/analyze-ptx.py
+++ b/src/build-scripts/analyze-ptx.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
+import getopt
+import graphviz
+import itertools
+import os
+import re
+import sys
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Dict
+
+#-------------------------------------------------------------------------------
+# PTX parsing helpers
+#-------------------------------------------------------------------------------
+
+# pre-compile some regex patterns to speed up parsing
+call_ptn = re.compile(r"^\s*(call\.uni).*$")
+dec_ptn  = re.compile(r"^\s*(\.pragma|\.extern|\.visible|\.func|\.local|\.global|\.reg|\.param|LBB[0-9_]+\:)(.*)$")
+fn_ptn   = re.compile(r"^(\.visible \.func|\.visible \.entry|\.weak \.func|\.func).*[\s]+([a-zA-Z0-9_]+)[\(\)]*$")
+inst_ptn = re.compile(r"^\s*([@!%p0-9 ]*)([a-zA-Z0-9\.]+)\s*([a-zA-Z0-9\$\.,% _\[\]{}+-]+);.*$")
+mem_ptn  = re.compile(r"^\s*(st|ld).*;$")
+ret_ptn  = re.compile(r"^\s*(ret);.*$")
+
+def get_func_name(line):
+    match = fn_ptn.match(line)
+    if match:
+        return match.group(2)
+    else:
+        return ""
+
+def is_func_or_decl(line):
+    match = fn_ptn.match(line)
+    if match:
+       return True
+    else:
+       return False
+
+def is_call_start(line):
+    if line.find("call.uni") != -1:
+        return True
+    else:
+        return False
+
+def is_instruction(line):
+    match = call_ptn.match(line)
+    if match:
+        return True
+    if len(line) < 4:
+        return False
+    if not line.endswith(';'):
+        return False
+
+    match = dec_ptn.match(line)
+    if not match:
+       return True
+    else:
+       return False
+
+def is_mem_inst(line):
+    match = mem_ptn.match(line)
+    if match:
+        return True
+    else:
+        return False
+
+def parse_inst(line):
+    if not is_instruction(line):
+        return "", "", ""
+    match = call_ptn.match(line)
+    if match:
+        return "", "call.uni", ""
+    match = ret_ptn.match(line)
+    if match:
+        return "", "ret", ""
+    match = inst_ptn.match(line)
+    if match:
+        return match.group(1), match.group(2), match.group(3)
+    else:
+        return "", "", ""
+
+#-------------------------------------------------------------------------------
+
+@dataclass
+class FuncStats:
+    func_name:  str = ""
+    inst_count: int = 0
+    call_count: int = 0
+    mem_count:  int = 0
+    call_dict:  Dict[str, int] = field(default_factory=dict) # func name, count
+    inst_dict:  Dict[str, int] = field(default_factory=dict) # inst, count
+
+@dataclass
+class FileStats:
+    total_funcs:      int = 0
+    total_insts:      int = 0
+    total_mem_insts:  int = 0
+    total_calls:      int = 0
+    extern_funcs:     Dict[str, int] = field(default_factory=dict) # func name, count
+    func_calls:       Dict[str, int] = field(default_factory=dict) # func name, count
+    summary_dict:     Dict[str, str] = field(default_factory=dict) # func name, summary
+    inst_dict:        Dict[str, int] = field(default_factory=dict) # inst, count
+    largest_function: str = ""
+    largest_size:     int = 0
+    csv_string:       str = ""
+
+#-------------------------------------------------------------------------------
+
+def parse_ptx(ptx_filename):
+    # read the raw PTX into a string
+    raw_ptx = ""
+    with open(ptx_filename, 'r') as ptx_file:
+        raw_ptx = ptx_file.read()
+
+    # variables to keep track of the parsing state
+    begin_func_or_decl = False
+    begin_call         = False
+    in_func            = False
+    brace_count        = 0
+
+    func_stats = FuncStats()
+    func_dict  = {}
+
+    for line in raw_ptx.splitlines():
+        # strip off comments
+        if line.find("//") != -1:
+            line = line[:line.find("//")]
+
+        # trim whitespace and trailing commas
+        line = line.strip(" \t\n\r,")
+
+        # keep track of when we hit a function declaration or definition
+        if is_func_or_decl(line):
+            begin_func_or_decl   = True
+            func_stats.func_name = get_func_name(line)
+
+        # keep track of braces so we can have some picture of nesting
+        brace_count = brace_count + line.count('{')
+        brace_count = brace_count - line.count('}')
+
+        # if we hit a call.uni, we need to look for the name of the callee
+        # on the next pass
+        if is_call_start(line):
+            begin_call            = True
+            func_stats.call_count = func_stats.call_count + 1
+        elif begin_call:
+            begin_call                 = False
+            func_stats.call_dict[line] = func_stats.call_dict.get(line, 0) + 1
+
+        pred, opcode, args = parse_inst(line)
+        if in_func and opcode != "":
+            func_stats.inst_count      = func_stats.inst_count + 1
+            func_stats.mem_count       = func_stats.mem_count + is_mem_inst(line)
+            inst                       = opcode
+            func_stats.inst_dict[inst] = func_stats.inst_dict.get((inst), 0) + 1
+
+        if begin_func_or_decl and brace_count == 1:
+            in_func            = True
+            begin_func_or_decl = False
+
+        # exiting the function -- save off the stats
+        if in_func and brace_count == 0:
+            func_dict[func_stats.func_name] = func_stats
+
+            # prepare for the next iteration
+            func_stats         = FuncStats()
+            begin_func_or_decl = False
+            begin_call         = False
+            in_func            = False
+            brace_count        = 0
+
+    return func_dict
+
+#-------------------------------------------------------------------------------
+
+def gather_file_stats(func_dict):
+    file_stats             = FileStats()
+    file_stats.total_funcs = len(func_dict)
+    file_stats.csv_string  = "Function Name, Total Instructions, Memory Instructions, Function Calls\n"
+
+    # print the function statistics
+    for key, entry in sorted(func_dict.items()):
+        func_name                   = entry.func_name
+        file_stats.total_insts     += entry.inst_count
+        file_stats.total_mem_insts += entry.mem_count
+        file_stats.total_calls     += entry.call_count
+
+        # keep track of the largest function
+        if entry.inst_count > file_stats.largest_size:
+            file_stats.largest_function = func_name
+            file_stats.largest_size     = entry.inst_count
+
+        # clamp the counts to prevent divide-by-zero
+        inst_count = max(1, entry.inst_count)
+        mem_count  = max(1, entry.mem_count)
+        call_count = max(1, entry.call_count)
+
+        summary_string  = ""
+        summary_string += " Function:            {}\n".format(func_name)
+        summary_string += " Total Instructions:  {}\n".format(inst_count)
+        summary_string += " Memory Instructions: {} ({:.2f}%)\n".format(mem_count, 100 * float(mem_count)/inst_count)
+        summary_string += " Total Calls:         {}\n".format(entry.call_count)
+
+        summary_string += "\n"
+        summary_string += "Top 10 Function Calls (name, count, %):\n"
+        for name, count in itertools.islice(sorted(entry.call_dict.items(), key=lambda item: -item[1]), 0, 11):
+            summary_string += " {}, {}, {:.2f}%\n".format(name, count, 100 * float(count)/max(1,file_stats.total_calls))
+
+        # print the instruction mix
+        summary_string += "\n"
+        summary_string += "Instruction Mix (name, count, %):\n"
+        for inst, count in sorted(entry.inst_dict.items()):
+            summary_string += " {}, {}, {:.2f}%\n".format(inst, count, 100 * float(count)/inst_count)
+            file_stats.inst_dict[inst] = file_stats.inst_dict.get((inst), 0) + count
+
+        # print the call mix
+        summary_string += "\n"
+        summary_string += "Function Calls (name, count, %):\n"
+        for name, count in sorted(entry.call_dict.items()):
+            file_stats.func_calls[name] = file_stats.func_calls.get((name), 0) + count
+            summary_string += " {}, {}, {:.2f}%\n".format(name, count, 100 * float(count)/call_count)
+            if not name in func_dict:
+                file_stats.extern_funcs[name] = 1
+
+        file_stats.summary_dict[func_name] = summary_string
+
+        file_stats.csv_string += "{},{},{},{}\n".format(func_name, entry.inst_count, entry.mem_count, entry.call_count)
+
+    return file_stats
+
+#-------------------------------------------------------------------------------
+
+def generate_summary(func_dict, file_stats, out_name):
+    summary_string  = "Overall Stats\n"
+    summary_string += " Total Functions:     {}\n".format(file_stats.total_funcs)
+    summary_string += " Total Instructions:  {}\n".format(file_stats.total_insts)
+    summary_string += " Memory Instructions: {} ({:.2f}%)\n".format(file_stats.total_mem_insts, 100 * float(file_stats.total_mem_insts)/max(1, file_stats.total_insts))
+    summary_string += " Total Calls:         {}\n".format(file_stats.total_calls)
+    summary_string += " Biggest Function:    {} ({} instructions)\n".format(file_stats.largest_function, file_stats.largest_size)
+
+    summary_string += "\n"
+    summary_string += "Top 10 Function Calls (name, count, %):\n"
+    for name, count in itertools.islice(sorted(file_stats.func_calls.items(), key=lambda item: -item[1]), 0, 11):
+        summary_string += " {}, {}, {:.2f}%\n".format(name, count, 100 * float(count)/max(1,file_stats.total_calls))
+
+    summary_string += "\n"
+    summary_string += "Function Call Counts (name, count, %):\n"
+    for name, count in sorted(file_stats.func_calls.items()):
+        summary_string += " {}, {}, {:.2f}%\n".format(name, count, 100 * float(count)/max(1,file_stats.total_calls))
+
+    summary_string += "\n"
+    summary_string += "Instruction Mix (name, count, %):\n"
+    for name, count in sorted(file_stats.inst_dict.items()):
+        summary_string += " {}, {}, {:.2f}%\n".format(name, count, 100 * float(count)/max(1,file_stats.total_insts))
+
+    summary_string += "\n"
+    summary_string += "Uncalled Functions:\n"
+    for name, count in sorted(func_dict.items()):
+        if not name in file_stats.func_calls:
+            summary_string += " {}\n".format(name)
+
+    summary_string += "\n"
+    summary_string += "Extern Functions:\n"
+    for name, val in sorted(file_stats.extern_funcs.items()):
+        summary_string += " {}\n".format(name)
+
+    with open("{}-summary.txt".format(out_name), "w") as summary_file:
+        summary_file.write(summary_string)
+        for func_name, summary in sorted(file_stats.summary_dict.items()):
+            summary_file.write("\n#---------------------------------------\n")
+            summary_file.write(summary)
+
+    with open("{}.csv".format(out_name), "w") as csv_file:
+        csv_file.write(file_stats.csv_string)
+
+    return summary_string
+
+#-------------------------------------------------------------------------------
+
+def wrap_name(name):
+    wrapped_name = ""
+    cur_line     = ""
+    last_char    = ''
+    wrap_len     = 20
+    split_pos    = 0
+    line_pos     = 0
+
+    for cur_char in name:
+        cur_line = cur_line + cur_char
+        line_pos = line_pos + 1
+
+        if not cur_char.isalpha():
+            # prefer to split at non-alphabetic characters
+            split_pos = line_pos
+        elif last_char.isupper() and not cur_char.isupper():
+            # otherwise, prefer to split at the first capitalized letter
+            # of some group
+            split_pos = line_pos - 2
+
+        if line_pos == wrap_len:
+            wrapped_name = wrapped_name + cur_line[:split_pos] + '\n'
+            cur_line     = cur_line[split_pos:]
+            line_pos     = len(cur_line)
+
+        last_char = cur_char
+
+    wrapped_name = wrapped_name + cur_line + '\n'
+    return wrapped_name.strip(" \t\n\r,")
+
+#-------------------------------------------------------------------------------
+
+def generate_callgraph(func_dict, file_stats, out_name):
+    callgraph = graphviz.Digraph("{} Call Graph".format(out_name),
+                                 filename="{}-callgraph.gv".format(out_name),
+                                 engine="dot")
+
+    callgraph.attr("graph", rankdir="TB")
+    callgraph.attr("graph", splines="true")
+    callgraph.attr("graph", concentrate="false")
+    callgraph.attr("graph", clusterrank="none")
+    callgraph.attr("node",  fontname="Courier New")
+    callgraph.attr("node",  shape="square")
+    callgraph.attr("node",  nojustify="true")
+    callgraph.attr("node",  width="2.5")
+    callgraph.attr("node",  height="2.5")
+    callgraph.attr("edge",  penwidth="3")
+    callgraph.attr("edge",  constrain="false")
+
+    # create a summary node
+    with callgraph.subgraph(name="Summary") as c:
+        c.attr("graph", rankdir="TB")
+        c.attr("graph", splines="true")
+        c.attr("graph", concentrate="false")
+        c.attr("graph", clusterrank="none")
+        c.attr("node",  fontname="Courier New")
+        c.attr("node",  shape="square")
+        c.attr("node",  nojustify="false")
+        c.attr("node",  width="2.5")
+        c.attr("node",  height="2.5")
+        c.attr("edge",  penwidth="3")
+        c.attr("edge",  constrain="false")
+        c.node(name="SUMMARY",
+               label="Summary\linsts: {}\lfuncs: {}\lcalls: {}\l".format
+               (file_stats.total_insts, file_stats.total_funcs, file_stats.total_calls))
+
+    # create the nodes
+    for func_name, entry in sorted(func_dict.items()):
+        num_calls_to = 0
+        if func_name in file_stats.func_calls:
+            num_calls_to = file_stats.func_calls[func_name]
+        label = "{}\n\ninsts:      {}\lcalls from: {}\lcalls to:   {}\l".format(
+            wrap_name(func_name),
+            entry.inst_count,
+            entry.call_count,
+            num_calls_to)
+        callgraph.node(name=wrap_name(func_name), label=label)
+
+    # create nodes for the extern functions
+    callgraph.attr("node", style="dashed")
+    for key, entry in sorted(file_stats.extern_funcs.items()):
+        func_name = key
+        callgraph.node(wrap_name(func_name))
+
+    # cycle through a handful of edge colors to add a little eye candy
+    color_idx   = 0
+    edge_colors = [ "#FF000080",  # red
+                    "#00800F80",  # green
+                    "#FFAF0080",  # orange
+                    "#0000FF80",  # blue
+                    "#40404080" ] # gray
+
+    # create the edges
+    for key, entry in sorted(func_dict.items()):
+        func_name = entry.func_name
+        callgraph.attr("edge",  color=edge_colors[color_idx])
+        for calleeName, count in sorted(entry.call_dict.items()):
+            callgraph.attr("edge",  tooltip="{} -> {}".format(func_name, calleeName))
+            callgraph.edge(wrap_name(func_name), wrap_name(calleeName))
+        color_idx = (color_idx + 1) % len(edge_colors)
+
+    callgraph.render()
+
+    return
+
+#-------------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("Wrong number of arguments\nUsage: $ parse-ptx.py <path-to-PTX-file>")
+
+    in_name = sys.argv[1]
+    if not os.path.isfile(in_name):
+        sys.exit("Unable to open PTX file")
+
+    out_name   = os.path.splitext(os.path.basename(in_name))[0]
+    func_dict  = parse_ptx(in_name)
+    file_stats = gather_file_stats(func_dict)
+
+    generate_summary(func_dict, file_stats, out_name)
+    generate_callgraph(func_dict, file_stats, out_name)
+
+    return
+
+if __name__ == "__main__":
+    main()
+
+#-------------------------------------------------------------------------------

--- a/src/build-scripts/process-ptx.py
+++ b/src/build-scripts/process-ptx.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+# Open a PTX file and:
+#  * convert all `.weak` functions to `.visible`;
+#  * add the `.visible` directive to global variables.
+
+from __future__ import print_function, absolute_import
+
+import re
+import sys
+
+in_name = sys.argv[1]
+out_name = sys.argv[2]
+ptx = ""
+with open(in_name, 'r') as ptx_in:
+    ptx = ptx_in.read()
+ptx = ptx.replace(".weak .func", ".visible .func")
+ptx = re.sub(r'(?m)^(\.const .align)', ".visible .const .align", ptx)
+ptx = re.sub(r'(?m)^(\.func)', ".visible .func", ptx)
+with open(out_name, 'w') as ptx_out:
+    ptx_out.write(ptx)

--- a/src/build-scripts/process-ptx.py
+++ b/src/build-scripts/process-ptx.py
@@ -17,7 +17,6 @@ out_name = sys.argv[2]
 ptx = ""
 with open(in_name, 'r') as ptx_in:
     ptx = ptx_in.read()
-ptx = ptx.replace(".weak .func", ".visible .func")
 ptx = re.sub(r'(?m)^(\.const .align)', ".visible .const .align", ptx)
 ptx = re.sub(r'(?m)^(\.func)', ".visible .func", ptx)
 with open(out_name, 'w') as ptx_out:

--- a/src/build-scripts/process-ptx.py
+++ b/src/build-scripts/process-ptx.py
@@ -4,8 +4,8 @@
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 # Open a PTX file and:
-#  * convert all `.weak` functions to `.visible`;
-#  * add the `.visible` directive to global variables.
+#  * add the `.visible` directive to all functions
+#  * add the `.visible` directive to global/constant variables
 
 from __future__ import print_function, absolute_import
 
@@ -18,6 +18,7 @@ ptx = ""
 with open(in_name, 'r') as ptx_in:
     ptx = ptx_in.read()
 ptx = re.sub(r'(?m)^(\.const .align)', ".visible .const .align", ptx)
+ptx = re.sub(r'(?m)^(\.global .align)', ".visible .global .align", ptx)
 ptx = re.sub(r'(?m)^(\.func)', ".visible .func", ptx)
 with open(out_name, 'w') as ptx_out:
     ptx_out.write(ptx)

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -21,12 +21,6 @@ function ( NVCC_COMPILE cuda_src extra_headers ptx_generated extra_nvcc_args )
     list (TRANSFORM OpenImageIO_INCLUDES PREPEND -I
           OUTPUT_VARIABLE ALL_OpenImageIO_INCLUDES)
 
-    if (${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
-        # Until we fully support opaque pointers, we need to disable
-        # them when using LLVM 15.
-        list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)
-    endif ()
-
     add_custom_command ( OUTPUT ${cuda_ptx}
         COMMAND ${CUDA_NVCC_EXECUTABLE}
             "-I${OPTIX_INCLUDES}"
@@ -108,6 +102,12 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
         # compiling for Cuda. When all 3rd parties have their export macro fixed these warnings
         # can be restored.
         set (CLANG_MSVC_FIX "${CLANG_MSVC_FIX} -Wno-ignored-attributes -Wno-unknown-attributes")
+    endif ()
+
+    if (${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
+        # Until we fully support opaque pointers, we need to disable
+        # them when using LLVM 15.
+        list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)
     endif ()
 
     list (TRANSFORM IMATH_INCLUDES PREPEND -I

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -213,7 +213,7 @@ function ( CUDA_SHADEOPS_COMPILE prefix output_bc output_ptx input_srcs headers 
     # Link all of the individual LLVM bitcode files, and emit PTX for the linked bitcode
     add_custom_command ( OUTPUT ${linked_bc} ${linked_ptx}
         COMMAND ${LLVM_LINK_TOOL} ${shadeops_bc_list} -o ${linked_bc}
-        COMMAND ${LLVM_OPT_TOOL} ${CUDA_OPT_FLAG_CLANG} ${linked_bc} -o ${linked_bc}
+        COMMAND ${LLVM_OPT_TOOL} ${CUDA_OPT_FLAG_CLANG} --nvptx-assign-valid-global-names ${linked_bc} -o ${linked_bc}
         COMMAND ${LLVM_LLC_TOOL} --march=nvptx64 -mcpu=${CUDA_TARGET_ARCH} ${linked_bc} -o ${linked_ptx}
         # This script converts all of the .weak functions defined in the PTX into .visible functions.
         COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/src/build-scripts/process-ptx.py"

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -94,6 +94,20 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
                 NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_ENVIRONMENT_PATH)
     endif ()
 
+    if (NOT LLVM_LLC_TOOL)
+        find_program (LLVM_LLC_TOOL NAMES "llc"
+                PATHS "${LLVM_DIRECTORY}/bin" "${LLVM_DIRECTORY}/tools/llvm"
+                NO_CMAKE_PATH NO_DEFAULT_PATH NO_CMAKE_SYSTEM_PATH
+                NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_ENVIRONMENT_PATH)
+    endif ()
+
+    if (NOT LLVM_OPT_TOOL)
+        find_program (LLVM_OPT_TOOL NAMES "opt"
+                PATHS "${LLVM_DIRECTORY}/bin" "${LLVM_DIRECTORY}/tools/llvm"
+                NO_CMAKE_PATH NO_DEFAULT_PATH NO_CMAKE_SYSTEM_PATH
+                NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_ENVIRONMENT_PATH)
+    endif ()
+
     if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         # fix compilation error when using MSVC
         set (CLANG_MSVC_FIX "-DBOOST_CONFIG_REQUIRES_THREADS_HPP")

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -136,6 +136,7 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
             "-I${OPTIX_INCLUDES}"
             "-I${CUDA_INCLUDES}"
             "-I${CMAKE_CURRENT_SOURCE_DIR}"
+            "-I${CMAKE_SOURCE_DIR}/src/liboslexec"
             "-I${CMAKE_BINARY_DIR}/include"
             "-I${PROJECT_SOURCE_DIR}/src/include"
             "-I${PROJECT_SOURCE_DIR}/src/cuda_common"
@@ -169,3 +170,54 @@ function ( LLVM_COMPILE_CUDA llvm_src headers prefix llvm_bc_cpp_generated extra
         DEPENDS "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py" ${llvm_src} ${headers} ${llvm_bc}
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 endfunction ()
+
+macro ( CUDA_SHADEOPS_COMPILE srclist rend_lib_src headers )
+    # Add all of the "shadeops" sources that need to be compiled to LLVM bitcode for CUDA
+    set ( shadeops_srcs
+        ${CMAKE_SOURCE_DIR}/src/liboslexec/llvm_ops.cpp
+        ${CMAKE_SOURCE_DIR}/src/liboslexec/opnoise.cpp
+        ${CMAKE_SOURCE_DIR}/src/liboslexec/opspline.cpp
+        ${CMAKE_SOURCE_DIR}/src/liboslexec/opcolor.cpp
+        ${CMAKE_SOURCE_DIR}/src/liboslexec/opmatrix.cpp
+        ${CMAKE_SOURCE_DIR}/src/liboslnoise/gabornoise.cpp
+        ${CMAKE_SOURCE_DIR}/src/liboslnoise/simplexnoise.cpp
+        ${rend_lib_src}
+        )
+
+    set (shadeops_bc_cuda_cpp   "${CMAKE_CURRENT_BINARY_DIR}/shadeops_cuda.bc.cpp")
+    set (linked_shadeops_bc     "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops.bc")
+    set (linked_shadeops_opt_bc "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops_opt.bc")
+    set (linked_shadeops_ptx    "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops.ptx")
+
+    list (APPEND ${srclist} ${shadeops_bc_cuda_cpp})
+
+    foreach ( shadeops_src ${shadeops_srcs} )
+        MAKE_CUDA_BITCODE ( ${shadeops_src} "_cuda" shadeops_bc "" )
+        list ( APPEND shadeops_bc_list ${shadeops_bc} )
+    endforeach ()
+
+    # Link all of the individual LLVM bitcode files, and emit PTX for the linked bitcode
+    add_custom_command ( OUTPUT ${linked_shadeops_opt_bc} ${linked_shadeops_ptx}
+        COMMAND ${LLVM_LINK_TOOL} ${shadeops_bc_list} -o ${linked_shadeops_bc}
+        COMMAND ${LLVM_OPT_TOOL} -O2 ${linked_shadeops_bc} -o ${linked_shadeops_opt_bc}
+        COMMAND ${LLVM_LLC_TOOL} --march=nvptx64 -mcpu=${CUDA_TARGET_ARCH} -O2 ${linked_shadeops_opt_bc} -o ${linked_shadeops_ptx}
+        # This script converts all of the .weak functions defined in the PTX into .visible functions.
+        COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/src/build-scripts/process-ptx.py"
+            ${linked_shadeops_ptx} ${linked_shadeops_ptx}
+            DEPENDS ${shadeops_bc_list} ${exec_headers} ${PROJECT_PUBLIC_HEADERS} ${shadeops_srcs} ${headers}
+                "${CMAKE_SOURCE_DIR}/src/build-scripts/process-ptx.py"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
+
+    # Serialize the linked bitcode into a CPP file that can be embedded
+    # in the current target binary
+    add_custom_command ( OUTPUT ${shadeops_bc_cuda_cpp}
+        COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py"
+            ${linked_shadeops_opt_bc} ${shadeops_bc_cuda_cpp} "rend_llvm_compiled_ops"
+
+        DEPENDS "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py" ${linked_shadeops_opt_bc}
+            ${exec_headers} ${PROJECT_PUBLIC_HEADERS}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
+
+    install (FILES ${linked_shadeops_ptx}
+        DESTINATION ${OSL_PTX_INSTALL_DIR})
+endmacro ()

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -62,6 +62,7 @@ enum class TargetISA {
     AVX512,
     AVX512_noFMA,
     HOST,
+    NVPTX,
     COUNT
 };
 
@@ -202,6 +203,9 @@ public:
     /// make_jit_execengine() or to detect_cpu_features(). Don't call
     /// target_isa() unless one of those has previously been called.
     TargetISA target_isa() const { return m_target_isa; }
+
+    /// Set the TargetISA to be used during codegen.
+    void set_target_isa(TargetISA requestedISA) { m_target_isa = requestedISA; }
 
     // Check support for certain CPU ISA features. These are only valid
     // after detect_cpu_features() (or make_jit_execengine()) has been

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -34,6 +34,7 @@ class LLVMContext;
 class Module;
 class PointerType;
 class StringRef;
+class TargetMachine;
 class Type;
 class Value;
 class VectorType;
@@ -266,6 +267,10 @@ public:
     /// Replace the ExecutionEngine (pass NULL to simply delete the
     /// current one).
     void execengine(llvm::ExecutionEngine* exec);
+
+    /// Return a pointer to the TargetMachine for NVPTX.  Create the TargetMachine
+    /// if it has not yet been created.
+    llvm::TargetMachine* nvptx_target_machine();
 
     enum class Linkage {
         External,  // Externally visible
@@ -1051,6 +1056,7 @@ private:
     llvm::legacy::FunctionPassManager* m_llvm_func_passes;
     llvm::ExecutionEngine* m_llvm_exec;
     TargetISA m_target_isa = TargetISA::UNKNOWN;
+    llvm::TargetMachine* m_nvptx_target_machine;
 
     std::vector<llvm::BasicBlock*> m_return_block;      // stack for func call
     std::vector<llvm::BasicBlock*> m_loop_after_block;  // stack for break

--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -1110,6 +1110,15 @@ public:
     static bool convert_value(void* dst, TypeDesc dsttype, const void* src,
                               TypeDesc srctype);
 
+    /// Tell the ShadingSystem if there are functions that should or should not
+    /// be inlined during LLVM optimization.  Functions that are not registered
+    /// will not receive any special treatment, and may or may not be inlined.
+    void register_inline_function(ustring name);
+    void unregister_inline_function(ustring name);
+    void register_noinline_function(ustring name);
+    void unregister_noinline_function(ustring name);
+
+
 private:
     pvt::ShadingSystemImpl* m_impl;
 };

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -206,10 +206,46 @@ if (USE_LLVM_BITCODE)
 
     EMBED_LLVM_BITCODE_IN_CPP ( "${rs_dependent_ops_srcs}" "_host_rs" "osl_llvm_compiled_rs_dependent_ops" lib_src "" "${include_dirs}")
 
-    # The shadeops are provided as bitcode by the renderer, so we need to
-    # enable bitcode support in liboslexec.
     if (CUDA_FOUND)
         add_definitions (-DOSL_LLVM_CUDA_BITCODE)
+
+        # The shadeops are compiled to both LLVM bitcode and PTX, and embedded
+        # in liboslexec in binary format. The bitcode is used to seed the LLVM
+        # module for each shader, and the PTX can be retrieved by the renderer
+        # through the shading system.
+        set (liboslexec_shadeops_srcs
+            ${CMAKE_SOURCE_DIR}/src/liboslexec/llvm_ops.cpp
+            ${CMAKE_SOURCE_DIR}/src/liboslexec/opnoise.cpp
+            ${CMAKE_SOURCE_DIR}/src/liboslexec/opspline.cpp
+            ${CMAKE_SOURCE_DIR}/src/liboslexec/opcolor.cpp
+            ${CMAKE_SOURCE_DIR}/src/liboslexec/opmatrix.cpp
+            ${CMAKE_SOURCE_DIR}/src/liboslnoise/gabornoise.cpp
+            ${CMAKE_SOURCE_DIR}/src/liboslnoise/simplexnoise.cpp
+        )
+
+        CUDA_SHADEOPS_COMPILE ( "shadeops_cuda"
+            shadeops_cuda_bc
+            shadeops_cuda_ptx
+            "${liboslexec_shadeops_srcs}"
+            ""
+        )
+
+        # Serialize the linked bitcode into a CPP file to be embedded in the current target binary
+        set (shadeops_bc_cuda_cpp "${CMAKE_CURRENT_BINARY_DIR}/shadeops_cuda.bc.cpp")
+        MAKE_EMBEDDED_CPP( "shadeops_cuda_llvm_compiled_ops" ${shadeops_bc_cuda_cpp} ${shadeops_cuda_bc} )
+        list (APPEND lib_src ${shadeops_bc_cuda_cpp})
+
+        # Serialize the linked PTX into a CPP file to be embedded in the current target binary
+        set (shadeops_ptx_cuda_cpp "${CMAKE_CURRENT_BINARY_DIR}/shadeops_cuda.ptx.cpp")
+        MAKE_EMBEDDED_CPP( "shadeops_cuda_ptx_compiled_ops" ${shadeops_ptx_cuda_cpp} ${shadeops_cuda_ptx} )
+        list (APPEND lib_src ${shadeops_ptx_cuda_cpp})
+
+        # Installing the shadeops PTX isn't necessary since the renderer can
+        # retrieve it through the shading system. But for testing purposes it is
+        # handy to make the PTX available offline.
+        install (FILES ${shadeops_cuda_ptx}
+            DESTINATION ${OSL_PTX_INSTALL_DIR})
+
     endif ()
 else ()
     # With MSVC/Mingw, we don't compile llvm_ops.cpp to LLVM bitcode, due

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -184,55 +184,6 @@ foreach(src ${lib_src})
     endif()
 endforeach(src)
 
-macro ( CUDA_SHADEOPS_COMPILE srclist )
-    # Add all of the "shadeops" sources that need to be compiled to LLVM bitcode for CUDA
-    set ( shadeops_srcs
-        llvm_ops.cpp
-        opnoise.cpp
-        opspline.cpp
-        opcolor.cpp
-        opmatrix.cpp
-        ../liboslnoise/gabornoise.cpp
-        ../liboslnoise/simplexnoise.cpp
-        ../testrender/cuda/rend_lib.cu
-        )
-
-    set ( shadeops_bc_cuda_cpp "${CMAKE_CURRENT_BINARY_DIR}/shadeops_cuda.bc.cpp" )
-    set ( linked_shadeops_bc "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops.bc" )
-    set ( linked_shadeops_opt_bc "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops_opt.bc" )
-    set ( linked_shadeops_ptx "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops.ptx" )
-
-    list ( APPEND ${srclist} ${shadeops_bc_cuda_cpp} )
-
-    foreach ( shadeops_src ${shadeops_srcs} )
-        MAKE_CUDA_BITCODE ( ${shadeops_src} "_cuda" shadeops_bc "" )
-        list ( APPEND shadeops_bc_list ${shadeops_bc} )
-    endforeach ()
-
-    # Link all of the individual LLVM bitcode files, and emit PTX for the linked bitcode
-    add_custom_command ( OUTPUT ${linked_shadeops_opt_bc} ${linked_shadeops_ptx}
-        COMMAND ${LLVM_LINK_TOOL} ${shadeops_bc_list} -o ${linked_shadeops_bc}
-        COMMAND ${LLVM_OPT_TOOL} -O2 ${linked_shadeops_bc} -o ${linked_shadeops_opt_bc}
-        COMMAND ${LLVM_LLC_TOOL} --march=nvptx64 -mcpu=sm_60 -O2 ${linked_shadeops_opt_bc} -o ${linked_shadeops_ptx}
-        # This script converts all of the .weak functions defined in the PTX into .visible functions.
-        COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/src/build-scripts/process-ptx.py"
-            ${linked_shadeops_ptx} ${linked_shadeops_ptx}
-            DEPENDS ${shadeops_bc_list} ${exec_headers} ${PROJECT_PUBLIC_HEADERS} ${shadeops_srcs}
-                "${CMAKE_SOURCE_DIR}/src/build-scripts/process-ptx.py"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
-
-    # Serialize the linked bitcode into a CPP file and add it to the list of liboslexec sources
-    add_custom_command ( OUTPUT ${shadeops_bc_cuda_cpp}
-        COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py"
-            ${linked_shadeops_opt_bc} ${shadeops_bc_cuda_cpp} "osl_llvm_compiled_ops_cuda"
-        DEPENDS "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py" ${linked_shadeops_opt_bc}
-        ${exec_headers} ${PROJECT_PUBLIC_HEADERS}
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
-
-    install (FILES ${linked_shadeops_ptx}
-        DESTINATION ${OSL_PTX_INSTALL_DIR})
-endmacro ( )
-
 if (USE_LLVM_BITCODE)
     set (llvm_ops_srcs llvm_ops.cpp)
 
@@ -255,10 +206,10 @@ if (USE_LLVM_BITCODE)
 
     EMBED_LLVM_BITCODE_IN_CPP ( "${rs_dependent_ops_srcs}" "_host_rs" "osl_llvm_compiled_rs_dependent_ops" lib_src "" "${include_dirs}")
 
-    # Optionally repeat the bitcode compilation with CUDA-specific options
+    # The shadeops are provided as bitcode by the renderer, so we need to
+    # enable bitcode support in liboslexec.
     if (CUDA_FOUND)
         add_definitions (-DOSL_LLVM_CUDA_BITCODE)
-        CUDA_SHADEOPS_COMPILE ( lib_src )
     endif ()
 else ()
     # With MSVC/Mingw, we don't compile llvm_ops.cpp to LLVM bitcode, due

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -194,10 +194,13 @@ macro ( CUDA_SHADEOPS_COMPILE srclist )
         opmatrix.cpp
         ../liboslnoise/gabornoise.cpp
         ../liboslnoise/simplexnoise.cpp
+        ../testrender/cuda/rend_lib.cu
         )
 
     set ( shadeops_bc_cuda_cpp "${CMAKE_CURRENT_BINARY_DIR}/shadeops_cuda.bc.cpp" )
     set ( linked_shadeops_bc "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops.bc" )
+    set ( linked_shadeops_opt_bc "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops_opt.bc" )
+    set ( linked_shadeops_ptx "${CMAKE_CURRENT_BINARY_DIR}/linked_shadeops.ptx" )
 
     list ( APPEND ${srclist} ${shadeops_bc_cuda_cpp} )
 
@@ -206,19 +209,28 @@ macro ( CUDA_SHADEOPS_COMPILE srclist )
         list ( APPEND shadeops_bc_list ${shadeops_bc} )
     endforeach ()
 
-    # Link all of the individual LLVM bitcode files
-    add_custom_command ( OUTPUT ${linked_shadeops_bc}
-        COMMAND ${LLVM_LINK_TOOL} -internalize ${shadeops_bc_list} -o ${linked_shadeops_bc}
-        DEPENDS ${shadeops_bc_list} ${exec_headers} ${PROJECT_PUBLIC_HEADERS} ${shadeops_srcs}
+    # Link all of the individual LLVM bitcode files, and emit PTX for the linked bitcode
+    add_custom_command ( OUTPUT ${linked_shadeops_opt_bc} ${linked_shadeops_ptx}
+        COMMAND ${LLVM_LINK_TOOL} ${shadeops_bc_list} -o ${linked_shadeops_bc}
+        COMMAND ${LLVM_OPT_TOOL} -O2 ${linked_shadeops_bc} -o ${linked_shadeops_opt_bc}
+        COMMAND ${LLVM_LLC_TOOL} --march=nvptx64 -mcpu=sm_60 -O2 ${linked_shadeops_opt_bc} -o ${linked_shadeops_ptx}
+        # This script converts all of the .weak functions defined in the PTX into .visible functions.
+        COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/src/build-scripts/process-ptx.py"
+            ${linked_shadeops_ptx} ${linked_shadeops_ptx}
+            DEPENDS ${shadeops_bc_list} ${exec_headers} ${PROJECT_PUBLIC_HEADERS} ${shadeops_srcs}
+                "${CMAKE_SOURCE_DIR}/src/build-scripts/process-ptx.py"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 
     # Serialize the linked bitcode into a CPP file and add it to the list of liboslexec sources
     add_custom_command ( OUTPUT ${shadeops_bc_cuda_cpp}
         COMMAND ${Python_EXECUTABLE} "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py"
-            ${linked_shadeops_bc} ${shadeops_bc_cuda_cpp} "osl_llvm_compiled_ops_cuda"
-        DEPENDS "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py" ${linked_shadeops_bc}
+            ${linked_shadeops_opt_bc} ${shadeops_bc_cuda_cpp} "osl_llvm_compiled_ops_cuda"
+        DEPENDS "${CMAKE_SOURCE_DIR}/src/build-scripts/serialize-bc.py" ${linked_shadeops_opt_bc}
         ${exec_headers} ${PROJECT_PUBLIC_HEADERS}
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
+
+    install (FILES ${linked_shadeops_ptx}
+        DESTINATION ${OSL_PTX_INSTALL_DIR})
 endmacro ( )
 
 if (USE_LLVM_BITCODE)

--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -41,6 +41,10 @@ public:
     /// and store the llvm::Function* handle to it with the ShaderGroup.
     virtual void run();
 
+    /// Set additional Module/Function options for the CUDA/OptiX target.
+    void prepare_module_for_cuda_jit();
+
+
 
     /// What LLVM debug level are we at?
     int llvm_debug() const;

--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -119,6 +119,11 @@ DECL(osl_allocate_weighted_closure_component, "CXiiX")
 DECL(osl_closure_to_string, "sXC")
 DECL(osl_closure_to_ustringhash, "hXC")
 #else
+// TODO: Figure out why trying to match the signatures between host and device
+//       definitions fails with 'LLVM had to make a cast' assertion failure.
+//
+//       In the meantime, use a signature that matches the definitions in rend_lib.cu,
+//       where void* is used instead of ClosureColor* and ShaderGlobals*.
 DECL(osl_add_closure_closure, "XXXX")
 DECL(osl_mul_closure_float, "XXXf")
 DECL(osl_mul_closure_color, "XXXc")

--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -110,6 +110,7 @@
 
 
 
+#ifndef __CUDA_ARCH__
 DECL(osl_add_closure_closure, "CXCC")
 DECL(osl_mul_closure_float, "CXCf")
 DECL(osl_mul_closure_color, "CXCc")
@@ -117,6 +118,15 @@ DECL(osl_allocate_closure_component, "CXii")
 DECL(osl_allocate_weighted_closure_component, "CXiiX")
 DECL(osl_closure_to_string, "sXC")
 DECL(osl_closure_to_ustringhash, "hXC")
+#else
+DECL(osl_add_closure_closure, "XXXX")
+DECL(osl_mul_closure_float, "XXXf")
+DECL(osl_mul_closure_color, "XXXc")
+DECL(osl_allocate_closure_component, "XXii")
+DECL(osl_allocate_weighted_closure_component, "XXiiX")
+DECL(osl_closure_to_string, "sXX")
+DECL(osl_closure_to_ustringhash, "hXX")
+#endif
 DECL(osl_format, "ss*")
 DECL(osl_gen_ustringhash_pod, "hs")
 DECL(osl_gen_printfmt, "xXhiXiX")

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1934,6 +1934,16 @@ BackendLLVM::run()
             }
         }
 
+        auto is_inline_fn = [&](const std::string& name) {
+            return shadingsys().m_inline_functions.find(ustring(name))
+                != shadingsys().m_inline_functions.end();
+        };
+
+        auto is_noinline_fn = [&](const std::string& name) {
+            return shadingsys().m_noinline_functions.find(ustring(name))
+                != shadingsys().m_noinline_functions.end();
+        };
+
         // Set the inlining behavior for each function in the module, based on
         // the shadingsys attributes. The inlining attributes are not modified
         // by default.
@@ -1964,6 +1974,16 @@ BackendLLVM::run()
 
             // Only apply the inline thresholds to library functions.
             if (!fn.hasFnAttribute("osl-lib-function")) {
+                continue;
+            }
+
+            if (is_inline_fn(fn.getName().str())) {
+                fn.addFnAttr(llvm::Attribute::AlwaysInline);
+                continue;
+            }
+
+            if (is_noinline_fn(fn.getName().str())) {
+                fn.deleteBody();
                 continue;
             }
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1693,6 +1693,12 @@ BackendLLVM::run()
 #    else
             OSL_ASSERT(0 && "Must generate LLVM CUDA bitcode for OptiX");
 #    endif
+            // Ensure that the correct target triple and data layout are set when targeting NVPTX.
+            // The triple is empty with recent versions of LLVM (e.g., 15) for reasons that aren't
+            // clear. So we must set them to the expected values.
+            // See: https://llvm.org/docs/NVPTXUsage.html
+            ll.module()->setTargetTriple("nvptx64-nvidia-cuda");
+            ll.module()->setDataLayout("e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
         }
         OSL_ASSERT(ll.module());
 #endif

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1707,19 +1707,19 @@ BackendLLVM::run()
         OSL_ASSERT(ll.module());
 #endif
 
-    // Create the ExecutionEngine. We don't create an ExecutionEngine in the
-    // OptiX case, because we are using the NVPTX backend and not MCJIT. However,
-    // it's still useful to set the target ISA to facilitate PTX-specific codegen.
-    if (use_optix()) {
-        ll.set_target_isa(TargetISA::NVPTX);
-    } else if (!ll.make_jit_execengine(
-                   &err, ll.lookup_isa_by_name(shadingsys().m_llvm_jit_target),
-                   shadingsys().llvm_debugging_symbols(),
-                   shadingsys().llvm_profiling_events())) {
-        shadingcontext()->errorfmt("Failed to create engine: {}\n", err);
-        OSL_ASSERT(0);
-        return;
-    }
+        // Create the ExecutionEngine. We don't create an ExecutionEngine in the
+        // OptiX case, because we are using the NVPTX backend and not MCJIT. However,
+        // it's still useful to set the target ISA to facilitate PTX-specific codegen.
+        if (use_optix()) {
+            ll.set_target_isa(TargetISA::NVPTX);
+        } else if (!ll.make_jit_execengine(
+                       &err, ll.lookup_isa_by_name(shadingsys().m_llvm_jit_target),
+                       shadingsys().llvm_debugging_symbols(),
+                       shadingsys().llvm_profiling_events())) {
+            shadingcontext()->errorfmt("Failed to create engine: {}\n", err);
+            OSL_ASSERT(0);
+            return;
+        }
 
         // End of mutex lock, for the OSL_LLVM_NO_BITCODE case
     }

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1920,6 +1920,15 @@ BackendLLVM::run()
             }
         }
 
+#ifndef OSL_CUDA_NO_FTZ
+        for (llvm::Function& fn : *ll.module()) {
+            fn.addFnAttr("nvptx-f32ftz", "true");
+            fn.addFnAttr("denormal-fp-math", "preserve-sign,preserve-sign");
+            fn.addFnAttr("denormal-fp-math-f32",
+                         "preserve-sign,preserve-sign");
+        }
+#endif
+
         ll.do_optimize();
 
         // Drop everything but the init and group entry functions and generated

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -122,8 +122,10 @@ extern unsigned char osl_llvm_compiled_ops_block[];
 extern int osl_llvm_compiled_rs_dependent_ops_size;
 extern unsigned char osl_llvm_compiled_rs_dependent_ops_block[];
 
+#ifdef OSL_LLVM_CUDA_BITCODE
 extern int shadeops_cuda_llvm_compiled_ops_size;
 extern unsigned char shadeops_cuda_llvm_compiled_ops_block[];
+#endif
 
 using namespace OSL::pvt;
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1636,9 +1636,9 @@ BackendLLVM::prepare_module_for_cuda_jit()
             || fn.getName().startswith("llvm."))
             continue;
 
-        // Merge layer functions which have one caller
+        // Merge layer functions which are only called from one place
         if (merge_layer_funcs && !fn.hasFnAttribute("osl-lib-function")
-            && fn.hasOneUser()) {
+            && fn.hasOneUse()) {
             fn.addFnAttr(llvm::Attribute::AlwaysInline);
             continue;
         }

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1869,6 +1869,15 @@ BackendLLVM::run()
     if (!group().does_nothing() && !use_optix()) {
         ll.do_optimize();
     } else if (!group().does_nothing() && use_optix()) {
+        // Set external linkage for the library functions to prevent the
+        // function signatures from being changed by subsequent dead arg
+        // elimination passes. The signatures need to match the
+        // corresponding PTX.
+        for (llvm::Function& fn : *ll.module()) {
+            if (fn.getName().startswith("osl"))
+                fn.setLinkage(llvm::GlobalValue::ExternalLinkage);
+        }
+
         // If the renderer support library bitcode is being used, we can link
         // the module before running the optimization passes to help generate
         // better code. However, this tends to increase the optimization time.

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1606,7 +1606,7 @@ BackendLLVM::prepare_module_for_cuda_jit()
     const bool no_inline_layer_funcs
         = shadingsys().optix_no_inline_layer_funcs();
     const bool merge_layer_funcs  = shadingsys().optix_merge_layer_funcs();
-    const bool no_inline_rendlib  = shadingsys().optix_no_inline_rendlib();
+    const bool no_inline_rend_lib = shadingsys().optix_no_inline_rend_lib();
     const int no_inline_thresh    = shadingsys().optix_no_inline_thresh();
     const int force_inline_thresh = shadingsys().optix_force_inline_thresh();
 
@@ -1654,7 +1654,7 @@ BackendLLVM::prepare_module_for_cuda_jit()
             continue;
         }
 
-        if (no_inline_rendlib && fn.hasFnAttribute("osl-rendlib-function")) {
+        if (no_inline_rend_lib && fn.hasFnAttribute("osl-rend_lib-function")) {
             fn.deleteBody();
             continue;
         }
@@ -1796,7 +1796,7 @@ BackendLLVM::run()
 
         } else {
 #    ifdef OSL_LLVM_CUDA_BITCODE
-            // Create a new module, and then link in the shadeops and rendlib modules.
+            // Create a new module, and then link in the shadeops and rend_lib modules.
             ll.module(ll.new_module("llvm_ops"));
 
             llvm::Module* shadeops_module = ll.module_from_bitcode(
@@ -1840,7 +1840,7 @@ BackendLLVM::run()
                     "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
 
                 for (llvm::Function& fn : *rend_lib_module) {
-                    fn.addFnAttr("osl-rendlib-function", "true");
+                    fn.addFnAttr("osl-rend_lib-function", "true");
                 }
 
                 std::unique_ptr<llvm::Module> rend_lib_ptr(rend_lib_module);

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -23,7 +23,7 @@
 #include "backendllvm.h"
 
 #if OSL_USE_OPTIX
-#include <llvm/Linker/Linker.h>
+#    include <llvm/Linker/Linker.h>
 #endif
 
 // Create external declarations for all built-in funcs we may call from LLVM
@@ -641,7 +641,8 @@ BackendLLVM::llvm_assign_initial_value(const Symbol& sym, bool force)
             // Handle init ops.
             build_llvm_code(sym.initbegin(), sym.initend());
 #if OSL_USE_OPTIX
-        } else if (use_optix() && !sym.typespec().is_closure() && !sym.lockgeom()) {
+        } else if (use_optix() && !sym.typespec().is_closure()
+                   && !sym.lockgeom()) {
             // If the call to osl_bind_interpolated_param returns 0, the default
             // value needs to be loaded from a CUDA variable.
             llvm::Value* cuda_var = getOrAllocateCUDAVariable(sym);
@@ -1881,7 +1882,8 @@ BackendLLVM::run()
         if (use_optix()) {
             ll.set_target_isa(TargetISA::NVPTX);
         } else if (!ll.make_jit_execengine(
-                       &err, ll.lookup_isa_by_name(shadingsys().m_llvm_jit_target),
+                       &err,
+                       ll.lookup_isa_by_name(shadingsys().m_llvm_jit_target),
                        shadingsys().llvm_debugging_symbols(),
                        shadingsys().llvm_profiling_events())) {
             shadingcontext()->errorfmt("Failed to create engine: {}\n", err);

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1744,7 +1744,7 @@ BackendLLVM::run()
             // The target triple and data layout used here are those specified
             // for NVPTX (https://www.llvm.org/docs/NVPTXUsage.html#triples).
             ll.module()->setDataLayout(
-                "e-i64:64-i128:128-v16:16-v32:32-n16:32:64");
+                "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
             ll.module()->setTargetTriple("nvptx64-nvidia-cuda");
         }
 #    endif
@@ -1799,9 +1799,6 @@ BackendLLVM::run()
 
         } else {
 #    ifdef OSL_LLVM_CUDA_BITCODE
-            // Create a new module, and then link in the shadeops and rend_lib modules.
-            ll.module(ll.new_module("llvm_ops"));
-
             llvm::Module* shadeops_module = ll.module_from_bitcode(
                 (char*)shadeops_cuda_llvm_compiled_ops_block,
                 shadeops_cuda_llvm_compiled_ops_size, "llvm_ops", &err);
@@ -1811,9 +1808,9 @@ BackendLLVM::run()
                     "llvm::parseBitcodeFile returned '{}' for cuda llvm_ops\n",
                     err);
 
-            shadeops_module->setTargetTriple("nvptx64-nvidia-cuda");
             shadeops_module->setDataLayout(
                 "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
+            shadeops_module->setTargetTriple("nvptx64-nvidia-cuda");
 
             std::unique_ptr<llvm::Module> shadeops_ptr(shadeops_module);
             llvm::Linker::linkModules(*ll.module(), std::move(shadeops_ptr),
@@ -1838,9 +1835,9 @@ BackendLLVM::run()
                         "llvm::parseBitcodeFile returned '{}' for cuda llvm_ops\n",
                         err);
 
-                rend_lib_module->setTargetTriple("nvptx64-nvidia-cuda");
                 rend_lib_module->setDataLayout(
                     "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64");
+                rend_lib_module->setTargetTriple("nvptx64-nvidia-cuda");
 
                 for (llvm::Function& fn : *rend_lib_module) {
                     fn.addFnAttr("osl-rend_lib-function", "true");

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1878,20 +1878,6 @@ BackendLLVM::run()
                 fn.setLinkage(llvm::GlobalValue::ExternalLinkage);
         }
 
-        // If the renderer support library bitcode is being used, we can link
-        // the module before running the optimization passes to help generate
-        // better code. However, this tends to increase the optimization time.
-        if (!shadingsys().m_lib_bitcode.empty()) {
-            std::vector<char>& bitcode = shadingsys().m_lib_bitcode;
-            OSL_ASSERT(bitcode.size() && "Library bitcode is empty");
-            llvm::Module* lib_module = ll.module_from_bitcode(
-                static_cast<const char*>(bitcode.data()), bitcode.size(),
-                "cuda_lib");
-            std::unique_ptr<llvm::Module> lib_ptr(lib_module);
-            llvm::Linker::linkModules(*ll.module(), std::move(lib_ptr),
-                                      llvm::Linker::Flags::LinkOnlyNeeded);
-        }
-
         ll.do_optimize();
 
         // Drop everything but the init and group entry functions and generated

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1901,21 +1901,21 @@ BackendLLVM::run()
                 || fn.getName().startswith("llvm."))
                 continue;
 
-            if (shadingsys().gpu_no_inline()) {
+            if (shadingsys().optix_no_inline()) {
                 fn.addFnAttr(llvm::Attribute::NoInline);
                 continue;
             }
 
-            if (shadingsys().gpu_no_inline_layer_funcs()
+            if (shadingsys().optix_no_inline_layer_funcs()
                 && !fn.hasFnAttribute("osl-lib-function")) {
                 fn.addFnAttr(llvm::Attribute::NoInline);
                 continue;
             }
 
             const int inst_count = fn.getInstructionCount();
-            if (inst_count >= shadingsys().gpu_no_inline_thresh()) {
+            if (inst_count >= shadingsys().optix_no_inline_thresh()) {
                 fn.addFnAttr(llvm::Attribute::NoInline);
-            } else if (inst_count <= shadingsys().gpu_force_inline_thresh()) {
+            } else if (inst_count <= shadingsys().optix_force_inline_thresh()) {
                 fn.addFnAttr(llvm::Attribute::AlwaysInline);
             }
         }

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -641,7 +641,7 @@ BackendLLVM::llvm_assign_initial_value(const Symbol& sym, bool force)
             // Handle init ops.
             build_llvm_code(sym.initbegin(), sym.initend());
 #if OSL_USE_OPTIX
-        } else if (use_optix() && !sym.typespec().is_closure()) {
+        } else if (use_optix() && !sym.typespec().is_closure() && !sym.lockgeom()) {
             // If the call to osl_bind_interpolated_param returns 0, the default
             // value needs to be loaded from a CUDA variable.
             llvm::Value* cuda_var = getOrAllocateCUDAVariable(sym);

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1644,6 +1644,18 @@ BackendLLVM::prepare_module_for_cuda_jit()
             continue;
         }
 
+        // Inline the functions registered with the ShadingSystem
+        if (is_inline_fn(fn.getName().str())) {
+            fn.addFnAttr(llvm::Attribute::AlwaysInline);
+            continue;
+        }
+
+        // No-inline the functions registered with the ShadingSystem
+        if (is_noinline_fn(fn.getName().str())) {
+            fn.deleteBody();
+            continue;
+        }
+
         if (no_inline) {
             fn.addFnAttr(llvm::Attribute::NoInline);
 
@@ -1667,16 +1679,6 @@ BackendLLVM::prepare_module_for_cuda_jit()
 
         // Only apply the inline thresholds to library functions.
         if (!fn.hasFnAttribute("osl-lib-function")) {
-            continue;
-        }
-
-        if (is_inline_fn(fn.getName().str())) {
-            fn.addFnAttr(llvm::Attribute::AlwaysInline);
-            continue;
-        }
-
-        if (is_noinline_fn(fn.getName().str())) {
-            fn.deleteBody();
             continue;
         }
 

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -122,7 +122,7 @@ using ustring_pod = const char*;
 #ifndef OSL_SHADEOP
 #    ifdef __CUDACC__
 #        define OSL_SHADEOP \
-            extern "C" __device__ OSL_LLVM_EXPORT __attribute__((always_inline))
+            extern "C" __device__
 #    elif defined(OSL_COMPILING_TO_BITCODE)
 #        define OSL_SHADEOP \
             extern "C" OSL_LLVM_EXPORT __attribute__((always_inline))

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -980,7 +980,7 @@ osl_raytype_bit(OpaqueExecContextPtr ec, int bit)
 }
 
 
-
+#ifndef __CUDA_ARCH__
 // extern declaration
 OSL_SHADEOP_NOINLINE int
 osl_range_check_err(int indexvalue, int length, ustringhash_pod symname,
@@ -1003,3 +1003,14 @@ osl_range_check(int indexvalue, int length, ustringhash_pod symname,
     }
     return indexvalue;
 }
+#endif
+
+
+#ifdef __CUDA_ARCH__
+extern "C" {
+__global__ void
+__direct_callable__dummy_shadeops()
+{
+}
+}
+#endif

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -122,7 +122,7 @@ using ustring_pod = const char*;
 #ifndef OSL_SHADEOP
 #    ifdef __CUDACC__
 #        define OSL_SHADEOP \
-            extern "C" __device__
+            extern "C" __device__ OSL_LLVM_EXPORT __attribute__((always_inline))
 #    elif defined(OSL_COMPILING_TO_BITCODE)
 #        define OSL_SHADEOP \
             extern "C" OSL_LLVM_EXPORT __attribute__((always_inline))

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -980,7 +980,6 @@ osl_raytype_bit(OpaqueExecContextPtr ec, int bit)
 }
 
 
-#ifndef __CUDA_ARCH__
 // extern declaration
 OSL_SHADEOP_NOINLINE int
 osl_range_check_err(int indexvalue, int length, ustringhash_pod symname,
@@ -1003,7 +1002,6 @@ osl_range_check(int indexvalue, int length, ustringhash_pod symname,
     }
     return indexvalue;
 }
-#endif
 
 
 #ifdef __CUDA_ARCH__

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1827,7 +1827,8 @@ LLVM_Util::setup_optimization_passes(int optlevel, bool target_host)
             target_machine ? target_machine->getTargetIRAnalysis()
                            : llvm::TargetIRAnalysis()));
         fpm.add(createTargetTransformInfoWrapperPass(
-          target_machine  ? target_machine->getTargetIRAnalysis() : llvm::TargetIRAnalysis()));
+            target_machine ? target_machine->getTargetIRAnalysis()
+                           : llvm::TargetIRAnalysis()));
     }
 
     // llvm_optimize 0-3 corresponds to the same set of optimizations
@@ -5932,11 +5933,11 @@ LLVM_Util::ptx_compile_group(llvm::Module*, const std::string& name,
     llvm::raw_svector_ostream assembly_stream(assembly);
 
     // TODO: Make sure rounding modes, etc., are set correctly
-#if OSL_LLVM_VERSION >= 100
+#    if OSL_LLVM_VERSION >= 100
     target_machine->addPassesToEmitFile(mpm, assembly_stream,
                                         nullptr,  // FIXME: Correct?
                                         llvm::CGFT_AssemblyFile);
-#else
+#    else
     target_machine->addPassesToEmitFile(mpm, assembly_stream,
                                         nullptr,  // FIXME: Correct?
                                         llvm::TargetMachine::CGFT_AssemblyFile);

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1828,17 +1828,6 @@ LLVM_Util::setup_optimization_passes(int optlevel, bool target_host)
                            : llvm::TargetIRAnalysis()));
         fpm.add(createTargetTransformInfoWrapperPass(
           target_machine  ? target_machine->getTargetIRAnalysis() : llvm::TargetIRAnalysis()));
-    } else if (target_isa() == TargetISA::NVPTX) {
-        target_machine = nvptx_target_machine();
-        llvm::Triple ModuleTriple(module()->getTargetTriple());
-        llvm::TargetLibraryInfoImpl TLII(ModuleTriple);
-        mpm.add(new llvm::TargetLibraryInfoWrapperPass(TLII));
-        mpm.add(createTargetTransformInfoWrapperPass(
-            target_machine ? target_machine->getTargetIRAnalysis()
-                           : llvm::TargetIRAnalysis()));
-        fpm.add(createTargetTransformInfoWrapperPass(
-            target_machine ? target_machine->getTargetIRAnalysis()
-                           : llvm::TargetIRAnalysis()));
     }
 
     // llvm_optimize 0-3 corresponds to the same set of optimizations

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1784,6 +1784,45 @@ LLVM_Util::setup_optimization_passes(int optlevel, bool target_host)
             target_machine ? target_machine->getTargetIRAnalysis()
                            : llvm::TargetIRAnalysis()));
         fpm.add(createTargetTransformInfoWrapperPass(
+          target_machine  ? target_machine->getTargetIRAnalysis() : llvm::TargetIRAnalysis()));
+    } else if (target_isa() == TargetISA::NVPTX) {
+        llvm::Triple ModuleTriple(module()->getTargetTriple());
+        llvm::TargetOptions options;
+        options.AllowFPOpFusion = llvm::FPOpFusion::Standard;
+        // N.B. 'Standard' only allow fusion of 'blessed' ops (currently just
+        // fmuladd). To truly disable FMA and never fuse FP-ops, we need to
+        // instead use llvm::FPOpFusion::Strict.
+        options.UnsafeFPMath                           = 1;
+        options.NoInfsFPMath                           = 1;
+        options.NoNaNsFPMath                           = 1;
+        options.HonorSignDependentRoundingFPMathOption = 0;
+        options.FloatABIType          = llvm::FloatABI::Default;
+        options.AllowFPOpFusion       = llvm::FPOpFusion::Fast;
+        options.NoZerosInBSS          = 0;
+        options.GuaranteedTailCallOpt = 0;
+#if OSL_LLVM_VERSION < 120
+        options.StackAlignmentOverride = 0;
+#endif
+        options.UseInitArray = 0;
+
+        // Verify that the NVPTX target has been initialized
+        std::string error;
+        const llvm::Target* llvm_target
+            = llvm::TargetRegistry::lookupTarget(ModuleTriple.str(), error);
+        OSL_ASSERT(llvm_target
+                   && "PTX compile error: LLVM Target is not initialized");
+
+        target_machine = llvm_target->createTargetMachine(
+            ModuleTriple.str(), CUDA_TARGET_ARCH, "+ptx50", options,
+            llvm::Reloc::Static, llvm::CodeModel::Small,
+            llvm::CodeGenOpt::Default);
+
+        llvm::TargetLibraryInfoImpl TLII(ModuleTriple);
+        mpm.add(new llvm::TargetLibraryInfoWrapperPass(TLII));
+        mpm.add(createTargetTransformInfoWrapperPass(
+            target_machine ? target_machine->getTargetIRAnalysis()
+                           : llvm::TargetIRAnalysis()));
+        fpm.add(createTargetTransformInfoWrapperPass(
             target_machine ? target_machine->getTargetIRAnalysis()
                            : llvm::TargetIRAnalysis()));
     }
@@ -5880,32 +5919,11 @@ LLVM_Util::absorb_module(
 }
 
 bool
-LLVM_Util::ptx_compile_group(llvm::Module* lib_module, const std::string& name,
+LLVM_Util::ptx_compile_group(llvm::Module*, const std::string& name,
                              std::string& out)
 {
 #if OSL_USE_OPTIX
     std::string target_triple = module()->getTargetTriple();
-
-    OSL_ASSERT(
-        lib_module == nullptr
-        || (lib_module->getTargetTriple() == target_triple
-            && "PTX compile error: Shader and renderer bitcode library targets do not match"));
-
-    // Create a new empty module to hold the linked shadeops and compiled
-    // ShaderGroup
-    llvm::Module* linked_module = new_module(name.c_str());
-
-    // First, link in the cloned ShaderGroup module
-    std::unique_ptr<llvm::Module> mod_ptr = llvm::CloneModule(*module());
-    bool failed = llvm::Linker::linkModules(*linked_module, std::move(mod_ptr));
-    OSL_ASSERT(!failed && "PTX compile error: Unable to link group module");
-
-    // Second, link in the shadeops library, keeping only the functions that are needed
-
-    if (lib_module) {
-        std::unique_ptr<llvm::Module> lib_ptr(lib_module);
-        failed = llvm::Linker::linkModules(*linked_module, std::move(lib_ptr));
-    }
 
     // Verify that the NVPTX target has been initialized
     std::string error;
@@ -5934,52 +5952,28 @@ LLVM_Util::ptx_compile_group(llvm::Module* lib_module, const std::string& name,
 
     llvm::TargetMachine* target_machine = llvm_target->createTargetMachine(
         target_triple, CUDA_TARGET_ARCH, "+ptx50", options, llvm::Reloc::Static,
-        llvm::CodeModel::Small, llvm::CodeGenOpt::Aggressive);
+        llvm::CodeModel::Small, llvm::CodeGenOpt::Default);
     OSL_ASSERT(
         target_machine
         && "PTX compile error: Unable to create target machine -- is NVPTX enabled in LLVM?");
 
-    // Setup the optimization passes
-    llvm::legacy::FunctionPassManager fn_pm(linked_module);
-    fn_pm.add(llvm::createTargetTransformInfoWrapperPass(
-        target_machine->getTargetIRAnalysis()));
-
-    llvm::legacy::PassManager mod_pm;
-    mod_pm.add(
-        new llvm::TargetLibraryInfoWrapperPass(llvm::Triple(target_triple)));
-    mod_pm.add(llvm::createTargetTransformInfoWrapperPass(
-        target_machine->getTargetIRAnalysis()));
-    mod_pm.add(llvm::createRewriteSymbolsPass());
-
-    // Make sure the 'flush-to-zero' instruction variants are used when possible
-    linked_module->addModuleFlag(llvm::Module::Override, "nvvm-reflect-ftz", 1);
-    for (llvm::Function& fn : *linked_module) {
-        fn.addFnAttr("nvptx-f32ftz", "true");
-    }
-
+    llvm::legacy::PassManager mpm;
     llvm::SmallString<4096> assembly;
     llvm::raw_svector_ostream assembly_stream(assembly);
 
     // TODO: Make sure rounding modes, etc., are set correctly
-#    if OSL_LLVM_VERSION >= 100
-    target_machine->addPassesToEmitFile(mod_pm, assembly_stream,
+#if OSL_LLVM_VERSION >= 100
+    target_machine->addPassesToEmitFile(mpm, assembly_stream,
                                         nullptr,  // FIXME: Correct?
                                         llvm::CGFT_AssemblyFile);
-#    else
-    target_machine->addPassesToEmitFile(mod_pm, assembly_stream,
+#else
+    target_machine->addPassesToEmitFile(mpm, assembly_stream,
                                         nullptr,  // FIXME: Correct?
                                         llvm::TargetMachine::CGFT_AssemblyFile);
 #    endif
 
-    // Run the optimization passes on the functions
-    fn_pm.doInitialization();
-    for (llvm::Module::iterator i = linked_module->begin();
-         i != linked_module->end(); i++) {
-        fn_pm.run(*i);
-    }
-
     // Run the optimization passes on the module to generate the PTX
-    mod_pm.run(*linked_module);
+    mpm.run(*module());
 
     // In a multithreaded environment, llvm will return "callseq <ID>" comments
     // with a non-deterministic ID, leading to OptiX JIT cache misses.
@@ -5991,8 +5985,6 @@ LLVM_Util::ptx_compile_group(llvm::Module* lib_module, const std::string& name,
         ptx_stream << line.substr(0, line.find("// callseq")) << std::endl;
     }
     out = ptx_stream.str();
-
-    delete linked_module;
 
     return true;
 #else

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -243,9 +243,15 @@ struct AttributeNeeded {
     }
 };
 
-// Prefix for OSL shade op declarations. Make them local visibility, but
-// "C" linkage (no C++ name mangling).
-#define OSL_SHADEOP extern "C" OSL_DLL_LOCAL
+// Prefix for OSL shade op declarations.
+// For non-CUDA, make them local visibility, but "C" linkage (no C++ name mangling).
+// For CUDA, just set "C" linkage.
+#ifndef __CUDA_ARCH__
+#    define OSL_SHADEOP extern "C" OSL_DLL_LOCAL
+#else
+#    define OSL_SHADEOP extern "C"
+#endif
+
 
 
 // Handy re-casting macros

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -727,11 +727,17 @@ public:
 
     /// Attributes to control optimization for OptiX/CUDA
     bool optix_no_inline() const { return m_optix_no_inline; }
-    bool optix_no_inline_layer_funcs() const { return m_optix_no_inline_layer_funcs; }
+    bool optix_no_inline_layer_funcs() const
+    {
+        return m_optix_no_inline_layer_funcs;
+    }
     bool optix_merge_layer_funcs() const { return m_optix_merge_layer_funcs; }
     bool optix_no_inline_rend_lib() const { return m_optix_no_inline_rend_lib; }
     int optix_no_inline_thresh() const { return m_optix_no_inline_thresh; }
-    int optix_force_inline_thresh() const { return m_optix_force_inline_thresh; }
+    int optix_force_inline_thresh() const
+    {
+        return m_optix_force_inline_thresh;
+    }
 
     /// Set the current color space.
     bool set_colorspace(ustring colorspace);
@@ -969,7 +975,7 @@ private:
                                       ///<   away things that can't GPU.
 
     /// Experimental attributes to help tuning OptiX optimization passes
-    bool m_optix_no_inline;  ///< Disable function inlining
+    bool m_optix_no_inline;              ///< Disable function inlining
     bool m_optix_no_inline_layer_funcs;  ///< Disable inlining for group layer funcs
     bool m_optix_merge_layer_funcs;  ///< Merge layer functions that have only one caller
     bool m_optix_no_inline_rend_lib;  ///< Disable inlining the rend_lib functions

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -727,6 +727,12 @@ public:
         return m_closure_registry.get_entry(id);
     }
 
+    /// Attributes to control GPU optimization
+    bool gpu_no_inline() const { return m_gpu_no_inline; }
+    bool gpu_no_inline_layer_funcs() const { return m_gpu_no_inline_layer_funcs; }
+    int gpu_no_inline_thresh() const { return m_gpu_no_inline_thresh; }
+    int gpu_force_inline_thresh() const { return m_gpu_force_inline_thresh; }
+
     /// Set the current color space.
     bool set_colorspace(ustring colorspace);
 
@@ -955,6 +961,12 @@ private:
     int m_opt_warnings;               ///< Warn on inability to optimize
     int m_gpu_opt_error;              ///< Error on inability to optimize
                                       ///<   away things that can't GPU.
+
+    /// Attributes to control GPU optimization
+    bool m_gpu_no_inline;  ///< Disable function inlining
+    bool m_gpu_no_inline_layer_funcs;  ///< Disable inlining for group layer funcs
+    int m_gpu_no_inline_thresh;  ///< Disable inlining for functions larger than the threshold
+    int m_gpu_force_inline_thresh;  ///< Force inling for functions smaller than the threshold
 
     ustring m_colorspace;  ///< What RGB colors mean
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -735,7 +735,7 @@ public:
     bool optix_no_inline() const { return m_optix_no_inline; }
     bool optix_no_inline_layer_funcs() const { return m_optix_no_inline_layer_funcs; }
     bool optix_merge_layer_funcs() const { return m_optix_merge_layer_funcs; }
-    bool optix_no_inline_rendlib() const { return m_optix_no_inline_rendlib; }
+    bool optix_no_inline_rend_lib() const { return m_optix_no_inline_rend_lib; }
     int optix_no_inline_thresh() const { return m_optix_no_inline_thresh; }
     int optix_force_inline_thresh() const { return m_optix_force_inline_thresh; }
 
@@ -978,7 +978,7 @@ private:
     bool m_optix_no_inline;  ///< Disable function inlining
     bool m_optix_no_inline_layer_funcs;  ///< Disable inlining for group layer funcs
     bool m_optix_merge_layer_funcs;  ///< Merge layer functions that have only one caller
-    bool m_optix_no_inline_rendlib;  ///< Disable inlining the rendlib functions
+    bool m_optix_no_inline_rend_lib;  ///< Disable inlining the rend_lib functions
     int m_optix_no_inline_thresh;  ///< Disable inlining for functions larger than the threshold
     int m_optix_force_inline_thresh;  ///< Force inling for functions smaller than the threshold
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -725,11 +725,11 @@ public:
         return m_closure_registry.get_entry(id);
     }
 
-    /// Attributes to control GPU optimization
-    bool gpu_no_inline() const { return m_gpu_no_inline; }
-    bool gpu_no_inline_layer_funcs() const { return m_gpu_no_inline_layer_funcs; }
-    int gpu_no_inline_thresh() const { return m_gpu_no_inline_thresh; }
-    int gpu_force_inline_thresh() const { return m_gpu_force_inline_thresh; }
+    /// Attributes to control optimization for OptiX/CUDA
+    bool optix_no_inline() const { return m_optix_no_inline; }
+    bool optix_no_inline_layer_funcs() const { return m_optix_no_inline_layer_funcs; }
+    int optix_no_inline_thresh() const { return m_optix_no_inline_thresh; }
+    int optix_force_inline_thresh() const { return m_optix_force_inline_thresh; }
 
     /// Set the current color space.
     bool set_colorspace(ustring colorspace);
@@ -960,11 +960,11 @@ private:
     int m_gpu_opt_error;              ///< Error on inability to optimize
                                       ///<   away things that can't GPU.
 
-    /// Experimental attributes to help tuning GPU optimization passes
-    bool m_gpu_no_inline;  ///< Disable function inlining
-    bool m_gpu_no_inline_layer_funcs;  ///< Disable inlining for group layer funcs
-    int m_gpu_no_inline_thresh;  ///< Disable inlining for functions larger than the threshold
-    int m_gpu_force_inline_thresh;  ///< Force inling for functions smaller than the threshold
+    /// Experimental attributes to help tuning OptiX optimization passes
+    bool m_optix_no_inline;  ///< Disable function inlining
+    bool m_optix_no_inline_layer_funcs;  ///< Disable inlining for group layer funcs
+    int m_optix_no_inline_thresh;  ///< Disable inlining for functions larger than the threshold
+    int m_optix_force_inline_thresh;  ///< Force inling for functions smaller than the threshold
 
     ustring m_colorspace;  ///< What RGB colors mean
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -243,15 +243,9 @@ struct AttributeNeeded {
     }
 };
 
-// Prefix for OSL shade op declarations.
-// For non-CUDA, make them local visibility, but "C" linkage (no C++ name mangling).
-// For CUDA, just set "C" linkage.
-#ifndef __CUDA_ARCH__
-#    define OSL_SHADEOP extern "C" OSL_DLL_LOCAL
-#else
-#    define OSL_SHADEOP extern "C"
-#endif
-
+// Prefix for OSL shade op declarations. Make them local visibility, but
+// "C" linkage (no C++ name mangling).
+#define OSL_SHADEOP extern "C" OSL_DLL_LOCAL
 
 
 // Handy re-casting macros

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -734,6 +734,8 @@ public:
     /// Attributes to control optimization for OptiX/CUDA
     bool optix_no_inline() const { return m_optix_no_inline; }
     bool optix_no_inline_layer_funcs() const { return m_optix_no_inline_layer_funcs; }
+    bool optix_merge_layer_funcs() const { return m_optix_merge_layer_funcs; }
+    bool optix_no_inline_rendlib() const { return m_optix_no_inline_rendlib; }
     int optix_no_inline_thresh() const { return m_optix_no_inline_thresh; }
     int optix_force_inline_thresh() const { return m_optix_force_inline_thresh; }
 
@@ -975,6 +977,8 @@ private:
     /// Experimental attributes to help tuning OptiX optimization passes
     bool m_optix_no_inline;  ///< Disable function inlining
     bool m_optix_no_inline_layer_funcs;  ///< Disable inlining for group layer funcs
+    bool m_optix_merge_layer_funcs;  ///< Merge layer functions that have only one caller
+    bool m_optix_no_inline_rendlib;  ///< Disable inlining the rendlib functions
     int m_optix_no_inline_thresh;  ///< Disable inlining for functions larger than the threshold
     int m_optix_force_inline_thresh;  ///< Force inling for functions smaller than the threshold
 

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -276,8 +276,6 @@ USTR(const void* s) noexcept
 #define DCOL(x)     (*(Dual2<Color3>*)x)
 #define TYPEDESC(x) OSL::bitcast<TypeDesc, long long>(x)
 
-
-
 /// Like an int (of type T), but also internally keeps track of the
 /// maximum value is has held, and the total "requested" deltas.
 /// You really shouldn't use an unsigned type for T, for two reasons:

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -821,6 +821,12 @@ public:
             return nullptr;
     }
 
+    void register_inline_function(ustring name);
+    void unregister_inline_function(ustring name);
+    void register_noinline_function(ustring name);
+    void unregister_noinline_function(ustring name);
+
+
 private:
     void printstats() const;
 
@@ -1067,6 +1073,9 @@ private:
     // N.B. group_profile_times is protected by m_stat_mutex.
 
     LLVM_Util::ScopedJitMemoryUser m_llvm_jit_memory_user;
+
+    std::unordered_set<ustring> m_inline_functions;
+    std::unordered_set<ustring> m_noinline_functions;
 
     friend class OSL::ShadingContext;
     friend class ShaderMaster;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -962,7 +962,7 @@ private:
     int m_gpu_opt_error;              ///< Error on inability to optimize
                                       ///<   away things that can't GPU.
 
-    /// Attributes to control GPU optimization
+    /// Experimental attributes to help tuning GPU optimization passes
     bool m_gpu_no_inline;  ///< Disable function inlining
     bool m_gpu_no_inline_layer_funcs;  ///< Disable inlining for group layer funcs
     int m_gpu_no_inline_thresh;  ///< Disable inlining for functions larger than the threshold

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -50,8 +50,10 @@ using namespace OSL::pvt;
 #endif
 
 
+#ifdef OSL_LLVM_CUDA_BITCODE
 extern int shadeops_cuda_ptx_compiled_ops_size;
 extern unsigned char shadeops_cuda_ptx_compiled_ops_block[];
+#endif
 
 
 OSL_NAMESPACE_ENTER
@@ -1968,6 +1970,7 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
         *(const char**)val = ustring(deps).c_str();
         return true;
     }
+#ifdef OSL_LLVM_CUDA_BITCODE
     if (name == "shadeops_cuda_ptx" && type.basetype == TypeDesc::PTR) {
         *(const char**)val = reinterpret_cast<const char*>(
             shadeops_cuda_ptx_compiled_ops_block);
@@ -1977,6 +1980,7 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
         *(int*)val = shadeops_cuda_ptx_compiled_ops_size;
         return true;
     }
+#endif
 
     return false;
 #undef ATTR_DECODE

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -49,6 +49,11 @@ using namespace OSL::pvt;
 #    undef bitor
 #endif
 
+
+extern int shadeops_cuda_ptx_compiled_ops_size;
+extern unsigned char shadeops_cuda_ptx_compiled_ops_block[];
+
+
 OSL_NAMESPACE_ENTER
 
 
@@ -1961,6 +1966,15 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
         else
             deps += ",OptiX-" OSL_OPTIX_VERSION;
         *(const char**)val = ustring(deps).c_str();
+        return true;
+    }
+    if (name == "shadeops_cuda_ptx" && type.basetype == TypeDesc::PTR) {
+        *(const char**)val = reinterpret_cast<const char*>(
+            shadeops_cuda_ptx_compiled_ops_block);
+        return true;
+    }
+    if (name == "shadeops_cuda_ptx_size" && type.basetype == TypeDesc::INT) {
+        *(int*)val = shadeops_cuda_ptx_compiled_ops_size;
         return true;
     }
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -4254,6 +4254,38 @@ ShadingSystemImpl::archive_shadergroup(ShaderGroup& group, string_view filename)
 
 
 void
+ShadingSystemImpl::register_inline_function(ustring name)
+{
+    m_inline_functions.insert(name);
+}
+
+
+
+void
+ShadingSystemImpl::unregister_inline_function(ustring name)
+{
+    m_inline_functions.erase(name);
+}
+
+
+
+void
+ShadingSystemImpl::register_noinline_function(ustring name)
+{
+    m_noinline_functions.insert(name);
+}
+
+
+
+void
+ShadingSystemImpl::unregister_noinline_function(ustring name)
+{
+    m_noinline_functions.erase(name);
+}
+
+
+
+void
 ClosureRegistry::register_closure(string_view name, int id,
                                   const ClosureParam* params,
                                   PrepareClosureFunc prepare,
@@ -4416,6 +4448,38 @@ OSL::ShadingSystem::oslquery(const ShaderGroup& group, int layernum)
 OSL::OSLQuery::OSLQuery(const ShaderGroup* group, int layernum)
 {
     init(group, layernum);
+}
+
+
+
+void
+ShadingSystem::register_inline_function(ustring name)
+{
+    return m_impl->register_inline_function(name);
+}
+
+
+
+void
+ShadingSystem::unregister_inline_function(ustring name)
+{
+    return m_impl->unregister_inline_function(name);
+}
+
+
+
+void
+ShadingSystem::register_noinline_function(ustring name)
+{
+    return m_impl->register_noinline_function(name);
+}
+
+
+
+void
+ShadingSystem::unregister_noinline_function(ustring name)
+{
+    return m_impl->unregister_noinline_function(name);
 }
 
 

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1104,6 +1104,10 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
     , m_exec_repeat(1)
     , m_opt_warnings(0)
     , m_gpu_opt_error(0)
+    , m_gpu_no_inline(false)
+    , m_gpu_no_inline_layer_funcs(false)
+    , m_gpu_no_inline_thresh(100000)
+    , m_gpu_force_inline_thresh(0)
     , m_colorspace("Rec709")
     , m_stat_opt_locking_time(0)
     , m_stat_specialization_time(0)
@@ -1625,6 +1629,10 @@ ShadingSystemImpl::attribute(string_view name, TypeDesc type, const void* val)
     ATTR_SET("exec_repeat", int, m_exec_repeat);
     ATTR_SET("opt_warnings", int, m_opt_warnings);
     ATTR_SET("gpu_opt_error", int, m_gpu_opt_error);
+    ATTR_SET("gpu_no_inline", int, m_gpu_no_inline);
+    ATTR_SET("gpu_no_inline_layer_funcs", int, m_gpu_no_inline_layer_funcs);
+    ATTR_SET("gpu_no_inline_thresh", int, m_gpu_no_inline_thresh);
+    ATTR_SET("gpu_force_inline_thresh", int, m_gpu_force_inline_thresh);
     ATTR_SET_STRING("commonspace",
                     m_shading_state_uniform.m_commonspace_synonym);
     ATTR_SET_STRING("debug_groupname", m_debug_groupname);
@@ -1806,6 +1814,10 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
     ATTR_DECODE("exec_repeat", int, m_exec_repeat);
     ATTR_DECODE("opt_warnings", int, m_opt_warnings);
     ATTR_DECODE("gpu_opt_error", int, m_gpu_opt_error);
+    ATTR_DECODE("gpu_no_inline", int, m_gpu_no_inline);
+    ATTR_DECODE("gpu_no_inline_layer_funcs", int, m_gpu_no_inline_layer_funcs);
+    ATTR_DECODE("gpu_no_inline_thresh", int, m_gpu_no_inline_thresh);
+    ATTR_DECODE("gpu_force_inline_thresh", int, m_gpu_force_inline_thresh);
 
     ATTR_DECODE("stat:masters", int, m_stat_shaders_loaded);
     ATTR_DECODE("stat:groups", int, m_stat_groups);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1104,10 +1104,10 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
     , m_exec_repeat(1)
     , m_opt_warnings(0)
     , m_gpu_opt_error(0)
-    , m_gpu_no_inline(false)
-    , m_gpu_no_inline_layer_funcs(false)
-    , m_gpu_no_inline_thresh(100000)
-    , m_gpu_force_inline_thresh(0)
+    , m_optix_no_inline(false)
+    , m_optix_no_inline_layer_funcs(false)
+    , m_optix_no_inline_thresh(100000)
+    , m_optix_force_inline_thresh(0)
     , m_colorspace("Rec709")
     , m_stat_opt_locking_time(0)
     , m_stat_specialization_time(0)
@@ -1629,10 +1629,10 @@ ShadingSystemImpl::attribute(string_view name, TypeDesc type, const void* val)
     ATTR_SET("exec_repeat", int, m_exec_repeat);
     ATTR_SET("opt_warnings", int, m_opt_warnings);
     ATTR_SET("gpu_opt_error", int, m_gpu_opt_error);
-    ATTR_SET("gpu_no_inline", int, m_gpu_no_inline);
-    ATTR_SET("gpu_no_inline_layer_funcs", int, m_gpu_no_inline_layer_funcs);
-    ATTR_SET("gpu_no_inline_thresh", int, m_gpu_no_inline_thresh);
-    ATTR_SET("gpu_force_inline_thresh", int, m_gpu_force_inline_thresh);
+    ATTR_SET("optix_no_inline", int, m_optix_no_inline);
+    ATTR_SET("optix_no_inline_layer_funcs", int, m_optix_no_inline_layer_funcs);
+    ATTR_SET("optix_no_inline_thresh", int, m_optix_no_inline_thresh);
+    ATTR_SET("optix_force_inline_thresh", int, m_optix_force_inline_thresh);
     ATTR_SET_STRING("commonspace",
                     m_shading_state_uniform.m_commonspace_synonym);
     ATTR_SET_STRING("debug_groupname", m_debug_groupname);
@@ -1814,10 +1814,10 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
     ATTR_DECODE("exec_repeat", int, m_exec_repeat);
     ATTR_DECODE("opt_warnings", int, m_opt_warnings);
     ATTR_DECODE("gpu_opt_error", int, m_gpu_opt_error);
-    ATTR_DECODE("gpu_no_inline", int, m_gpu_no_inline);
-    ATTR_DECODE("gpu_no_inline_layer_funcs", int, m_gpu_no_inline_layer_funcs);
-    ATTR_DECODE("gpu_no_inline_thresh", int, m_gpu_no_inline_thresh);
-    ATTR_DECODE("gpu_force_inline_thresh", int, m_gpu_force_inline_thresh);
+    ATTR_DECODE("optix_no_inline", int, m_optix_no_inline);
+    ATTR_DECODE("optix_no_inline_layer_funcs", int, m_optix_no_inline_layer_funcs);
+    ATTR_DECODE("optix_no_inline_thresh", int, m_optix_no_inline_thresh);
+    ATTR_DECODE("optix_force_inline_thresh", int, m_optix_force_inline_thresh);
 
     ATTR_DECODE("stat:masters", int, m_stat_shaders_loaded);
     ATTR_DECODE("stat:groups", int, m_stat_groups);
@@ -2393,6 +2393,10 @@ ShadingSystemImpl::getstats(int level) const
     INTOPT(exec_repeat);
     INTOPT(opt_warnings);
     INTOPT(gpu_opt_error);
+    BOOLOPT(optix_no_inline);
+    BOOLOPT(optix_no_inline_layer_funcs);
+    INTOPT(optix_no_inline_thresh);
+    INTOPT(optix_force_inline_thresh);
     STROPT(debug_groupname);
     STROPT(debug_layername);
     STROPT(archive_groupname);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1113,6 +1113,8 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
     , m_gpu_opt_error(0)
     , m_optix_no_inline(false)
     , m_optix_no_inline_layer_funcs(false)
+    , m_optix_merge_layer_funcs(true)
+    , m_optix_no_inline_rendlib(false)
     , m_optix_no_inline_thresh(100000)
     , m_optix_force_inline_thresh(0)
     , m_colorspace("Rec709")
@@ -1638,6 +1640,8 @@ ShadingSystemImpl::attribute(string_view name, TypeDesc type, const void* val)
     ATTR_SET("gpu_opt_error", int, m_gpu_opt_error);
     ATTR_SET("optix_no_inline", int, m_optix_no_inline);
     ATTR_SET("optix_no_inline_layer_funcs", int, m_optix_no_inline_layer_funcs);
+    ATTR_SET("optix_merge_layer_funcs", int, m_optix_merge_layer_funcs);
+    ATTR_SET("optix_no_inline_rendlib", int, m_optix_no_inline_rendlib);
     ATTR_SET("optix_no_inline_thresh", int, m_optix_no_inline_thresh);
     ATTR_SET("optix_force_inline_thresh", int, m_optix_force_inline_thresh);
     ATTR_SET_STRING("commonspace",
@@ -1823,6 +1827,8 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
     ATTR_DECODE("gpu_opt_error", int, m_gpu_opt_error);
     ATTR_DECODE("optix_no_inline", int, m_optix_no_inline);
     ATTR_DECODE("optix_no_inline_layer_funcs", int, m_optix_no_inline_layer_funcs);
+    ATTR_DECODE("optix_merge_layer_funcs", int, m_optix_merge_layer_funcs);
+    ATTR_DECODE("optix_no_inline_rendlib", int, m_optix_no_inline_rendlib);
     ATTR_DECODE("optix_no_inline_thresh", int, m_optix_no_inline_thresh);
     ATTR_DECODE("optix_force_inline_thresh", int, m_optix_force_inline_thresh);
 
@@ -2413,6 +2419,8 @@ ShadingSystemImpl::getstats(int level) const
     INTOPT(gpu_opt_error);
     BOOLOPT(optix_no_inline);
     BOOLOPT(optix_no_inline_layer_funcs);
+    BOOLOPT(optix_merge_layer_funcs);
+    BOOLOPT(optix_no_inline_rendlib);
     INTOPT(optix_no_inline_thresh);
     INTOPT(optix_force_inline_thresh);
     STROPT(debug_groupname);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1114,7 +1114,7 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
     , m_optix_no_inline(false)
     , m_optix_no_inline_layer_funcs(false)
     , m_optix_merge_layer_funcs(true)
-    , m_optix_no_inline_rendlib(false)
+    , m_optix_no_inline_rend_lib(false)
     , m_optix_no_inline_thresh(100000)
     , m_optix_force_inline_thresh(0)
     , m_colorspace("Rec709")
@@ -1641,7 +1641,7 @@ ShadingSystemImpl::attribute(string_view name, TypeDesc type, const void* val)
     ATTR_SET("optix_no_inline", int, m_optix_no_inline);
     ATTR_SET("optix_no_inline_layer_funcs", int, m_optix_no_inline_layer_funcs);
     ATTR_SET("optix_merge_layer_funcs", int, m_optix_merge_layer_funcs);
-    ATTR_SET("optix_no_inline_rendlib", int, m_optix_no_inline_rendlib);
+    ATTR_SET("optix_no_inline_rend_lib", int, m_optix_no_inline_rend_lib);
     ATTR_SET("optix_no_inline_thresh", int, m_optix_no_inline_thresh);
     ATTR_SET("optix_force_inline_thresh", int, m_optix_force_inline_thresh);
     ATTR_SET_STRING("commonspace",
@@ -1828,7 +1828,7 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
     ATTR_DECODE("optix_no_inline", int, m_optix_no_inline);
     ATTR_DECODE("optix_no_inline_layer_funcs", int, m_optix_no_inline_layer_funcs);
     ATTR_DECODE("optix_merge_layer_funcs", int, m_optix_merge_layer_funcs);
-    ATTR_DECODE("optix_no_inline_rendlib", int, m_optix_no_inline_rendlib);
+    ATTR_DECODE("optix_no_inline_rend_lib", int, m_optix_no_inline_rend_lib);
     ATTR_DECODE("optix_no_inline_thresh", int, m_optix_no_inline_thresh);
     ATTR_DECODE("optix_force_inline_thresh", int, m_optix_force_inline_thresh);
 
@@ -2420,7 +2420,7 @@ ShadingSystemImpl::getstats(int level) const
     BOOLOPT(optix_no_inline);
     BOOLOPT(optix_no_inline_layer_funcs);
     BOOLOPT(optix_merge_layer_funcs);
-    BOOLOPT(optix_no_inline_rendlib);
+    BOOLOPT(optix_no_inline_rend_lib);
     INTOPT(optix_no_inline_thresh);
     INTOPT(optix_force_inline_thresh);
     STROPT(debug_groupname);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1826,7 +1826,8 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
     ATTR_DECODE("opt_warnings", int, m_opt_warnings);
     ATTR_DECODE("gpu_opt_error", int, m_gpu_opt_error);
     ATTR_DECODE("optix_no_inline", int, m_optix_no_inline);
-    ATTR_DECODE("optix_no_inline_layer_funcs", int, m_optix_no_inline_layer_funcs);
+    ATTR_DECODE("optix_no_inline_layer_funcs", int,
+                m_optix_no_inline_layer_funcs);
     ATTR_DECODE("optix_merge_layer_funcs", int, m_optix_merge_layer_funcs);
     ATTR_DECODE("optix_no_inline_rend_lib", int, m_optix_no_inline_rend_lib);
     ATTR_DECODE("optix_no_inline_thresh", int, m_optix_no_inline_thresh);

--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -15,21 +15,19 @@ if (OSL_USE_OPTIX)
         cuda/optix_raytracer.cu
         cuda/sphere.cu
         cuda/wrapper.cu
+        )
+
+    set (testrender_shadeops_srcs
         cuda/rend_lib.cu)
 
     # We need to make sure that the PTX files are regenerated whenever these
     # headers change.
     set (testrender_cuda_headers
-         cuda/rend_lib.h )
+        cuda/rend_lib.h)
 
-    LLVM_COMPILE_CUDA (
-        ${CMAKE_CURRENT_SOURCE_DIR}/cuda/rend_lib.cu
-        ${testrender_cuda_headers}
-        "rend_llvm_compiled_ops"
-        rend_lib_bc_cpp
-        "" )
-
-    list (APPEND testrender_srcs ${rend_lib_bc_cpp})
+    add_definitions (-DOSL_LLVM_CUDA_BITCODE)
+    CUDA_SHADEOPS_COMPILE ( testrender_srcs
+        ${testrender_shadeops_srcs} ${testrender_cuda_headers} )
 
     # Generate PTX for all of the CUDA files
     foreach (cudasrc ${testrender_cuda_srcs})

--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -17,23 +17,35 @@ if (OSL_USE_OPTIX)
         cuda/wrapper.cu
         )
 
-    set (testrender_shadeops_srcs
-        cuda/rend_lib.cu)
+    set (testrender_rend_lib_srcs
+        cuda/rend_lib.cu
+        )
 
     # We need to make sure that the PTX files are regenerated whenever these
     # headers change.
     set (testrender_cuda_headers
         cuda/rend_lib.h)
 
-    add_definitions (-DOSL_LLVM_CUDA_BITCODE)
-    CUDA_SHADEOPS_COMPILE ( testrender_srcs
-        ${testrender_shadeops_srcs} ${testrender_cuda_headers} )
-
     # Generate PTX for all of the CUDA files
     foreach (cudasrc ${testrender_cuda_srcs})
         NVCC_COMPILE ( ${cudasrc} "" ptx_generated "" )
         list (APPEND ptx_list ${ptx_generated})
     endforeach ()
+
+    # Compile the renderer-supplied shadeops (rend_lib) to LLVM bitcode and PTX
+    add_definitions (-DOSL_LLVM_CUDA_BITCODE)
+    CUDA_SHADEOPS_COMPILE ( "rend_lib_testrender"
+        rend_lib_bc
+        rend_lib_ptx
+        "${testrender_rend_lib_srcs}"
+        "${testrender_cuda_headers}"
+    )
+
+    # Serialize the linked bitcode into a CPP file to be embedded in the current target binary
+    set (rend_lib_bc_cuda_cpp "${CMAKE_CURRENT_BINARY_DIR}/rend_lib_cuda.bc.cpp")
+    MAKE_EMBEDDED_CPP( "rend_lib_llvm_compiled_ops" ${rend_lib_bc_cuda_cpp} ${rend_lib_bc} )
+    list (APPEND testrender_srcs ${rend_lib_bc_cuda_cpp})
+    list (APPEND ptx_list ${rend_lib_ptx})
 
     add_custom_target (testrender_ptx ALL
         DEPENDS ${ptx_list}
@@ -48,7 +60,7 @@ endif()
 if (CMAKE_COMPILER_IS_INTELCLANG)
     # To better match existing test results
     add_compile_options("-fp-model=precise")
-    # Better performance is likely by not requiring a precise floating point 
+    # Better performance is likely by not requiring a precise floating point
     # model, although with slightly different numerical results.
 endif ()
 

--- a/src/testrender/cuda/optix_raytracer.cu
+++ b/src/testrender/cuda/optix_raytracer.cu
@@ -15,6 +15,20 @@
 #include "render_params.h"
 
 
+OSL_NAMESPACE_ENTER
+namespace pvt {
+__device__ CUdeviceptr s_color_system          = 0;
+__device__ CUdeviceptr osl_printf_buffer_start = 0;
+__device__ CUdeviceptr osl_printf_buffer_end   = 0;
+__device__ uint64_t test_str_1                 = 0;
+__device__ uint64_t test_str_2                 = 0;
+__device__ uint64_t num_named_xforms           = 0;
+__device__ CUdeviceptr xform_name_buffer       = 0;
+__device__ CUdeviceptr xform_buffer            = 0;
+}
+OSL_NAMESPACE_EXIT
+
+
 extern "C" {
 __device__ __constant__ RenderParams render_params;
 }
@@ -34,10 +48,6 @@ __miss__()
 }
 
 
-extern __device__ char* test_str_1;
-extern __device__ char* test_str_2;
-
-
 extern "C" __global__ void
 __raygen__setglobals()
 {
@@ -50,12 +60,10 @@ __raygen__setglobals()
 }
 
 
-
 extern "C" __global__ void
 __miss__setglobals()
 {
 }
-
 
 
 extern "C" __global__ void

--- a/src/testrender/cuda/optix_raytracer.cu
+++ b/src/testrender/cuda/optix_raytracer.cu
@@ -25,7 +25,7 @@ __device__ uint64_t test_str_2                 = 0;
 __device__ uint64_t num_named_xforms           = 0;
 __device__ CUdeviceptr xform_name_buffer       = 0;
 __device__ CUdeviceptr xform_buffer            = 0;
-}
+}  // namespace pvt
 OSL_NAMESPACE_EXIT
 
 

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -143,7 +143,8 @@ osl_allocate_weighted_closure_component(void* sg_, int id, int size,
 {
     ShaderGlobals* sg_ptr = (ShaderGlobals*)sg_;
 
-    const OSL::Color3* wc = (const OSL::Color3*) __builtin_assume_aligned(w,alignof(float));
+    const OSL::Color3* wc
+        = (const OSL::Color3*)__builtin_assume_aligned(w, alignof(float));
 
     if (wc->x == 0.0f && wc->y == 0.0f && wc->z == 0.0f) {
         return NULL;
@@ -166,7 +167,8 @@ __device__ void*
 osl_mul_closure_color(void* sg_, void* a, const void* w)
 {
     ShaderGlobals* sg_ptr = (ShaderGlobals*)sg_;
-    const OSL::Color3* wc = (const OSL::Color3*) __builtin_assume_aligned(w,alignof(float));
+    const OSL::Color3* wc
+        = (const OSL::Color3*)__builtin_assume_aligned(w, alignof(float));
 
     if (a == NULL) {
         return NULL;
@@ -194,7 +196,7 @@ osl_mul_closure_color(void* sg_, void* a, const void* w)
 __device__ void*
 osl_mul_closure_float(void* sg_, void* a, float w)
 {
-    a = __builtin_assume_aligned(a,alignof(float));
+    a = __builtin_assume_aligned(a, alignof(float));
 
     ShaderGlobals* sg_ptr = (ShaderGlobals*)sg_;
 
@@ -210,7 +212,8 @@ osl_mul_closure_float(void* sg_, void* a, float w)
     void* ret = ((char*)sg_ptr->renderstate)
                 + alignment_offset_calc(sg_ptr->renderstate,
                                         alignof(OSL::ClosureComponent));
-    sg_ptr->renderstate = closure_mul_float_allot(ret, w, (OSL::ClosureColor*)a);
+    sg_ptr->renderstate = closure_mul_float_allot(ret, w,
+                                                  (OSL::ClosureColor*)a);
 
     return ret;
 }
@@ -220,8 +223,8 @@ osl_mul_closure_float(void* sg_, void* a, float w)
 __device__ void*
 osl_add_closure_closure(void* sg_, void* a, void* b)
 {
-    a = __builtin_assume_aligned(a,alignof(float));
-    b = __builtin_assume_aligned(b,alignof(float));
+    a = __builtin_assume_aligned(a, alignof(float));
+    b = __builtin_assume_aligned(b, alignof(float));
 
     ShaderGlobals* sg_ptr = (ShaderGlobals*)sg_;
 
@@ -237,7 +240,8 @@ osl_add_closure_closure(void* sg_, void* a, void* b)
     void* ret = ((char*)sg_ptr->renderstate)
                 + alignment_offset_calc(sg_ptr->renderstate,
                                         alignof(OSL::ClosureComponent));
-    sg_ptr->renderstate = closure_add_allot(ret, (OSL::ClosureColor*)a, (OSL::ClosureColor*)b);
+    sg_ptr->renderstate = closure_add_allot(ret, (OSL::ClosureColor*)a,
+                                            (OSL::ClosureColor*)b);
 
     return ret;
 }
@@ -289,7 +293,8 @@ osl_bind_interpolated_param(void* sg_, const char* name, long long type,
         *userdata_initialized = status = 1 + ok;
     }
     if (status == 2) {
-        MEMCPY_ALIGNED(symbol_data, userdata_data, symbol_data_size, alignof(float));
+        MEMCPY_ALIGNED(symbol_data, userdata_data, symbol_data_size,
+                       alignof(float));
         return 1;
     }
     return 0;
@@ -434,12 +439,12 @@ osl_range_check_err(int indexvalue, int length, OSL::ustring_pod symname,
 
 
 
-#define MAT(m) (*(OSL::Matrix44*)__builtin_assume_aligned(m,alignof(float)))
+#define MAT(m) (*(OSL::Matrix44*)__builtin_assume_aligned(m, alignof(float)))
 
 __device__ int
 osl_get_matrix(void* sg_, void* r, const char* from)
 {
-    r = __builtin_assume_aligned(r,alignof(float));
+    r                 = __builtin_assume_aligned(r, alignof(float));
     ShaderGlobals* sg = (ShaderGlobals*)sg_;
     if (HDSTR(from) == STRING_PARAMS(common)) {
         MAT(r).makeIdentity();
@@ -484,7 +489,7 @@ osl_get_matrix(void* sg_, void* r, const char* from)
 __device__ int
 osl_get_inverse_matrix(void* sg_, void* r, const char* to)
 {
-    r = __builtin_assume_aligned(r,alignof(float));
+    r                 = __builtin_assume_aligned(r, alignof(float));
     ShaderGlobals* sg = (ShaderGlobals*)sg_;
     if (HDSTR(to) == STRING_PARAMS(common)) {
         MAT(r).makeIdentity();

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -434,22 +434,6 @@ osl_range_check_err(int indexvalue, int length, OSL::ustring_pod symname,
 
 
 
-__device__ int
-osl_range_check(int indexvalue, int length, OSL::ustring_pod symname, void* sg,
-                OSL::ustring_pod sourcefile, int sourceline,
-                OSL::ustring_pod groupname, int layer,
-                OSL::ustring_pod layername, OSL::ustring_pod shadername)
-{
-    if (indexvalue < 0 || indexvalue >= length) {
-        indexvalue = osl_range_check_err(indexvalue, length, symname, sg,
-                                         sourcefile, sourceline, groupname,
-                                         layer, layername, shadername);
-    }
-    return indexvalue;
-}
-
-
-
 #define MAT(m) (*(OSL::Matrix44*)__builtin_assume_aligned(m,alignof(float)))
 
 __device__ int

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -426,17 +426,17 @@ osl_texture(void* sg_, const char* name, void* handle, void* opt_, float s,
 
 
 __device__ int
-osl_range_check_err(int indexvalue, int length, OSL::ustring_pod symname,
-                    void* sg, OSL::ustring_pod sourcefile, int sourceline,
-                    OSL::ustring_pod groupname, int layer,
-                    OSL::ustring_pod layername, OSL::ustring_pod shadername)
+osl_range_check_err(int indexvalue, int length, OSL::ustringhash_pod symname,
+                    void* sg, OSL::ustringhash_pod sourcefile, int sourceline,
+                    OSL::ustringhash_pod groupname, int layer,
+                    OSL::ustringhash_pod layername,
+                    OSL::ustringhash_pod shadername)
 {
     if (indexvalue < 0 || indexvalue >= length) {
         return indexvalue < 0 ? 0 : length - 1;
     }
     return indexvalue;
 }
-
 
 
 #define MAT(m) (*(OSL::Matrix44*)__builtin_assume_aligned(m, alignof(float)))

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -13,6 +13,9 @@
 
 #include "rend_lib.h"
 
+#define MEMCPY_ALIGNED(dst, src, size, alignment)    \
+    memcpy(__builtin_assume_aligned(dst, alignment), \
+           __builtin_assume_aligned(src, alignment), size);
 
 OSL_NAMESPACE_ENTER
 namespace pvt {
@@ -140,7 +143,7 @@ osl_allocate_weighted_closure_component(void* sg_, int id, int size,
 {
     ShaderGlobals* sg_ptr = (ShaderGlobals*)sg_;
 
-    const OSL::Color3* wc = (const OSL::Color3*)w;
+    const OSL::Color3* wc = (const OSL::Color3*) __builtin_assume_aligned(w,alignof(float));
 
     if (wc->x == 0.0f && wc->y == 0.0f && wc->z == 0.0f) {
         return NULL;
@@ -163,7 +166,7 @@ __device__ void*
 osl_mul_closure_color(void* sg_, void* a, const void* w)
 {
     ShaderGlobals* sg_ptr = (ShaderGlobals*)sg_;
-    const OSL::Color3* wc = (const OSL::Color3*)w;
+    const OSL::Color3* wc = (const OSL::Color3*) __builtin_assume_aligned(w,alignof(float));
 
     if (a == NULL) {
         return NULL;
@@ -191,6 +194,8 @@ osl_mul_closure_color(void* sg_, void* a, const void* w)
 __device__ void*
 osl_mul_closure_float(void* sg_, void* a, float w)
 {
+    a = __builtin_assume_aligned(a,alignof(float));
+
     ShaderGlobals* sg_ptr = (ShaderGlobals*)sg_;
 
     if (a == NULL || w == 0.0f) {
@@ -215,6 +220,9 @@ osl_mul_closure_float(void* sg_, void* a, float w)
 __device__ void*
 osl_add_closure_closure(void* sg_, void* a, void* b)
 {
+    a = __builtin_assume_aligned(a,alignof(float));
+    b = __builtin_assume_aligned(b,alignof(float));
+
     ShaderGlobals* sg_ptr = (ShaderGlobals*)sg_;
 
     if (a == NULL) {
@@ -254,7 +262,7 @@ rend_get_userdata(OSL::StringParam name, void* data, int data_size,
     }
     // TODO: This is temporary code for initial testing and demonstration.
     if (IS_STRING(type) && name == HDSTR(OSL::pvt::test_str_1)) {
-        memcpy(data, &OSL::pvt::test_str_2, 8);
+        MEMCPY_ALIGNED(data, &OSL::pvt::test_str_2, 8, alignof(float));
         return true;
     }
 
@@ -281,7 +289,7 @@ osl_bind_interpolated_param(void* sg_, const char* name, long long type,
         *userdata_initialized = status = 1 + ok;
     }
     if (status == 2) {
-        memcpy(symbol_data, userdata_data, symbol_data_size);
+        MEMCPY_ALIGNED(symbol_data, userdata_data, symbol_data_size, alignof(float));
         return 1;
     }
     return 0;
@@ -442,11 +450,12 @@ osl_range_check(int indexvalue, int length, OSL::ustring_pod symname, void* sg,
 
 
 
-#define MAT(m) (*(OSL::Matrix44*)m)
+#define MAT(m) (*(OSL::Matrix44*)__builtin_assume_aligned(m,alignof(float)))
 
 __device__ int
 osl_get_matrix(void* sg_, void* r, const char* from)
 {
+    r = __builtin_assume_aligned(r,alignof(float));
     ShaderGlobals* sg = (ShaderGlobals*)sg_;
     if (HDSTR(from) == STRING_PARAMS(common)) {
         MAT(r).makeIdentity();
@@ -491,6 +500,7 @@ osl_get_matrix(void* sg_, void* r, const char* from)
 __device__ int
 osl_get_inverse_matrix(void* sg_, void* r, const char* to)
 {
+    r = __builtin_assume_aligned(r,alignof(float));
     ShaderGlobals* sg = (ShaderGlobals*)sg_;
     if (HDSTR(to) == STRING_PARAMS(common)) {
         MAT(r).makeIdentity();

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -266,7 +266,6 @@ rend_get_userdata(OSL::StringParam name, void* data, int data_size,
 #undef IS_PTR
 
 
-
 __device__ int
 osl_bind_interpolated_param(void* sg_, const char* name, long long type,
                             int userdata_has_derivs, void* userdata_data,

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -174,6 +174,8 @@ bool
 OptixRaytracer::init_optix_context(int xres OSL_MAYBE_UNUSED,
                                    int yres OSL_MAYBE_UNUSED)
 {
+    shadingsys->attribute ("lib_bitcode", {OSL::TypeDesc::UINT8, rend_llvm_compiled_ops_size},
+                           rend_llvm_compiled_ops_block);
     return true;
 }
 

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -376,7 +376,8 @@ OptixRaytracer::make_optix_materials()
                              &shadeops_ptx_size);
 
     if (shadeops_ptx == nullptr || shadeops_ptx_size == 0) {
-        errhandler().severefmt("Could not retrieve PTX for the shadeops library");
+        errhandler().severefmt(
+            "Could not retrieve PTX for the shadeops library");
         return false;
     }
 
@@ -384,11 +385,11 @@ OptixRaytracer::make_optix_materials()
     OptixModule shadeops_module;
     sizeof_msg_log = sizeof(msg_log);
     OPTIX_CHECK_MSG(optixModuleCreateFn(m_optix_ctx, &module_compile_options,
-                                        &pipeline_compile_options,
-                                        shadeops_ptx, shadeops_ptx_size,
-                                        msg_log, &sizeof_msg_log,
-                                        &shadeops_module),
-                    fmtformat("Creating module for shadeops library: {}", msg_log));
+                                        &pipeline_compile_options, shadeops_ptx,
+                                        shadeops_ptx_size, msg_log,
+                                        &sizeof_msg_log, &shadeops_module),
+                    fmtformat("Creating module for shadeops library: {}",
+                              msg_log));
     modules.push_back(shadeops_module);
 
     OptixProgramGroupOptions program_options = {};
@@ -452,20 +453,22 @@ OptixRaytracer::make_optix_materials()
     create_optix_pg(&quad_hitgroup_desc, 1, &program_options, &quad_hitgroup);
 
     // Direct-callable -- renderer-specific support functions for OSL on the device
-    OptixProgramGroupDesc rend_lib_desc         = {};
-    rend_lib_desc.kind                          = OPTIX_PROGRAM_GROUP_KIND_CALLABLES;
-    rend_lib_desc.callables.moduleDC            = rend_lib_module;
-    rend_lib_desc.callables.entryFunctionNameDC = "__direct_callable__dummy_rend_lib";
+    OptixProgramGroupDesc rend_lib_desc = {};
+    rend_lib_desc.kind                  = OPTIX_PROGRAM_GROUP_KIND_CALLABLES;
+    rend_lib_desc.callables.moduleDC    = rend_lib_module;
+    rend_lib_desc.callables.entryFunctionNameDC
+        = "__direct_callable__dummy_rend_lib";
     rend_lib_desc.callables.moduleCC            = 0;
     rend_lib_desc.callables.entryFunctionNameCC = nullptr;
     OptixProgramGroup rend_lib_group;
     create_optix_pg(&rend_lib_desc, 1, &program_options, &rend_lib_group);
 
     // Direct-callable -- built-in support functions for OSL on the device
-    OptixProgramGroupDesc shadeops_desc         = {};
-    shadeops_desc.kind                          = OPTIX_PROGRAM_GROUP_KIND_CALLABLES;
-    shadeops_desc.callables.moduleDC            = shadeops_module;
-    shadeops_desc.callables.entryFunctionNameDC = "__direct_callable__dummy_shadeops";
+    OptixProgramGroupDesc shadeops_desc = {};
+    shadeops_desc.kind                  = OPTIX_PROGRAM_GROUP_KIND_CALLABLES;
+    shadeops_desc.callables.moduleDC    = shadeops_module;
+    shadeops_desc.callables.entryFunctionNameDC
+        = "__direct_callable__dummy_shadeops";
     shadeops_desc.callables.moduleCC            = 0;
     shadeops_desc.callables.entryFunctionNameCC = nullptr;
     OptixProgramGroup shadeops_group;
@@ -589,7 +592,7 @@ OptixRaytracer::make_optix_materials()
     OptixPipelineLinkOptions pipeline_link_options;
     pipeline_link_options.maxTraceDepth = 1;
 #if (OPTIX_VERSION < 70700)
-    pipeline_link_options.debugLevel    = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
+    pipeline_link_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
 #endif
 #if (OPTIX_VERSION < 70100)
     pipeline_link_options.overrideUsesMotionBlur = false;

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -182,8 +182,12 @@ bool
 OptixRaytracer::init_optix_context(int xres OSL_MAYBE_UNUSED,
                                    int yres OSL_MAYBE_UNUSED)
 {
-    shadingsys->attribute ("lib_bitcode", {OSL::TypeDesc::UINT8, rend_lib_llvm_compiled_ops_size},
-                           rend_lib_llvm_compiled_ops_block);
+    if (!options.get_int("no_rend_lib_bitcode")) {
+        shadingsys->attribute("lib_bitcode",
+                              { OSL::TypeDesc::UINT8,
+                                rend_lib_llvm_compiled_ops_size },
+                              rend_lib_llvm_compiled_ops_block);
+    }
     return true;
 }
 

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -96,11 +96,14 @@ set_shadingsys_options()
     // These attributes have been added to aid tuning the GPU optimization
     // passes and may be removed or changed in the future.
     shadingsys->attribute("optix_no_inline", optix_no_inline);
-    shadingsys->attribute("optix_no_inline_layer_funcs", optix_no_inline_layer_funcs);
-    shadingsys->attribute("optix_merge_layer_funcs", !optix_no_merge_layer_funcs);
-    shadingsys->attribute("optix_no_inline_rend_lib",optix_no_inline_rend_lib);
+    shadingsys->attribute("optix_no_inline_layer_funcs",
+                          optix_no_inline_layer_funcs);
+    shadingsys->attribute("optix_merge_layer_funcs",
+                          !optix_no_merge_layer_funcs);
+    shadingsys->attribute("optix_no_inline_rend_lib", optix_no_inline_rend_lib);
     shadingsys->attribute("optix_no_inline_thresh", optix_no_inline_thresh);
-    shadingsys->attribute("optix_force_inline_thresh", optix_force_inline_thresh);
+    shadingsys->attribute("optix_force_inline_thresh",
+                          optix_force_inline_thresh);
 
     shadingsys->attribute("profile", int(profile));
     shadingsys->attribute("debug_nan", debugnan);

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -61,7 +61,7 @@ static bool use_optix              = OIIO::Strutil::stoi(
 static bool optix_no_inline             = false;
 static bool optix_no_inline_layer_funcs = false;
 static bool optix_no_merge_layer_funcs  = false;
-static bool optix_no_inline_rendlib     = false;
+static bool optix_no_inline_rend_lib    = false;
 static int optix_no_inline_thresh       = 100000;
 static int optix_force_inline_thresh    = 0;
 
@@ -97,7 +97,7 @@ set_shadingsys_options()
     shadingsys->attribute("optix_no_inline", optix_no_inline);
     shadingsys->attribute("optix_no_inline_layer_funcs", optix_no_inline_layer_funcs);
     shadingsys->attribute("optix_merge_layer_funcs", !optix_no_merge_layer_funcs);
-    shadingsys->attribute("optix_no_inline_rendlib", optix_no_inline_rendlib);
+    shadingsys->attribute("optix_no_inline_rend_lib",optix_no_inline_rend_lib);
     shadingsys->attribute("optix_no_inline_thresh", optix_no_inline_thresh);
     shadingsys->attribute("optix_force_inline_thresh", optix_force_inline_thresh);
 
@@ -186,8 +186,8 @@ getargs(int argc, const char* argv[])
       .help("Disable inlining the group layer functions when compiling for OptiX");
     ap.arg("--optix_no_merge_layer_funcs", &optix_no_merge_layer_funcs)
       .help("Disable merging group layer functions with only one caller when compiling for OptiX");
-    ap.arg("--optix_no_inline_rendlib", &optix_no_inline_rendlib)
-      .help("Disable inlining the rendlib functions when compiling for OptiX");
+    ap.arg("--optix_no_inline_rend_lib", &optix_no_inline_rend_lib)
+      .help("Disable inlining the rend_lib functions when compiling for OptiX");
     ap.arg("--optix_no_inline_thresh %d:THRESH", &optix_no_inline_thresh)
       .help("Don't inline functions larger than the threshold when compiling for OptiX");
     ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -58,10 +58,10 @@ static std::string shaderpath;
 static bool shadingsys_options_set = false;
 static bool use_optix              = OIIO::Strutil::stoi(
                  OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
-static bool gpu_no_inline             = false;
-static bool gpu_no_inline_layer_funcs = false;
-static int gpu_no_inline_thresh       = 100000;
-static int gpu_force_inline_thresh    = 0;
+static bool optix_no_inline             = false;
+static bool optix_no_inline_layer_funcs = false;
+static int optix_no_inline_thresh       = 100000;
+static int optix_force_inline_thresh    = 0;
 
 
 // Set shading system global attributes based on command line options.
@@ -89,13 +89,13 @@ set_shadingsys_options()
         llvm_opt = atoi(llvm_opt_env);
     shadingsys->attribute("llvm_optimize", llvm_opt);
 
-    // Experimental: Control the inlining behavior when compiling for the GPU.
+    // Experimental: Control the inlining behavior when compiling for OptiX.
     // These attributes have been added to aid tuning the GPU optimization
     // passes and may be removed or changed in the future.
-    shadingsys->attribute("gpu_no_inline", gpu_no_inline);
-    shadingsys->attribute("gpu_no_inline_layer_funcs", gpu_no_inline_layer_funcs);
-    shadingsys->attribute("gpu_no_inline_thresh", gpu_no_inline_thresh);
-    shadingsys->attribute("gpu_force_inline_thresh", gpu_force_inline_thresh);
+    shadingsys->attribute("optix_no_inline", optix_no_inline);
+    shadingsys->attribute("optix_no_inline_layer_funcs", optix_no_inline_layer_funcs);
+    shadingsys->attribute("optix_no_inline_thresh", optix_no_inline_thresh);
+    shadingsys->attribute("optix_force_inline_thresh", optix_force_inline_thresh);
 
     shadingsys->attribute("profile", int(profile));
     shadingsys->attribute("debug_nan", debugnan);
@@ -176,14 +176,14 @@ getargs(int argc, const char* argv[])
       .help("Do lots of runtime shader optimization");
     ap.arg("--llvm_opt %d:LEVEL", &llvm_opt)
       .help("LLVM JIT optimization level");
-    ap.arg("--gpu_no_inline", &gpu_no_inline)
-      .help("Disable function inlining in GPU code");
-    ap.arg("--gpu_no_inline_layer_funcs", &gpu_no_inline_layer_funcs)
-      .help("Disable inlining the group layer functions in GPU code");
-    ap.arg("--gpu_no_inline_thresh %d:THRESH", &gpu_no_inline_thresh)
-      .help("Don't inline functions larger than the threshold in GPU code");
-    ap.arg("--gpu_force_inline_thresh %d:THRESH", &gpu_force_inline_thresh)
-      .help("Force inline functions smaller than the threshold in GPU code");
+    ap.arg("--optix_no_inline", &optix_no_inline)
+      .help("Disable function inlining when compiling for OptiX");
+    ap.arg("--optix_no_inline_layer_funcs", &optix_no_inline_layer_funcs)
+      .help("Disable inlining the group layer functions when compiling for OptiX");
+    ap.arg("--optix_no_inline_thresh %d:THRESH", &optix_no_inline_thresh)
+      .help("Don't inline functions larger than the threshold when compiling for OptiX");
+    ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)
+      .help("Force inline functions smaller than the threshold when compiling for OptiX");
     ap.arg("--debugnan", &debugnan)
       .help("Turn on 'debugnan' mode");
     ap.arg("--path SEARCHPATH", &shaderpath)

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -89,7 +89,9 @@ set_shadingsys_options()
         llvm_opt = atoi(llvm_opt_env);
     shadingsys->attribute("llvm_optimize", llvm_opt);
 
-    // Control the inlining behavior when optimizing for the GPU
+    // Experimental: Control the inlining behavior when compiling for the GPU.
+    // These attributes have been added to aid tuning the GPU optimization
+    // passes and may be removed or changed in the future.
     shadingsys->attribute("gpu_no_inline", gpu_no_inline);
     shadingsys->attribute("gpu_no_inline_layer_funcs", gpu_no_inline_layer_funcs);
     shadingsys->attribute("gpu_no_inline_thresh", gpu_no_inline_thresh);

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -62,6 +62,7 @@ static bool optix_no_inline             = false;
 static bool optix_no_inline_layer_funcs = false;
 static bool optix_no_merge_layer_funcs  = false;
 static bool optix_no_inline_rend_lib    = false;
+static bool optix_no_rend_lib_bitcode   = false;
 static int optix_no_inline_thresh       = 100000;
 static int optix_force_inline_thresh    = 0;
 
@@ -188,6 +189,8 @@ getargs(int argc, const char* argv[])
       .help("Disable merging group layer functions with only one caller when compiling for OptiX");
     ap.arg("--optix_no_inline_rend_lib", &optix_no_inline_rend_lib)
       .help("Disable inlining the rend_lib functions when compiling for OptiX");
+    ap.arg("--optix_no_rend_lib_bitcode", &optix_no_rend_lib_bitcode)
+      .help("Don't pass LLVM bitcode for the rend_lib functions to the ShadingSystem");
     ap.arg("--optix_no_inline_thresh %d:THRESH", &optix_no_inline_thresh)
       .help("Don't inline functions larger than the threshold when compiling for OptiX");
     ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)
@@ -271,12 +274,16 @@ main(int argc, const char* argv[])
     // Other renderer and global options
     if (debug1 || verbose)
         rend->errhandler().verbosity(ErrorHandler::VERBOSE);
-    rend->attribute("saveptx", (int)saveptx);
     rend->attribute("max_bounces", max_bounces);
     rend->attribute("rr_depth", rr_depth);
     rend->attribute("aa", aa);
     rend->attribute("show_albedo_scale", show_albedo_scale);
     OIIO::attribute("threads", num_threads);
+
+#if OSL_USE_OPTIX
+    rend->attribute("saveptx", (int)saveptx);
+    rend->attribute("no_rend_lib_bitcode", (int)optix_no_rend_lib_bitcode);
+#endif
 
     // Create a new shading system.  We pass it the RendererServices
     // object that services callbacks from the shading system, the

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -58,7 +58,10 @@ static std::string shaderpath;
 static bool shadingsys_options_set = false;
 static bool use_optix              = OIIO::Strutil::stoi(
                  OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
-
+static bool gpu_no_inline             = false;
+static bool gpu_no_inline_layer_funcs = false;
+static int gpu_no_inline_thresh       = 100000;
+static int gpu_force_inline_thresh    = 0;
 
 
 // Set shading system global attributes based on command line options.
@@ -85,6 +88,12 @@ set_shadingsys_options()
             "TESTSHADE_LLVM_OPT"))  // overrides llvm_opt
         llvm_opt = atoi(llvm_opt_env);
     shadingsys->attribute("llvm_optimize", llvm_opt);
+
+    // Control the inlining behavior when optimizing for the GPU
+    shadingsys->attribute("gpu_no_inline", gpu_no_inline);
+    shadingsys->attribute("gpu_no_inline_layer_funcs", gpu_no_inline_layer_funcs);
+    shadingsys->attribute("gpu_no_inline_thresh", gpu_no_inline_thresh);
+    shadingsys->attribute("gpu_force_inline_thresh", gpu_force_inline_thresh);
 
     shadingsys->attribute("profile", int(profile));
     shadingsys->attribute("debug_nan", debugnan);
@@ -165,6 +174,14 @@ getargs(int argc, const char* argv[])
       .help("Do lots of runtime shader optimization");
     ap.arg("--llvm_opt %d:LEVEL", &llvm_opt)
       .help("LLVM JIT optimization level");
+    ap.arg("--gpu_no_inline", &gpu_no_inline)
+      .help("Disable function inlining in GPU code");
+    ap.arg("--gpu_no_inline_layer_funcs", &gpu_no_inline_layer_funcs)
+      .help("Disable inlining the group layer functions in GPU code");
+    ap.arg("--gpu_no_inline_thresh %d:THRESH", &gpu_no_inline_thresh)
+      .help("Don't inline functions larger than the threshold in GPU code");
+    ap.arg("--gpu_force_inline_thresh %d:THRESH", &gpu_force_inline_thresh)
+      .help("Force inline functions smaller than the threshold in GPU code");
     ap.arg("--debugnan", &debugnan)
       .help("Turn on 'debugnan' mode");
     ap.arg("--path SEARCHPATH", &shaderpath)

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -60,6 +60,8 @@ static bool use_optix              = OIIO::Strutil::stoi(
                  OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
 static bool optix_no_inline             = false;
 static bool optix_no_inline_layer_funcs = false;
+static bool optix_no_merge_layer_funcs  = false;
+static bool optix_no_inline_rendlib     = false;
 static int optix_no_inline_thresh       = 100000;
 static int optix_force_inline_thresh    = 0;
 
@@ -94,6 +96,8 @@ set_shadingsys_options()
     // passes and may be removed or changed in the future.
     shadingsys->attribute("optix_no_inline", optix_no_inline);
     shadingsys->attribute("optix_no_inline_layer_funcs", optix_no_inline_layer_funcs);
+    shadingsys->attribute("optix_merge_layer_funcs", !optix_no_merge_layer_funcs);
+    shadingsys->attribute("optix_no_inline_rendlib", optix_no_inline_rendlib);
     shadingsys->attribute("optix_no_inline_thresh", optix_no_inline_thresh);
     shadingsys->attribute("optix_force_inline_thresh", optix_force_inline_thresh);
 
@@ -180,6 +184,10 @@ getargs(int argc, const char* argv[])
       .help("Disable function inlining when compiling for OptiX");
     ap.arg("--optix_no_inline_layer_funcs", &optix_no_inline_layer_funcs)
       .help("Disable inlining the group layer functions when compiling for OptiX");
+    ap.arg("--optix_no_merge_layer_funcs", &optix_no_merge_layer_funcs)
+      .help("Disable merging group layer functions with only one caller when compiling for OptiX");
+    ap.arg("--optix_no_inline_rendlib", &optix_no_inline_rendlib)
+      .help("Disable inlining the rendlib functions when compiling for OptiX");
     ap.arg("--optix_no_inline_thresh %d:THRESH", &optix_no_inline_thresh)
       .help("Don't inline functions larger than the threshold when compiling for OptiX");
     ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -8,9 +8,9 @@ set ( testshade_srcs
       simplerend.cpp )
 
 if (OSL_BUILD_BATCHED)
-    list(APPEND testshade_srcs 
+    list(APPEND testshade_srcs
         batched_simplerend.cpp)
-endif()    
+endif()
 
 if (OSL_USE_OPTIX)
     list (APPEND testshade_srcs optixgridrender.cpp)
@@ -19,8 +19,9 @@ if (OSL_USE_OPTIX)
         ../testrender/cuda/wrapper.cu
         )
 
-    set (testshade_shadeops_srcs
-        ../testrender/cuda/rend_lib.cu)
+    set (testshade_rend_lib_srcs
+        ../testrender/cuda/rend_lib.cu
+        )
 
     set ( testshade_cuda_headers
         ../testrender/cuda/rend_lib.h )
@@ -30,15 +31,26 @@ if (OSL_USE_OPTIX)
     set ( extra_cuda_headers
         render_params.h )
 
-    add_definitions (-DOSL_LLVM_CUDA_BITCODE)
-    CUDA_SHADEOPS_COMPILE ( testshade_srcs
-        ${testshade_shadeops_srcs} ${testshade_cuda_headers} )
-
     # Generate PTX for all of the CUDA files
     foreach (cudasrc ${testshade_cuda_srcs})
         NVCC_COMPILE ( ${cudasrc} ${extra_cuda_headers} ptx_generated "-I../testrender/cuda" )
         list (APPEND ptx_list ${ptx_generated})
     endforeach ()
+
+    # Compile the renderer-supplied shadeops (rend_lib) to LLVM bitcode and PTX
+    add_definitions (-DOSL_LLVM_CUDA_BITCODE)
+    CUDA_SHADEOPS_COMPILE ( "rend_lib_testshade"
+        rend_lib_bc
+        rend_lib_ptx
+        "${testshade_rend_lib_srcs}"
+        "${testshade_cuda_headers}"
+    )
+
+    # Serialize the rend_lib bitcode into a CPP file to be embedded in the current target binary
+    set (rend_lib_bc_cuda_cpp "${CMAKE_CURRENT_BINARY_DIR}/rend_lib_cuda.bc.cpp")
+    MAKE_EMBEDDED_CPP( "rend_lib_llvm_compiled_ops" ${rend_lib_bc_cuda_cpp} ${rend_lib_bc} )
+    list (APPEND testshade_srcs ${rend_lib_bc_cuda_cpp})
+    list (APPEND ptx_list ${rend_lib_ptx})
 
     add_custom_target (testshade_ptx ALL
         DEPENDS ${ptx_list}
@@ -50,7 +62,7 @@ if (OSL_USE_OPTIX)
              DESTINATION ${OSL_PTX_INSTALL_DIR})
 endif()
 
-set ( rs_srcs 
+set ( rs_srcs
     rs_simplerend.cpp )
 
 set(include_dirs ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -17,7 +17,10 @@ if (OSL_USE_OPTIX)
     set ( testshade_cuda_srcs
         cuda/optix_grid_renderer.cu
         ../testrender/cuda/wrapper.cu
-        ../testrender/cuda/rend_lib.cu )
+        )
+
+    set (testshade_shadeops_srcs
+        ../testrender/cuda/rend_lib.cu)
 
     set ( testshade_cuda_headers
         ../testrender/cuda/rend_lib.h )
@@ -27,14 +30,9 @@ if (OSL_USE_OPTIX)
     set ( extra_cuda_headers
         render_params.h )
 
-    LLVM_COMPILE_CUDA (
-        ${CMAKE_CURRENT_SOURCE_DIR}/../testrender/cuda/rend_lib.cu
-        ${testshade_cuda_headers}
-        "rend_llvm_compiled_ops"
-        rend_lib_bc_cpp
-        "-I../testrender/cuda" )
-
-    list (APPEND testshade_srcs ${rend_lib_bc_cpp})
+    add_definitions (-DOSL_LLVM_CUDA_BITCODE)
+    CUDA_SHADEOPS_COMPILE ( testshade_srcs
+        ${testshade_shadeops_srcs} ${testshade_cuda_headers} )
 
     # Generate PTX for all of the CUDA files
     foreach (cudasrc ${testshade_cuda_srcs})

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -14,6 +14,20 @@
 #include <optix_device.h>
 
 
+OSL_NAMESPACE_ENTER
+namespace pvt {
+__device__ CUdeviceptr s_color_system          = 0;
+__device__ CUdeviceptr osl_printf_buffer_start = 0;
+__device__ CUdeviceptr osl_printf_buffer_end   = 0;
+__device__ uint64_t test_str_1                 = 0;
+__device__ uint64_t test_str_2                 = 0;
+__device__ uint64_t num_named_xforms           = 0;
+__device__ CUdeviceptr xform_name_buffer       = 0;
+__device__ CUdeviceptr xform_buffer            = 0;
+}
+OSL_NAMESPACE_EXIT
+
+
 extern "C" {
 __device__ __constant__ RenderParams render_params;
 }

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -24,7 +24,7 @@ __device__ uint64_t test_str_2                 = 0;
 __device__ uint64_t num_named_xforms           = 0;
 __device__ CUdeviceptr xform_name_buffer       = 0;
 __device__ CUdeviceptr xform_buffer            = 0;
-}
+}  // namespace pvt
 OSL_NAMESPACE_EXIT
 
 

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -25,6 +25,13 @@ extern int rend_llvm_compiled_ops_size;
 extern unsigned char rend_llvm_compiled_ops_block[];
 
 
+// The entry point for OptiX Module creation changed in OptiX 7.7
+#if OPTIX_VERSION < 70700
+const auto optixModuleCreateFn = optixModuleCreateFromPTX;
+#else
+const auto optixModuleCreateFn = optixModuleCreate;
+#endif
+
 
 OSL_NAMESPACE_ENTER
 
@@ -327,12 +334,11 @@ OptixGridRenderer::make_optix_materials()
 
     sizeof_msg_log = sizeof(msg_log);
     OptixModule program_module;
-    OPTIX_CHECK_MSG(optixModuleCreateFromPTX(m_optix_ctx,
-                                             &module_compile_options,
-                                             &pipeline_compile_options,
-                                             program_ptx.c_str(),
-                                             program_ptx.size(), msg_log,
-                                             &sizeof_msg_log, &program_module),
+    OPTIX_CHECK_MSG(optixModuleCreateFn(m_optix_ctx, &module_compile_options,
+                                        &pipeline_compile_options,
+                                        program_ptx.c_str(), program_ptx.size(),
+                                        msg_log, &sizeof_msg_log,
+                                        &program_module),
                     fmtformat("Creating Module from PTX-file {}", msg_log));
 
     // Record it so we can destroy it later
@@ -429,12 +435,11 @@ OptixGridRenderer::make_optix_materials()
     // Create shadeops library program group
     sizeof_msg_log = sizeof(msg_log);
     OptixModule shadeops_module;
-    OPTIX_CHECK_MSG(optixModuleCreateFromPTX(m_optix_ctx,
-                                             &module_compile_options,
-                                             &pipeline_compile_options,
-                                             shadeops_ptx.c_str(),
-                                             shadeops_ptx.size(), msg_log,
-                                             &sizeof_msg_log, &shadeops_module),
+    OPTIX_CHECK_MSG(optixModuleCreateFn(m_optix_ctx, &module_compile_options,
+                                        &pipeline_compile_options,
+                                        shadeops_ptx.c_str(),
+                                        shadeops_ptx.size(), msg_log,
+                                        &sizeof_msg_log, &shadeops_module),
                     fmtformat("Creating module from PTX-file: {}", msg_log));
 
     // Record it so we can destroy it later
@@ -510,12 +515,13 @@ OptixGridRenderer::make_optix_materials()
         // and set the OSL functions as Callable Programs so that they
         // can be executed by the closest hit program in the wrapper
         sizeof_msg_log = sizeof(msg_log);
-        OPTIX_CHECK_MSG(
-            optixModuleCreateFromPTX(m_optix_ctx, &module_compile_options,
-                                     &pipeline_compile_options, osl_ptx.c_str(),
-                                     osl_ptx.size(), msg_log, &sizeof_msg_log,
-                                     &optix_module),
-            fmtformat("Creating Module from PTX-file {}", msg_log));
+        OPTIX_CHECK_MSG(optixModuleCreateFn(m_optix_ctx,
+                                            &module_compile_options,
+                                            &pipeline_compile_options,
+                                            osl_ptx.c_str(), osl_ptx.size(),
+                                            msg_log, &sizeof_msg_log,
+                                            &optix_module),
+                        fmtformat("Creating Module from PTX-file {}", msg_log));
 
         modules.push_back(optix_module);
 
@@ -561,7 +567,9 @@ OptixGridRenderer::make_optix_materials()
 
     OptixPipelineLinkOptions pipeline_link_options;
     pipeline_link_options.maxTraceDepth = 1;
-    pipeline_link_options.debugLevel    = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
+#if (OPTIX_VERSION < 70700)
+    pipeline_link_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
+#endif
 #if (OPTIX_VERSION < 70100)
     pipeline_link_options.overrideUsesMotionBlur = false;
 #endif
@@ -590,8 +598,16 @@ OptixGridRenderer::make_optix_materials()
 
     // Set the pipeline stack size
     OptixStackSizes stack_sizes = {};
-    for (OptixProgramGroup& program_group : final_groups)
+    for (OptixProgramGroup& program_group : final_groups) {
+#if (OPTIX_VERSION < 70700)
         OPTIX_CHECK(optixUtilAccumulateStackSizes(program_group, &stack_sizes));
+#else
+        // OptiX 7.7+ is able to take the whole pipeline into account
+        // when calculating the stack requirements.
+        OPTIX_CHECK(optixUtilAccumulateStackSizes(program_group, &stack_sizes,
+                                                  m_optix_pipeline));
+#endif
+    }
 
     uint32_t max_trace_depth = 1;
     uint32_t max_cc_depth    = 1;
@@ -604,11 +620,12 @@ OptixGridRenderer::make_optix_materials()
         &direct_callable_stack_size_from_traversal,
         &direct_callable_stack_size_from_state, &continuation_stack_size));
 
-    // NB: Providing the shadeops as a large PTX module is a slight abuse of
-    //     the OptiX API. Older drivers may have a hard time computing the
-    //     stack requirements for non-entry functions, so we need to pad the
-    //     direct callable stack size to accommodate these functions.
+#if (OPTIX_VERSION < 70700)
+    // NB: Older versions of OptiX are unable to compute the stack requirements
+    //     for extern functions (e.g., the shadeops functions), so we need to
+    //     pad the direct callable stack size to accommodate these functions.
     direct_callable_stack_size_from_state += 512;
+#endif
 
     const uint32_t max_traversal_depth = 1;
     OPTIX_CHECK(optixPipelineSetStackSize(

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -190,6 +190,8 @@ bool
 OptixGridRenderer::init_optix_context(int xres OSL_MAYBE_UNUSED,
                                       int yres OSL_MAYBE_UNUSED)
 {
+    shadingsys->attribute ("lib_bitcode", {OSL::TypeDesc::UINT8, rend_llvm_compiled_ops_size},
+                           rend_llvm_compiled_ops_block);
     return true;
 }
 

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -197,10 +197,12 @@ bool
 OptixGridRenderer::init_optix_context(int xres OSL_MAYBE_UNUSED,
                                       int yres OSL_MAYBE_UNUSED)
 {
-    shadingsys->attribute("lib_bitcode",
-                          { OSL::TypeDesc::UINT8,
-                            rend_lib_llvm_compiled_ops_size },
-                          rend_lib_llvm_compiled_ops_block);
+    if (!options.get_int("no_rend_lib_bitcode")) {
+        shadingsys->attribute("lib_bitcode",
+                              { OSL::TypeDesc::UINT8,
+                                rend_lib_llvm_compiled_ops_size },
+                              rend_lib_llvm_compiled_ops_block);
+    }
     return true;
 }
 

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -438,7 +438,8 @@ OptixGridRenderer::make_optix_materials()
                              &shadeops_ptx_size);
 
     if (shadeops_ptx == nullptr || shadeops_ptx_size == 0) {
-        errhandler().severefmt("Could not retrieve PTX for the shadeops library");
+        errhandler().severefmt(
+            "Could not retrieve PTX for the shadeops library");
         return false;
     }
 
@@ -446,11 +447,11 @@ OptixGridRenderer::make_optix_materials()
     OptixModule shadeops_module;
     sizeof_msg_log = sizeof(msg_log);
     OPTIX_CHECK_MSG(optixModuleCreateFn(m_optix_ctx, &module_compile_options,
-                                        &pipeline_compile_options,
-                                        shadeops_ptx, shadeops_ptx_size,
-                                        msg_log, &sizeof_msg_log,
-                                        &shadeops_module),
-                    fmtformat("Creating module for shadeops library{}", msg_log));
+                                        &pipeline_compile_options, shadeops_ptx,
+                                        shadeops_ptx_size, msg_log,
+                                        &sizeof_msg_log, &shadeops_module),
+                    fmtformat("Creating module for shadeops library{}",
+                              msg_log));
 
     // Record it so we can destroy it later
     modules.push_back(shadeops_module);
@@ -625,12 +626,9 @@ OptixGridRenderer::make_optix_materials()
 
     // Set up OptiX pipeline
     std::vector<OptixProgramGroup> final_groups = {
-        shadeops_group,
-        rend_lib_group,
-        raygen_group,
-        miss_group,
-        hitgroup_group,
-        setglobals_raygen_group,
+        shadeops_group,        rend_lib_group,
+        raygen_group,          miss_group,
+        hitgroup_group,        setglobals_raygen_group,
         setglobals_miss_group,
     };
     if (m_fused_callable) {

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -50,6 +50,10 @@ public:
 
     virtual void register_named_transforms();
 
+    /// Register "shadeops" functions that should or should not be inlined
+    /// during ShaderGroup optimization.
+    void register_inline_functions();
+
     /// Return true if the texture handle (previously returned by
     /// get_texture_handle()) is a valid texture that can be subsequently
     /// read or sampled.

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -94,6 +94,7 @@ static bool optix_no_inline_rend_lib    = false;
 static bool optix_no_rend_lib_bitcode   = false;
 static int optix_no_inline_thresh       = 100000;
 static int optix_force_inline_thresh    = 0;
+static bool optix_register_inline_funcs = false;
 static int xres = 1, yres = 1;
 static int num_threads = 0;
 static std::string groupname;
@@ -802,6 +803,8 @@ getargs(int argc, const char* argv[])
       .help("Don't inline functions larger than the threshold when compiling for OptiX");
     ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)
       .help("Force inline functions smaller than the threshold when compiling for OptiX");
+    ap.arg("--optix_register_inline_funcs", &optix_register_inline_funcs)
+      .help("Register functions that should or should not be inlined during LLVM optimization");
     ap.arg("--entry %L:LAYERNAME", &entrylayers)
       .help("Add layer to the list of entry points");
     ap.arg("--entryoutput %L:NAME", &entryoutputs)
@@ -1946,6 +1949,7 @@ test_shade(int argc, const char* argv[])
 #if OSL_USE_OPTIX
     rend->attribute("saveptx", (int)saveptx);
     rend->attribute("no_rend_lib_bitcode", (int)optix_no_rend_lib_bitcode);
+    rend->attribute("optix_register_inline_funcs", (int)optix_register_inline_funcs);
 #endif
 
     // Hand the userdata options from the command line over to the renderer

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -89,6 +89,8 @@ static bool use_optix            = OIIO::Strutil::stoi(
                OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
 static bool optix_no_inline             = false;
 static bool optix_no_inline_layer_funcs = false;
+static bool optix_no_merge_layer_funcs  = false;
+static bool optix_no_inline_rendlib     = false;
 static int optix_no_inline_thresh       = 100000;
 static int optix_force_inline_thresh    = 0;
 static int xres = 1, yres = 1;
@@ -227,6 +229,8 @@ set_shadingsys_options()
     // passes and may be removed or changed in the future.
     shadingsys->attribute("optix_no_inline", optix_no_inline);
     shadingsys->attribute("optix_no_inline_layer_funcs", optix_no_inline_layer_funcs);
+    shadingsys->attribute("optix_merge_layer_funcs", !optix_no_merge_layer_funcs);
+    shadingsys->attribute("optix_no_inline_rendlib", optix_no_inline_rendlib);
     shadingsys->attribute("optix_no_inline_thresh", optix_no_inline_thresh);
     shadingsys->attribute("optix_force_inline_thresh", optix_force_inline_thresh);
 
@@ -784,6 +788,10 @@ getargs(int argc, const char* argv[])
       .help("Disable function inlining when compiling for OptiX");
     ap.arg("--optix_no_inline_layer_funcs", &optix_no_inline_layer_funcs)
       .help("Disable inlining the group layer functions when compiling for OptiX");
+    ap.arg("--optix_no_merge_layer_funcs", &optix_no_merge_layer_funcs)
+      .help("Disable merging group layer functions with only one caller when compiling for OptiX");
+    ap.arg("--optix_no_inline_rendlib", &optix_no_inline_rendlib)
+      .help("Disable inlining the rendlib functions when compiling for OptiX");
     ap.arg("--optix_no_inline_thresh %d:THRESH", &optix_no_inline_thresh)
       .help("Don't inline functions larger than the threshold when compiling for OptiX");
     ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -90,7 +90,7 @@ static bool use_optix            = OIIO::Strutil::stoi(
 static bool optix_no_inline             = false;
 static bool optix_no_inline_layer_funcs = false;
 static bool optix_no_merge_layer_funcs  = false;
-static bool optix_no_inline_rendlib     = false;
+static bool optix_no_inline_rend_lib    = false;
 static int optix_no_inline_thresh       = 100000;
 static int optix_force_inline_thresh    = 0;
 static int xres = 1, yres = 1;
@@ -230,7 +230,7 @@ set_shadingsys_options()
     shadingsys->attribute("optix_no_inline", optix_no_inline);
     shadingsys->attribute("optix_no_inline_layer_funcs", optix_no_inline_layer_funcs);
     shadingsys->attribute("optix_merge_layer_funcs", !optix_no_merge_layer_funcs);
-    shadingsys->attribute("optix_no_inline_rendlib", optix_no_inline_rendlib);
+    shadingsys->attribute("optix_no_inline_rend_lib", optix_no_inline_rend_lib);
     shadingsys->attribute("optix_no_inline_thresh", optix_no_inline_thresh);
     shadingsys->attribute("optix_force_inline_thresh", optix_force_inline_thresh);
 
@@ -790,8 +790,8 @@ getargs(int argc, const char* argv[])
       .help("Disable inlining the group layer functions when compiling for OptiX");
     ap.arg("--optix_no_merge_layer_funcs", &optix_no_merge_layer_funcs)
       .help("Disable merging group layer functions with only one caller when compiling for OptiX");
-    ap.arg("--optix_no_inline_rendlib", &optix_no_inline_rendlib)
-      .help("Disable inlining the rendlib functions when compiling for OptiX");
+    ap.arg("--optix_no_inline_rend_lib", &optix_no_inline_rend_lib)
+      .help("Disable inlining the rend_lib functions when compiling for OptiX");
     ap.arg("--optix_no_inline_thresh %d:THRESH", &optix_no_inline_thresh)
       .help("Don't inline functions larger than the threshold when compiling for OptiX");
     ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1949,7 +1949,8 @@ test_shade(int argc, const char* argv[])
 #if OSL_USE_OPTIX
     rend->attribute("saveptx", (int)saveptx);
     rend->attribute("no_rend_lib_bitcode", (int)optix_no_rend_lib_bitcode);
-    rend->attribute("optix_register_inline_funcs", (int)optix_register_inline_funcs);
+    rend->attribute("optix_register_inline_funcs",
+                    (int)optix_register_inline_funcs);
 #endif
 
     // Hand the userdata options from the command line over to the renderer

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -87,10 +87,10 @@ static bool print_outputs        = false;
 static bool output_placement     = true;
 static bool use_optix            = OIIO::Strutil::stoi(
                OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
-static bool gpu_no_inline             = false;
-static bool gpu_no_inline_layer_funcs = false;
-static int gpu_no_inline_thresh       = 100000;
-static int gpu_force_inline_thresh    = 0;
+static bool optix_no_inline             = false;
+static bool optix_no_inline_layer_funcs = false;
+static int optix_no_inline_thresh       = 100000;
+static int optix_force_inline_thresh    = 0;
 static int xres = 1, yres = 1;
 static int num_threads = 0;
 static std::string groupname;
@@ -222,13 +222,13 @@ set_shadingsys_options()
         llvm_opt = atoi(llvm_opt_env);
     shadingsys->attribute("llvm_optimize", llvm_opt);
 
-    // Experimental: Control the inlining behavior when compiling for the GPU.
+    // Experimental: Control the inlining behavior when compiling for OptiX.
     // These attributes have been added to aid tuning the GPU optimization
     // passes and may be removed or changed in the future.
-    shadingsys->attribute("gpu_no_inline", gpu_no_inline);
-    shadingsys->attribute("gpu_no_inline_layer_funcs", gpu_no_inline_layer_funcs);
-    shadingsys->attribute("gpu_no_inline_thresh", gpu_no_inline_thresh);
-    shadingsys->attribute("gpu_force_inline_thresh", gpu_force_inline_thresh);
+    shadingsys->attribute("optix_no_inline", optix_no_inline);
+    shadingsys->attribute("optix_no_inline_layer_funcs", optix_no_inline_layer_funcs);
+    shadingsys->attribute("optix_no_inline_thresh", optix_no_inline_thresh);
+    shadingsys->attribute("optix_force_inline_thresh", optix_force_inline_thresh);
 
     if (const char* use_rs_bitcode_env = getenv("TESTSHADE_RS_BITCODE")) {
         use_rs_bitcode = atoi(use_rs_bitcode_env);
@@ -780,14 +780,14 @@ getargs(int argc, const char* argv[])
       .help("Do lots of runtime shader optimization");
     ap.arg("--llvm_opt %d:LEVEL", &llvm_opt)
       .help("LLVM JIT optimization level");
-    ap.arg("--gpu_no_inline", &gpu_no_inline)
-      .help("Disable function inlining in GPU code");
-    ap.arg("--gpu_no_inline_layer_funcs", &gpu_no_inline_layer_funcs)
-      .help("Disable inlining the group layer functions in GPU code");
-    ap.arg("--gpu_no_inline_thresh %d:THRESH", &gpu_no_inline_thresh)
-      .help("Don't inline functions larger than the threshold in GPU code");
-    ap.arg("--gpu_force_inline_thresh %d:THRESH", &gpu_force_inline_thresh)
-      .help("Force inline functions smaller than the threshold in GPU code");
+    ap.arg("--optix_no_inline", &optix_no_inline)
+      .help("Disable function inlining when compiling for OptiX");
+    ap.arg("--optix_no_inline_layer_funcs", &optix_no_inline_layer_funcs)
+      .help("Disable inlining the group layer functions when compiling for OptiX");
+    ap.arg("--optix_no_inline_thresh %d:THRESH", &optix_no_inline_thresh)
+      .help("Don't inline functions larger than the threshold when compiling for OptiX");
+    ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)
+      .help("Force inline functions smaller than the threshold when compiling for OptiX");
     ap.arg("--entry %L:LAYERNAME", &entrylayers)
       .help("Add layer to the list of entry points");
     ap.arg("--entryoutput %L:NAME", &entryoutputs)

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -229,11 +229,14 @@ set_shadingsys_options()
     // These attributes have been added to aid tuning the GPU optimization
     // passes and may be removed or changed in the future.
     shadingsys->attribute("optix_no_inline", optix_no_inline);
-    shadingsys->attribute("optix_no_inline_layer_funcs", optix_no_inline_layer_funcs);
-    shadingsys->attribute("optix_merge_layer_funcs", !optix_no_merge_layer_funcs);
+    shadingsys->attribute("optix_no_inline_layer_funcs",
+                          optix_no_inline_layer_funcs);
+    shadingsys->attribute("optix_merge_layer_funcs",
+                          !optix_no_merge_layer_funcs);
     shadingsys->attribute("optix_no_inline_rend_lib", optix_no_inline_rend_lib);
     shadingsys->attribute("optix_no_inline_thresh", optix_no_inline_thresh);
-    shadingsys->attribute("optix_force_inline_thresh", optix_force_inline_thresh);
+    shadingsys->attribute("optix_force_inline_thresh",
+                          optix_force_inline_thresh);
 
     if (const char* use_rs_bitcode_env = getenv("TESTSHADE_RS_BITCODE")) {
         use_rs_bitcode = atoi(use_rs_bitcode_env);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -91,6 +91,7 @@ static bool optix_no_inline             = false;
 static bool optix_no_inline_layer_funcs = false;
 static bool optix_no_merge_layer_funcs  = false;
 static bool optix_no_inline_rend_lib    = false;
+static bool optix_no_rend_lib_bitcode   = false;
 static int optix_no_inline_thresh       = 100000;
 static int optix_force_inline_thresh    = 0;
 static int xres = 1, yres = 1;
@@ -792,6 +793,8 @@ getargs(int argc, const char* argv[])
       .help("Disable merging group layer functions with only one caller when compiling for OptiX");
     ap.arg("--optix_no_inline_rend_lib", &optix_no_inline_rend_lib)
       .help("Disable inlining the rend_lib functions when compiling for OptiX");
+    ap.arg("--optix_no_rend_lib_bitcode", &optix_no_rend_lib_bitcode)
+      .help("Don't pass LLVM bitcode for the rend_lib functions to the ShadingSystem");
     ap.arg("--optix_no_inline_thresh %d:THRESH", &optix_no_inline_thresh)
       .help("Don't inline functions larger than the threshold when compiling for OptiX");
     ap.arg("--optix_force_inline_thresh %d:THRESH", &optix_force_inline_thresh)
@@ -1936,7 +1939,11 @@ test_shade(int argc, const char* argv[])
     // Other renderer and global options
     if (debug1 || verbose)
         rend->errhandler().verbosity(ErrorHandler::VERBOSE);
+
+#if OSL_USE_OPTIX
     rend->attribute("saveptx", (int)saveptx);
+    rend->attribute("no_rend_lib_bitcode", (int)optix_no_rend_lib_bitcode);
+#endif
 
     // Hand the userdata options from the command line over to the renderer
     rend->userdata.merge(userdata);

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -222,7 +222,9 @@ set_shadingsys_options()
         llvm_opt = atoi(llvm_opt_env);
     shadingsys->attribute("llvm_optimize", llvm_opt);
 
-    // Control the inlining behavior when optimizing for the GPU
+    // Experimental: Control the inlining behavior when compiling for the GPU.
+    // These attributes have been added to aid tuning the GPU optimization
+    // passes and may be removed or changed in the future.
     shadingsys->attribute("gpu_no_inline", gpu_no_inline);
     shadingsys->attribute("gpu_no_inline_layer_funcs", gpu_no_inline_layer_funcs);
     shadingsys->attribute("gpu_no_inline_thresh", gpu_no_inline_thresh);


### PR DESCRIPTION
## Description
This PR is an overhaul of PTX compilation in OSL. The goal is to minimize the size of the generated PTX to help reduce time spent in subsequent stages (e.g., module creation, pipeline linking, etc.).

### rend_lib
The main functional change is in how the functions defined in rend_lib.cu are handled. In the current setup, rend_lib.cu is compiled to a standalone PTX file using nvcc. The functions are considered `extern` in generated shaders, and the dependencies are satisfied when the final pipeline is linked together. Since the functions are `extern`, they are not available for optimization when each shader is generated. This prevents the inlining of small functions, which incurs a lot of function call overhead in terms of PTX size and run-time cost.

So instead of compiling rend_lib.cu separately, it is compiled to LLVM bitcode along with the rest of the "shadeops" sources. This bitcode is used to seed the LLVM Module for each shader. This makes the definitions available when each shader is being generated and optimized, which allows the optimizer to make better decisions. It also allows for better control of inlining decisions which affect the size and quality of the generated PTX.

### shadeops
Another significant functional change is in how the shadeops functions (including those defined in rend_lib.cu) are treated. In the current pipeline, each shader must carry along with it definitions for all non-inlined shadeops functions that are used. This bloats the size of the PTX for each shader, and results in many duplicate copies of those functions existing in the final linked pipeline.

In the new pipeline, the unified shadeops+rend_lib bitcode is compiled to PTX using the offline `llc` tool. This PTX is used by the renderer to create a single "shadeops" module that provides the definitions for those functions. This makes it possible to drop the definitions for those functions from the PTX for each shader, which can significantly reduce the size of the generated PTX.

### quirks
This PR contains some interesting "quirks" which are largely fallout from compiling rend_lib.cu using clang instead of nvcc:

- The clang-generated PTX is processed by a Python script to transform some function & symbol declarations to better match what was generated by nvcc. It might be possible to add the right decorators to the C++/CUDA code to get the correct visibility for these symbols, but I was not successful in doing so.
- It was necessary to change the function signatures for some of the rend_lib functions to use `void*` instead of the actual OSL types (e.g., `OSL::Color3*`). Trying to use the actual types produces an LLVM assertion failure, for reasons that I don't understand.
- I have enabled flush-to-zero (FTZ) for clang-compiled code, to better match the behavior of nvcc. I added a CMake variable to enable or disable FTZ in the event that somebody wants to disable it.
- I have added some alignment hints on pointer accesses in rend_lib.cu. clang does not appear to be able to deduce the alignment of pointers in many cases, which turns things like `memcpy` and `memset` into long series of byte operations. Functions like `osl_get_matrix` are bloated substantially if the hints aren't provided.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

No new tests added, but no new test failures were added either. :wink:

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

