### PR TITLE
README.md: added filmography and Siggraph OSL course info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ Films using OSL (grouped by year of release date):
   Storks,
   Miss Peregrine's Home for Peculiar Children,
   Fantastic Beasts and Where to Find Them,
-  Assassin's Creed
+  Assassin's Creed,
+  Kubo and the Two Strings
 * **(2017)**
   Lego Batman,
   The Great Wall,
@@ -353,7 +354,8 @@ Films using OSL (grouped by year of release date):
   Richard Jewell,
   Game of Thrones (S8),
   Lost in Space (S1),
-  Togo
+  Togo,
+  Missing Link
 * **(2020)**
   Underwater,
   Birds of Prey,
@@ -427,6 +429,13 @@ The OSL language specification can be found at
 [src/doc/osl-languagespec.pdf](src/doc/osl-languagespec.pdf) (in a source
 distribution) or in the share/doc/OSL/osl-languagespec.pdf file of an
 installed binary distribution.
+
+For those interested in learning to program in OSL, there is the
+[Siggraph 2022](https://dl.acm.org/doi/proceedings/10.1145/3532720) course
+[OSL Shaders for RenderMan](https://dl.acm.org/doi/abs/10.1145/3532724.3535604),
+which uses RenderMan in the examples and
+[Supplementary Materials](https://github.com/LaikaStudios/OSLShadersForRenderMan),
+but which is primarily about shader writing in OSL.
 
 
 Contact & reporting problems


### PR DESCRIPTION
## Description

Updated README.md to include LAIKA films and added Siggraph OSL course info to Documentation.

## Checklist:

- [ x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x ] My code follows the prevailing code style of this project.

