### PR TITLE
Zero derivs for interactive params when needed

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3283,11 +3283,15 @@ RuntimeOptimizer::run()
                 // interactive parameter, including correct alignment.
                 size_t offset    = interactive_data.size();
                 size_t typesize  = s.typespec().simpletype().size();
+                size_t totalsize = typesize * (s.has_derivs() ? 3 : 1);
                 size_t alignment = typesize > 4 ? 8 : 4;
                 offset = OIIO::round_to_multiple_of_pow2(offset, alignment);
-                interactive_data.resize(offset + typesize);
+                interactive_data.resize(offset + totalsize);
                 // Copy from the instance value to the interactive block
                 memcpy(&interactive_data[offset], s.data(), typesize);
+                if (totalsize > typesize)
+                    memset(&interactive_data[offset] + typesize, 0,
+                           totalsize - typesize);
                 // Make sure the symbol remembers it's stored in the interactive
                 // arena with the right offset.
                 group().add_interactive_param(layer, s.name(), offset);


### PR DESCRIPTION
Sometimes an interactive param is used in a way that gets flagged as needing derivs. But we were neither allocating space for that nor zeroing them. This resulted on memory corruption.


## Description

This fixes incorrect renders in a production context where params are often tagged as needing derivs.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

