### PR TITLE
ci: Simplify build_llvm.bash script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,8 +340,8 @@ jobs:
             python_ver: "3.10"
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
-            setenvs: export LLVM_VERSION=13.0.0
-                            LLVM_DISTRO_NAME=ubuntu-20.04
+            setenvs: export LLVM_VERSION=14.0.0
+                            LLVM_DISTRO_NAME=ubuntu-18.04
                             OPENCOLORIO_VERSION=v2.2.0
                             PUGIXML_VERSION=v1.13
           - desc: bleeding edge gcc12/C++17 llvm14 oiio/ocio/exr/pybind-master boost1.71 py3.10 avx2 batch-b16avx512
@@ -356,7 +356,7 @@ jobs:
             python_ver: "3.10"
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
-            setenvs: export LLVM_VERSION=14.0.0
+            setenvs: export LLVM_VERSION=15.0.6
                             LLVM_DISTRO_NAME=ubuntu-18.04
                             OPENCOLORIO_VERSION=main
                             PUGIXML_VERSION=master

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -14,29 +14,18 @@ uname
 
 
 if [[ `uname` == "Linux" ]] ; then
-    LLVM_VERSION=${LLVM_VERSION:=14.0.0}
-    LLVM_INSTALL_DIR=${LLVM_INSTALL_DIR:=${PWD}/llvm-install}
-    if [[ "$GITHUB_WORKFLOW" != "" ]] ; then
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-18.04}
-    elif [[ "$TRAVIS_DIST" == "trusty" ]] ; then
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-14.04}
-    elif [[ "$TRAVIS_DIST" == "xenial" ]] ; then
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-16.04}
-    elif [[ "$TRAVIS_DIST" == "bionic" ]] ; then
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=ubuntu-18.04}
-    else
-        LLVM_DISTRO_NAME=${LLVM_DISTRO_NAME:=error}
-    fi
+    : ${LLVM_VERSION:=14.0.0}
+    : ${LLVM_INSTALL_DIR:=${PWD}/llvm-install}
+    : ${LLVM_DISTRO_NAME:=ubuntu-18.04}
     LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
     echo LLVMTAR = $LLVMTAR
-    if [[ "$LLVM_VERSION" == "10.0.0" ]] || [[ "$LLVM_VERSION" == "11.0.0" ]] \
-      || [[ "$LLVM_VERSION" == "11.1.0" ]] || [[ "$LLVM_VERSION" == "12.0.0" ]] \
-      || [[ "$LLVM_VERSION" == "13.0.0" ]]  || [[ "$LLVM_VERSION" == "14.0.0" ]] ;
+    if [[ "$LLVM_VERSION" == "9.0.0" ]] || [[ "$LLVM_VERSION" == "9.0.1" ]] ;
     then
+        # old -- get rid of this when LLVM 10 is the newest we allow
+        curl --location http://releases.llvm.org/${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
+    else
         # new
         curl --location https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
-    else
-        curl --location http://releases.llvm.org/${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
     fi
     ls -l $LLVMTAR
     tar xf $LLVMTAR


### PR DESCRIPTION
* Remove leftover logic from when we used TravisCI.
* Pick a default for LLVM_DISTRO_NAME so it works when the script is run standalone when not on GitHub Actions CI.
* Switch the logic about file location to enumerate only the couple of old versions that uses the old download location, rather than trying to enumerate an ever-growing set of modern releases that use the current download location.
* Comment o say that when LLVM 10+ is the floor, the old case can go away entirely.

Also bump the CI "bleeding edge" test to use LLVM 15.0.6.
