### PR TITLE
build(cmake): Fix incorrect variable name to control symbol visibility

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -121,11 +121,11 @@ endif ()
 # give more fine-grained control for hiding symbols, because sometimes
 # dependent libraries may not be well behaved and need extra hiding.
 #
-set (CXX_VISIBILITY_PRESET "hidden" CACHE STRING "Symbol visibility (hidden or default")
+set (CMAKE_CXX_VISIBILITY_PRESET "hidden" CACHE STRING "Symbol visibility (hidden or default")
 option (VISIBILITY_INLINES_HIDDEN "Hide symbol visibility of inline functions" ON)
 set (VISIBILITY_MAP_FILE "${PROJECT_SOURCE_DIR}/src/build-scripts/hidesymbols.map" CACHE FILEPATH "Visibility map file")
-set (C_VISIBILITY_PRESET ${CXX_VISIBILITY_PRESET})
-if (${CXX_VISIBILITY_PRESET} STREQUAL "hidden" AND VISIBILITY_MAP_FILE AND
+set (CMAKE_C_VISIBILITY_PRESET ${CMAKE_CXX_VISIBILITY_PRESET})
+if (${CMAKE_CXX_VISIBILITY_PRESET} STREQUAL "hidden" AND VISIBILITY_MAP_FILE AND
     (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG) AND
     (CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU"))
     # Linux/FreeBSD/Hurd: also hide all the symbols of dependent libraries

--- a/src/liboslexec/opcolor.h
+++ b/src/liboslexec/opcolor.h
@@ -27,7 +27,7 @@ class ShadingContext;
 namespace pvt {
 
 
-class ColorSystem {
+class OSLEXECPUBLIC ColorSystem {
 #ifdef __CUDACC__
     using Context = void*;
 #else

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -723,7 +723,7 @@ public:
     /// Set the current color space.
     bool set_colorspace(ustring colorspace);
 
-    int raytype_bit(ustring name);
+    OSLEXECPUBLIC int raytype_bit(ustring name);
 
     void optimize_all_groups(int nthreads = 0, int mythread = 0,
                              int totalthreads = 1, bool do_jit = true);

--- a/src/liboslexec/pointcloud.h
+++ b/src/liboslexec/pointcloud.h
@@ -15,7 +15,7 @@ namespace pvt {
 
 #ifdef USE_PARTIO
 
-class PointCloud {
+class OSLEXECPUBLIC PointCloud {
 public:
     PointCloud(ustringhash filename, Partio::ParticlesDataMutable* partio_cloud,
                bool write);


### PR DESCRIPTION
As Fabrice Macagno pointed out on the oiio-dev mail list, we weren't setting the correct variable name CMAKE_CXX_VISIBILITY_PRESET.

And, oops, this also revealed that there were some things that needed to be declared public that were not (because, specifically, they needed to be called across library boundaries by the per-ISA dynamic libraries used by batch shading!).
