### PR TITLE
ci: Fix package name for icc

### DIFF
--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -42,7 +42,7 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
 
     if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$CXX" == "icpx" || "$CC" == "icx" || "$USE_ICX" != "" ]] ; then
         sudo cp src/build-scripts/oneAPI.repo /etc/yum.repos.d
-        sudo /usr/bin/yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0-3768
+        sudo /usr/bin/yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0.x86_64
         # Because multiple (possibly newer) versions of oneAPI may be installed,
         # use a config file to specify compiler and tbb versions
         # NOTE: oneAPI components have independent version numbering.


### PR DESCRIPTION
The Intel yum repo renamed this package a couple weeks ago, and it broke our CI. Update to the new name.

