### PR TITLE
Don't try to ReParameter symbols not in the group

### DIFF
--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -109,7 +109,7 @@ ShaderInstance::findsymbol(ustring name) const
 
 
 int
-ShaderInstance::findparam(ustring name) const
+ShaderInstance::findparam(ustring name, bool search_master) const
 {
     if (m_instsymbols.size())
         for (int i = m_firstparam, e = m_lastparam; i < e; ++i)
@@ -117,9 +117,11 @@ ShaderInstance::findparam(ustring name) const
                 return i;
 
     // Not found? Try the master.
-    for (int i = m_firstparam, e = m_lastparam; i < e; ++i)
-        if (master()->symbol(i)->name() == name)
-            return i;
+    if (search_master) {
+        for (int i = m_firstparam, e = m_lastparam; i < e; ++i)
+            if (master()->symbol(i)->name() == name)
+                return i;
+    }
 
     return -1;
 }

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1158,7 +1158,7 @@ public:
 
     /// Find the named parameter, return its index in the symbol array, or
     /// -1 if not found.
-    int findparam(ustring name) const;
+    int findparam(ustring name, bool search_master = true) const;
 
     /// Return a pointer to the symbol (specified by integer index),
     /// or NULL (if index was -1, as returned by 'findsymbol').

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3213,7 +3213,14 @@ ShadingSystemImpl::ReParameter(ShaderGroup& group, string_view layername_,
         return false;  // could not find the named layer
 
     // Find the named parameter within the layer
-    int paramindex = layer->findparam(ustring(paramname));
+    int paramindex = layer->findparam(ustring(paramname),
+                                      false /* don't go to master */);
+    if (paramindex < 0) {
+        paramindex = layer->findparam(ustring(paramname), true);
+        if (paramindex >= 0)
+            // This param exists, but it got optimized away, no failure
+            return true;
+    }
     if (paramindex < 0)
         return false;  // could not find the named parameter
 


### PR DESCRIPTION
Sometimes, after optimization, symbols tagged as interactive get removed because they are unused. But ReParameter is failing with errors because it goes looking for the removed symbol to master, which is, of course, not interactive. This patch avoids that so the symbol is not found, and then we just return false.


## Description

We found this issue in production because code was being removed, then symbols too, then reparameter failed. 
There is no other way to prevent the error than from inside OSL. I'm suggesting this change but any other way to
handle it would work for us.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

