### PR TITLE
ci: Lock down icx version

### DIFF
--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -40,22 +40,23 @@ if [[ "$ASWF_ORG" != ""  ]] ; then
         popd
     fi
 
-    if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$CXX" == "icpx" || "$CC" == "icx" || "$USE_ICX" != "" ]] ; then
+    if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" ]] ; then
+        # Lock down icc to 2022.1 because newer versions hosted on the Intel
+        # repo require a glibc too new for the ASWF CentOS7-based containers
+        # we run CI on.
         sudo cp src/build-scripts/oneAPI.repo /etc/yum.repos.d
         sudo /usr/bin/yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0.x86_64
-        # Because multiple (possibly newer) versions of oneAPI may be installed,
-        # use a config file to specify compiler and tbb versions
-        # NOTE: oneAPI components have independent version numbering.
         set +e; source /opt/intel/oneapi/setvars.sh --config oneapi_2022.1.0.cfg; set -e
-
-        if [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" ]] ; then
-            echo "Verifying installation of Intel(r) C++ Compiler:"
-            icpc --version
-        fi
-        if [[ "$CXX" == "icpx" || "$CC" == "icx" || "$USE_ICX" != "" ]] ; then
-            echo "Verifying installation of Intel(r) oneAPI DPC++/C++ Compiler:"
-            icpx --version
-        fi
+    elif [[ "$CXX" == "icpc" || "$CC" == "icc" || "$USE_ICC" != "" || "$CXX" == "icpx" || "$CC" == "icx" || "$USE_ICX" != "" ]] ; then
+        # Lock down icx to 2023.1 because newer versions hosted on the Intel
+        # repo require a libstd++ too new for the ASWF containers we run CI on
+        # because their default install of gcc 9 based toolchain.
+        sudo cp src/build-scripts/oneAPI.repo /etc/yum.repos.d
+        sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.1.0.x86_64
+        # sudo yum install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        set +e; source /opt/intel/oneapi/setvars.sh; set -e
+        echo "Verifying installation of Intel(r) oneAPI DPC++/C++ Compiler:"
+        icpx --version
     fi
 
 else


### PR DESCRIPTION
Intel's servers have again updated the default icx that you get when you install from their yum repository, and the new one seems incompatible with our libstdc++ toolchain. So lock down on 2023.1.0 for now so that our CI can pass.

This is copied from a similar fix in OIIO.

Actually, it turns out that OSL had previously locked down to 2022.1, but that was only for the sake of icc; icx could have been newer all along (and was in OIIO's CI). So really, we are bumping icx *forward* for OSL's CI testing... but not all the way forward, only to the most recent version that still runs properly on our CI runners.
