### PR TITLE
fix: Have ReParameter only copy data when it changes

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -999,6 +999,10 @@ private:
     long long m_stat_pointcloud_writes;
     atomic_ll m_stat_layers_executed;           ///< Total layers executed
     atomic_ll m_stat_total_shading_time_ticks;  ///< Total shading time (ticks)
+    atomic_ll m_stat_reparam_calls_total;
+    atomic_ll m_stat_reparam_bytes_total;
+    atomic_ll m_stat_reparam_calls_changed;
+    atomic_ll m_stat_reparam_bytes_changed;
 
     int m_stat_max_llvm_local_mem;     ///< Stat: max LLVM local mem
     PeakCounter<off_t> m_stat_memory;  ///< Stat: all shading system memory

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1111,6 +1111,10 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
     m_stat_pointcloud_writes                 = 0;
     m_stat_layers_executed                   = 0;
     m_stat_total_shading_time_ticks          = 0;
+    m_stat_reparam_calls_total               = 0;
+    m_stat_reparam_bytes_total               = 0;
+    m_stat_reparam_calls_changed             = 0;
+    m_stat_reparam_bytes_changed             = 0;
 
     m_groups_to_compile_count     = 0;
     m_threads_currently_compiling = 0;
@@ -1799,6 +1803,14 @@ ShadingSystemImpl::getattribute(string_view name, TypeDesc type, void* val)
     ATTR_DECODE("stat:pointcloud_max_results", int,
                 m_stat_pointcloud_max_results);
     ATTR_DECODE("stat:pointcloud_failures", int, m_stat_pointcloud_failures);
+    ATTR_DECODE("stat:reparam_calls_total", long long,
+                m_stat_reparam_calls_total);
+    ATTR_DECODE("stat:reparam_bytes_total", long long,
+                m_stat_reparam_bytes_total);
+    ATTR_DECODE("stat:reparam_calls_changed", long long,
+                m_stat_reparam_calls_changed);
+    ATTR_DECODE("stat:reparam_bytes_changed", long long,
+                m_stat_reparam_bytes_changed);
     ATTR_DECODE("stat:memory_current", long long, m_stat_memory.current());
     ATTR_DECODE("stat:memory_peak", long long, m_stat_memory.peak());
     ATTR_DECODE("stat:mem_master_current", long long,
@@ -2485,6 +2497,14 @@ ShadingSystemImpl::getstats(int level) const
         out << "    pointcloud_get calls: " << m_stat_pointcloud_gets << "\n";
         out << "    pointcloud_write calls: " << m_stat_pointcloud_writes
             << "\n";
+    }
+    if (m_stat_reparam_calls_total) {
+        print(out,
+              "  ReParameter: {} calls ({}) total, changed {} calls ({})\n",
+              (long long)m_stat_reparam_calls_total,
+              OIIO::Strutil::memformat(m_stat_reparam_bytes_total),
+              (long long)m_stat_reparam_calls_changed,
+              OIIO::Strutil::memformat(m_stat_reparam_bytes_changed));
     }
     out << "  Memory total: " << m_stat_memory.memstat() << '\n';
     out << "    Master memory: " << m_stat_mem_master.memstat() << '\n';
@@ -3252,12 +3272,18 @@ ShadingSystemImpl::ReParameter(ShaderGroup& group, string_view layername_,
         return false;
 
     // Do the deed
-    int offset = group.interactive_param_offset(layerindex, sym->name());
-    memcpy(group.interactive_arena_ptr() + offset, val, type.size());
-    if (use_optix()) {
-        renderer()->copy_to_device(group.device_interactive_arena().d_get()
-                                       + offset,
-                                   val, type.size());
+    int offset  = group.interactive_param_offset(layerindex, sym->name());
+    size_t size = type.size();
+    m_stat_reparam_calls_total += 1;
+    m_stat_reparam_bytes_total += size;
+    if (memcmp(group.interactive_arena_ptr() + offset, val, size)) {
+        memcpy(group.interactive_arena_ptr() + offset, val, type.size());
+        if (use_optix())
+            renderer()->copy_to_device(group.device_interactive_arena().d_get()
+                                           + offset,
+                                       val, type.size());
+        m_stat_reparam_calls_changed += 1;
+        m_stat_reparam_bytes_changed += size;
     }
     return true;
 }


### PR DESCRIPTION
For GPU in particular, this prevents needless transfers to the device when no values actually change.

Also, keep track of some statistics about how much ReParameter is being used. (Which also helps to verify that this change works as intended.)
