### PR TITLE
docs: Update CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,10 @@ Contributors should be reading the osl-dev mail list:
 
 You can sign up for the mail list on your own using the link above.
 
-We also have an `openshadinglanguage` channel on the
-[ASWF Slack](https://slack.aswf.io/). But note that the Slack channel is
-not archived, so while it's ok for fleeting comments, it is unreliable as
-a permanent repository of useful information. Serious discussions that are
-we would want to refer to over time should be sent to the mail list instead.
+The [ASWF Slack](https://slack.aswf.io/) has an `openshadinglanguage` channel.
+Sign up for the Slack on your own, then under "channels", select "browse
+channels" and you should see the openshadinglanguage channel (among those of
+the other projects and working groups).
 
 
 Bug Reports and Issue Tracking
@@ -55,15 +54,16 @@ Contributor License Agreement (CLA) and Intellectual Property
 To protect the project -- and the contributors! -- we do require a
 Contributor License Agreement (CLA) for anybody submitting changes.
 
-* [Corporate CLA](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/ASWF/CLA-corporate.md)
+* [Corporate CLA](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/ASWF/CLA-corporate.md) :
   If you are writing the code as part of your job, or if there is any
   possibility that your employers might think they own any intellectual
   property you create. This needs to be executed by someone who has
   signatory power for the company.
 
-* [Individual CLA](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/ASWF/CLA-individual.md).
-  If you are an individual writing the code on your own time and you're SURE
-  you are the sole owner of any intellectual property you contribute.
+* [Individual CLA](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/ASWF/CLA-individual.md) :
+  If you are an individual writing the code on your own time, using your own
+  equipment, and you're SURE you are the sole owner of any intellectual
+  property you contribute.
 
 The easiest way to sign CLAs is digitally [using EasyCLA](https://corporate.v1.easycla.lfx.linuxfoundation.org).
 Companies who prefer not to use the online tools may sign, scan, and email
@@ -79,8 +79,7 @@ Please note that these CLAs are based on the Apache 2.0 CLAs, and differ
 minimally, only as much as was required to correctly describe the EasyCLA
 process and our use of a CLA manager.
 
-
-** Contribution sign off
+**Contribution sign off**
 
 ASWF requires the use of the [Developer’s Certificate of Origin 1.1
 (DCO)](https://developercertificate.org/), which is the same mechanism that
@@ -115,7 +114,8 @@ repository. The protocol is like this:
 own repository on GitHub, and then clone it to get a repository on your
 local machine.
 
-2. Edit, compile, and test your changes.
+2. Edit, compile, and test your changes.  Run clang-format (see the
+instructions on coding style below).
 
 3. Push your changes to your fork (each unrelated pull request to a separate
 "topic branch", please).
@@ -127,29 +127,25 @@ component that deserves extended discussion or debate among the wider OSL
 community, then it may be prudent to email osl-dev pointing everybody to
 the pull request URL and discussing any issues you think are important.
 
-6. The reviewer will look over the code and critique on the "comments" area,
+6. All pull requests automatically launch CI jobs on GitHub Actions to
+ensure that the build completes and that the tests suite runs correctly, for
+a variety of platform, compiler, library, and flag combinations. The status
+of the CI tests for your PR will be displayed on the GitHub PR page. We will
+not accept PRs that don't build cleanly or pass the existing testsuite.
+
+7. The reviewer will look over the code and critique on the "comments" area,
 or discuss in email. Reviewers may ask for changes, explain problems they
 found, congratulate the author on a clever solution, etc. But until somebody
 says "LGTM" (looks good to me), the code should not be committed. Sometimes
 this takes a few rounds of give and take. Please don't take it hard if your
 first try is not accepted. It happens to all of us.
 
-7. After approval, one of the senior developers (with commit approval to the
+8. After approval, one of the senior developers (with commit approval to the
 official main repository) will merge your fixes into the master branch.
 
 
 Coding Style
 ------------
-
-There are two overarching rules:
-
-1. When making changes, conform to the style and conventions of the surrounding code.
-
-2. Strive for clarity, even if that means occasionally breaking the
-guidelines. Use your head and ask for advice if your common sense seems to
-disagree with the conventions.
-
-Below we try to enumerate the guidelines embodied in the code.
 
 #### File conventions
 
@@ -158,115 +154,73 @@ All headers should contain
 
     #pragma once
 
+All source files should begin with these three lines:
 
-All source files should begin with the copyright and license, which can be
-found in the [LICENSE](LICENSE) file (or cut and pasted from any other other source
-file). Two notes on this:
+    // Copyright Contributors to the Open Shading Language project.
+    // SPDX-License-Identifier: BSD-3-Clause
+    // https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
-* For NEW source files, please change the copyright year to the present. DO
-NOT edit existing files only to update the copyright year, it just creates
-pointless deltas and offers no increased protection.
+as a comment in the syntax of whatever source code is used in that file (for
+example, for python or shell files, use `#` rather than `//`).
 
-* Occasionally a file contains substantial code from another project
-and will also list its copyright. Do NOT copy that notice to any new files,
-it really only applies to the particular file in which it appears.
+Occasionally a file may contain substantial code from another project and will
+also list its original copyright and license information. Do NOT alter that
+notice or copy it to any new files, it really only applies to the particular
+file in which it appears.
 
 #### Formatting
 
-We use clang-format to enforce formatting rules for the vast majority of the
-code base. It is automatically run during CI and is a CI failure if the code
-does not conform. There are, however, parts of the code base that are not
-clang-formatted, either because we have not yet put them under the
-clang-format regime, or because individual modules were deemed to be less
-clear with clang-format than with hand formatting.
+We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
+to uniformly format our source code prior to PR submission. Make sure that
+clang-format is installed on your local machine, and just run
 
-For non-clang-format regions of code, NEVER alter somebody else's code to
-reformat just because you found something that violates the rules. Let the
-group/author/leader know, and resist the temptation to change it yourself.
+    make clang-format
 
-Each line of text in your code should be at most 80 characters long.
-Exceptions are allowed for those rare cases where letting a line be longer
-(and wrapping on an 80-character window) is actually a better and clearer
-alternative than trying to split it into two lines. Sometimes this happens,
-but it's extremely rare.
+and it will automatically reformat your code according to the configuration
+file found in the `.clang-format` file at the root directory of the OIIO
+source code checkout.
 
-Indent 4 spaces at a time, and use actual spaces, not tabs. For files that
-must use tabs for some reason, tabs should always be on 8's. Most editors
-have a setting that forces indentations to be spaces. With emacs, you can do
-this:
+One of the CI test matrix entries runs clang-format and fails if any
+diffs were generated (that is, if any of your code did not 100% conform to
+the `.clang-format` formatting configuration). If it fails, clicking on that
+test log will show you the diffs generated, so that you can easily correct
+it on your end and update the PR with the formatting fixes.
 
-    (setq c-default-style "bsd")
-    (setq-default indent-tabs-mode nil)
+If you don't have clang-format set up on your machine, and your patch is not
+very long, you may find that it's more convenient to just submit it and hope
+for the best, and if it doesn't pass the CI test, look at the diffs in the log
+for the "clang-format" CI run and make the corrections by hand and then submit
+an update to the patch (i.e. relying on CI to run clang-format for you).
 
-Opening brace on the same line as the condition or loop.
+Because the basic formatting is automated by clang-format, we won't
+enumerate the rules here.
 
-One statement per line, except in rare cases where violating this rule makes
-the code more clear.
+For the occasional non-clang-format regions of code, NEVER alter somebody
+else's code to reformat just because you found something that violates the
+rules. Let the group/author/leader know, and resist the temptation to change
+it yourself.
 
-Three (3) consecutive empty lines between function or class method
-implementations, one blank line between method declarations within a class
-definition. Put a single blank line within a function if it helps to
-visually separate different sequential tasks. Don't put multiple blank lines
-in a row within a function, or blank lines right after an opening brace or
-right before a closing brace. The goal is to use just enough white space to
-help developers visually parse the code (for example, spotting at a glance
-where new functions begin), but not so much as to spread it out or be
-confusing.
+Each line of text in your code, including comments, should be at most 80
+characters long. Exceptions are allowed for those rare cases where letting a
+line be longer (and wrapping on an 80-character window) is actually a better
+and clearer alternative than trying to split it into two lines. Sometimes this
+happens, but it's extremely rare.
 
-For if, for, while, etc., put a space before the paren, but NOT inside the parens. For example:
+We prefer three (3) consecutive empty lines between freestanding functions or
+class definitions, one blank line between method declarations within a class
+definition. Put a single blank line within a function if it helps to visually
+separate different sequential tasks, but don't put multiple blank lines in a
+row within a function, or blank lines right after an opening brace or right
+before a closing brace. The goal is to use just enough white space to help
+developers visually parse the code (for example, spotting at a glance where
+new functions begin), but not so much as to spread it out or be confusing.
 
-    if (foo)    // Yes
-    
-    if(foo)     // No
-    if ( foo )  // No
-
-Function calls should have a space between the function name and the opening
-parenthesis, NO space inside the parenthesis, except for a single blank
-space between each argument. For example:
-
-    x = foo(a, b);      // Yes
-    
-    x = foo ( a, b );   // No
-    x = foo (a,b);      // No
-
-Function declarations: function names should begin at column 0 for a full
-function definition. (It's ok to violate this rule for very short inline
-functions within class definitions.)
-
-
-Here is a short code fragment that shows some of these rules in action:
-
-    static int
-    function(int a, int b)
-    {
-        int x = a + b;
-        if (a == 0 || b == 0) {
-            x += 1;
-            x *= 4;
-        } else {
-            x -= 3;
-        }
-        for (int i = 0;  i < 3;  ++i) {
-            x += a * i;
-            x *= foo(i);  // function call
-        }
-        return x;
-    }
-
-Don't ever reformat, re-indent, change whitespace, or make any other such
-changes to working code. If you're adding just a few lines or fixing a bug
-in existing code, stick to the style of the surrounding code. In very rare
-circumstances, and with consensus of the group, reformatting is sometimes
-helpful to improve code readability, but it should be done as a separate
-formatting-only checkin.
 
 #### Identifiers
 
-In general, classes and templates should start with upper case and capitalize new words:
-
-    class CustomerList;
-
-In general, local variables should start with lower case.
+In general, classes and templates should start with upper case and
+capitalize new words: `class CustomerList;` In general, local variables
+should start with lower case. Macros should be `ALL_CAPS`, if used at all.
 
 If your class is extremely similar to, or modeled after, something in the
 standard library, Boost, or something else we interoperate with, it's ok to
@@ -277,8 +231,6 @@ were standards.
 
     template <class T> shared_ptr;
     class scoped_mutex;
-
-Macros should be ALL_CAPS, if used at all.
 
 Names of data should generally be nouns. Functions/methods are trickier: a
 the name of a function that returns a value but has no side effects should
@@ -310,7 +262,7 @@ Prefer C++11 `std` rather than Boost or other third party libraries, where
 both can do the same task.
 
 If you see a third party library already used as a dependency (such as OIIO,
-Boost, Ilmbase, or LLVM), feel free to any of its public features in OSL
+Boost, Imath, or LLVM), feel free to any of its public features in OSL
 internals (provided those features are present in the minimum version of
 that library that we support).
 
@@ -334,9 +286,6 @@ protected members of classes), please use Doxygen-style comments. They looks
 like this:
 
     /// Explanation of a class.  Note THREE slashes!
-    /// Also, you need at least two lines like this.  If you don't have enough
-    /// for two lines, make one line blank like this:
-    ///
     class myclass {
         ....
         float foo;  ///< Doxygen comments on same line look like this


### PR DESCRIPTION
Tighten up some of the explanations and update obsolete parts of the CONTRIBUTING document.

This doesn't change any of our policies or procedures. But some advice was out of date or no longer applicable (for example, now that we use clang-format, we do not need to detail all the formatting rules, they are enforced automatically).
