### PR TITLE
Fix userdata derivatives for interpolated params on GPU

### DIFF
--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -563,6 +563,8 @@ BackendLLVM::llvm_assign_initial_value(const Symbol& sym, bool force)
             llvm::Value* dst = llvm_void_ptr(sym);
             TypeDesc t       = sym.typespec().simpletype();
             ll.op_memcpy(dst, src, t.size(), t.basesize());
+            if (sym.has_derivs())
+                llvm_zero_derivs(sym);
 #endif
         } else if (!sym.lockgeom() && !sym.typespec().is_closure()) {
             // geometrically-varying param; memcpy its default value


### PR DESCRIPTION
## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->
Following #1657, it turns out we forgot to zero initialize the userdata derivatives for the optix path. 
This leads to some rendering glitches caused by the memory garbage left in those derivatives.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

