### PR TITLE
build: Fix for Apple clang 14+ warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,7 @@ jobs:
                             QT_BREW_VERSION="@5"
           - desc: MacOS-12
             os: macos-12
-            nametag: macos11-p310
+            nametag: macos12-p310
             cc_compiler: /usr/local/opt/llvm@15/bin/clang
             cxx_compiler: /usr/local/opt/llvm@15/bin/clang++
             cxx_std: 17
@@ -459,6 +459,17 @@ jobs:
             aclang: 13
             setenvs: export LLVMBREWVER="@15" DO_BREW_UPDATE=1
                             OPENIMAGEIO_VERSION=master
+          - desc: MacOS-13
+            os: macos-13
+            nametag: macos13-p311
+            cc_compiler: /usr/local/opt/llvm@15/bin/clang
+            cxx_compiler: /usr/local/opt/llvm@15/bin/clang++
+            cxx_std: 17
+            python_ver: "3.11"
+            aclang: 14
+            setenvs: export LLVMBREWVER="@15" DO_BREW_UPDATE=1
+                            OPENIMAGEIO_VERSION=master
+
     runs-on: ${{matrix.os}}
     env:
       CXX: ${{matrix.cxx_compiler}}

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -165,6 +165,7 @@ if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
     # Suppress warnings about our strategic use of bitwise operations in place
     # of logical operators to produce branchless code in some places.
     if (CLANG_VERSION_STRING VERSION_GREATER_EQUAL 14.0
+        OR APPLECLANG_VERSION_STRING VERSION_GREATER_EQUAL 14.0
         OR INTELCLANG_VERSION_STRING VERSION_GREATER_EQUAL 14.0)
         add_compile_options ("-Wno-bitwise-instead-of-logical")
     endif ()

--- a/src/liboslcomp/oslgram.y
+++ b/src/liboslcomp/oslgram.y
@@ -28,7 +28,8 @@
 #pragma clang diagnostic ignored "-Wparentheses-equality"
 #endif
 
-#if (OSL_CLANG_VERSION >= 150000) || (OSL_INTEL_CLANG_VERSION >= 140000)
+#if (OSL_CLANG_VERSION >= 150000) || (OSL_APPLE_CLANG_VERSION >= 140000) \
+    || (OSL_INTEL_CLANG_VERSION >= 140000)
 #pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 

--- a/src/liboslexec/osogram.y
+++ b/src/liboslexec/osogram.y
@@ -27,7 +27,8 @@
 #pragma clang diagnostic ignored "-Wparentheses-equality"
 #endif
 
-#if (OSL_CLANG_VERSION >= 150000) || (OSL_INTEL_CLANG_VERSION >= 140000)
+#if (OSL_CLANG_VERSION >= 150000) || (OSL_APPLE_CLANG_VERSION >= 140000) \
+    || (OSL_INTEL_CLANG_VERSION >= 140000)
 #pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #endif
 


### PR DESCRIPTION
Also add a MacOS 13 test to the CI matrix.
