### PR TITLE
admin: Add missing copyright notice to many files

### DIFF
--- a/src/build-scripts/ci-coverage.bash
+++ b/src/build-scripts/ci-coverage.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
 # Run code coverage analysis
 # This assumes that the build occurred with CODECOV=1 andtests have already
 # fully run.

--- a/src/build-scripts/save-env.bash
+++ b/src/build-scripts/save-env.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
 # Save the env for use by other stages. Exclude things that we know aren't
 # needed.
 printenv \

--- a/src/shaders/mandelbrot.osl
+++ b/src/shaders/mandelbrot.osl
@@ -1,7 +1,6 @@
-/////////////////////////////////////////////////////////////////////////////
 // Copyright Contributors to the Open Shading Language project.
-// BSD licensed, see https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
-/////////////////////////////////////////////////////////////////////////////
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 
 

--- a/testsuite/andor-reg/a_float_u_b_float_u.osl
+++ b/testsuite/andor-reg/a_float_u_b_float_u.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_float_u_b_float_u (output vector cout = 0, output vector mcout = 0)
 {
     float a = 1/raytype("camera")*5 ;

--- a/testsuite/bitwise-and-reg/a_u_b_u.osl
+++ b/testsuite/bitwise-and-reg/a_u_b_u.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_u_b_u (output vector cout = 0, output vector mcout = 0) 
 {
     int a = raytype("camera")*10;

--- a/testsuite/bitwise-and-reg/a_u_b_v.osl
+++ b/testsuite/bitwise-and-reg/a_u_b_v.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_u_b_v (output vector cout = 0, output vector mcout = 0) 
 {
     int a = 2;

--- a/testsuite/bitwise-and-reg/a_v_b_u.osl
+++ b/testsuite/bitwise-and-reg/a_v_b_u.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_v_b_u (output vector cout = 0, output vector mcout = 0) 
 {
     int a = int(P[0])*10;

--- a/testsuite/bitwise-and-reg/a_v_b_v.osl
+++ b/testsuite/bitwise-and-reg/a_v_b_v.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_v_b_v(output vector cout = 0, output vector mcout = 0) 
 {
     int a = int(P[0])*10;

--- a/testsuite/bitwise-and-reg/a_v_b_vconditional.osl
+++ b/testsuite/bitwise-and-reg/a_v_b_vconditional.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_v_b_vconditional (output vector cout = 0, output vector mcout = 0) 
 {
     int a = int(P[0])*10;

--- a/testsuite/bitwise-and-reg/a_vconditional_b_u.osl
+++ b/testsuite/bitwise-and-reg/a_vconditional_b_u.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_vconditional_b_u (output vector cout = 0, output vector mcout = 0) 
 {
     int a = (P[0] < 0.5);

--- a/testsuite/bitwise-and-reg/a_vconditional_b_v.osl
+++ b/testsuite/bitwise-and-reg/a_vconditional_b_v.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_vconditional_b_v (output vector cout = 0, output vector mcout = 0) 
 {
     int a = (P[0] < 0.5);

--- a/testsuite/bitwise-and-reg/a_vconditional_b_vconditional.osl
+++ b/testsuite/bitwise-and-reg/a_vconditional_b_vconditional.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_vconditional_b_vconditional (output vector cout = 0, output vector mcout = 0) 
 {
     int a = (P[0] < 0.5);

--- a/testsuite/bitwise-xor-reg/a_v_b_v.osl
+++ b/testsuite/bitwise-xor-reg/a_v_b_v.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_v_b_v(output vector cout = 0, output vector mcout = 0) 
 {
     int a = int(P[0])*10;

--- a/testsuite/bitwise-xor-reg/a_v_b_vconditional.osl
+++ b/testsuite/bitwise-xor-reg/a_v_b_vconditional.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_v_b_vconditional (output vector cout = 0, output vector mcout = 0) 
 {
     int a = int(P[0])*10;

--- a/testsuite/bitwise-xor-reg/a_vconditional_b_u.osl
+++ b/testsuite/bitwise-xor-reg/a_vconditional_b_u.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_vconditional_b_u (output vector cout = 0, output vector mcout = 0) 
 {
     int a = (P[0] < 0.5);

--- a/testsuite/bitwise-xor-reg/a_vconditional_b_v.osl
+++ b/testsuite/bitwise-xor-reg/a_vconditional_b_v.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_vconditional_b_v (output vector cout = 0, output vector mcout = 0) 
 {
     int a = (P[0] < 0.5);

--- a/testsuite/bitwise-xor-reg/a_vconditional_b_vconditional.osl
+++ b/testsuite/bitwise-xor-reg/a_vconditional_b_vconditional.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader a_vconditional_b_vconditional (output vector cout = 0, output vector mcout = 0) 
 {
     int a = (P[0] < 0.5);

--- a/testsuite/blackbody-reg/blackbody_u_temperature.osl
+++ b/testsuite/blackbody-reg/blackbody_u_temperature.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader blackbody_u_temperature (output color Cout = 0, output color mCout = 0)
 {
     float T = 10000.0*(1.0/(2*raytype("camera")));   // map u range from 0K to 10,000K

--- a/testsuite/blackbody-reg/blackbody_v_temperature.osl
+++ b/testsuite/blackbody-reg/blackbody_v_temperature.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader blackbody_v_temperature (output color Cout = 0, output color mCout = 0)
 {
     float T = 10000.0*u;    // map u range from 0K to 10,000K

--- a/testsuite/color-reg/test_color_3xu_float.osl
+++ b/testsuite/color-reg/test_color_3xu_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_color_3xu_float (output color Cout = 0)
 {

--- a/testsuite/color-reg/test_color_u_space_3xv_dfloat.osl
+++ b/testsuite/color-reg/test_color_u_space_3xv_dfloat.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_color_u_space_3xv_dfloat (string colorspace = "--param colorspace must_be_provided", output color Cout = 0)
 {

--- a/testsuite/color-reg/test_color_u_space_3xv_float.osl
+++ b/testsuite/color-reg/test_color_u_space_3xv_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_color_u_space_3xv_float (string colorspace = "--param colorspace must_be_provided", output color Cout = 0)
 {

--- a/testsuite/color-reg/test_color_v_dfloat.osl
+++ b/testsuite/color-reg/test_color_v_dfloat.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_color_v_dfloat(output color Cout = 0)
 {

--- a/testsuite/color-reg/test_color_v_float.osl
+++ b/testsuite/color-reg/test_color_v_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_color_v_float (output color Cout = 0)
 {

--- a/testsuite/color-reg/test_color_v_space_3xu_float.osl
+++ b/testsuite/color-reg/test_color_v_space_3xu_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_color_v_space_3xu_float (output color Cout = 0)
 {

--- a/testsuite/color-reg/test_color_v_space_3xv_dfloat.osl
+++ b/testsuite/color-reg/test_color_v_space_3xv_dfloat.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_color_v_space_3xv_dfloat (output color Cout = 0)
 {

--- a/testsuite/color-reg/test_color_v_space_3xv_float.osl
+++ b/testsuite/color-reg/test_color_v_space_3xv_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_color_v_space_3xv_float (output color Cout = 0)
 {

--- a/testsuite/common/shaders/pretty.h
+++ b/testsuite/common/shaders/pretty.h
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 // pretty(x) rounds very small values to zero and turns -0 values into +0.
 // This is useful for testsuite to eliminate some pesky LSB errors that
 // cause reference output to differ between platforms.

--- a/testsuite/length-reg/test_length_u_normal.osl
+++ b/testsuite/length-reg/test_length_u_normal.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_length_u_normal (output color Cout = 0)
 {

--- a/testsuite/length-reg/test_length_u_vector.osl
+++ b/testsuite/length-reg/test_length_u_vector.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_length_u_vector (output color Cout = 0)
 {

--- a/testsuite/length-reg/test_length_v_dnormal.osl
+++ b/testsuite/length-reg/test_length_v_dnormal.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_length_v_dnormal (output color Cout = 0)
 {

--- a/testsuite/length-reg/test_length_v_dvector.osl
+++ b/testsuite/length-reg/test_length_v_dvector.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_length_v_dvector (output color Cout = 0)
 {

--- a/testsuite/length-reg/test_length_v_normal.osl
+++ b/testsuite/length-reg/test_length_v_normal.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_length_v_normal (output color Cout = 0)
 {

--- a/testsuite/length-reg/test_length_v_vector.osl
+++ b/testsuite/length-reg/test_length_v_vector.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_length_v_vector (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_u_float_u_float_u_float.osl
+++ b/testsuite/mix-reg/test_mix_u_float_u_float_u_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_u_float_u_float_u_float (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_float_v_float_v_float.osl
+++ b/testsuite/mix-reg/test_mix_v_float_v_float_v_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_float_v_float_v_float (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_vector_u_vector_u_float.osl
+++ b/testsuite/mix-reg/test_mix_v_vector_u_vector_u_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_vector_u_vector_u_float (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_vector_u_vector_u_vector.osl
+++ b/testsuite/mix-reg/test_mix_v_vector_u_vector_u_vector.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_vector_u_vector_u_vector (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_vector_u_vector_v_float.osl
+++ b/testsuite/mix-reg/test_mix_v_vector_u_vector_v_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_vector_u_vector_v_float (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_vector_u_vector_v_vector.osl
+++ b/testsuite/mix-reg/test_mix_v_vector_u_vector_v_vector.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_vector_u_vector_v_vector (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_vector_v_vector_u_float.osl
+++ b/testsuite/mix-reg/test_mix_v_vector_v_vector_u_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_vector_v_vector_u_float (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_vector_v_vector_u_vector.osl
+++ b/testsuite/mix-reg/test_mix_v_vector_v_vector_u_vector.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_vector_v_vector_u_vector (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_vector_v_vector_v_float.osl
+++ b/testsuite/mix-reg/test_mix_v_vector_v_vector_v_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_vector_v_vector_v_float (output color Cout = 0)
 {

--- a/testsuite/mix-reg/test_mix_v_vector_v_vector_v_vector.osl
+++ b/testsuite/mix-reg/test_mix_v_vector_v_vector_v_vector.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_mix_v_vector_v_vector_v_vector (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_u_color_u_color_u_color.osl
+++ b/testsuite/select-reg/test_u_color_u_color_u_color.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_u_color_u_color_u_color (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_v_float_u_float_u_float.osl
+++ b/testsuite/select-reg/test_v_float_u_float_u_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_v_float_u_float_u_float (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_v_float_u_float_u_int.osl
+++ b/testsuite/select-reg/test_v_float_u_float_u_int.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_v_float_u_float_u_int (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_v_float_u_float_v_float.osl
+++ b/testsuite/select-reg/test_v_float_u_float_v_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_v_float_u_float_v_float (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_v_float_u_float_v_int.osl
+++ b/testsuite/select-reg/test_v_float_u_float_v_int.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_v_float_u_float_v_int (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_v_float_v_float_u_float.osl
+++ b/testsuite/select-reg/test_v_float_v_float_u_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_v_float_v_float_u_float (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_v_float_v_float_u_int.osl
+++ b/testsuite/select-reg/test_v_float_v_float_u_int.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_v_float_v_float_u_int (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_v_float_v_float_v_float.osl
+++ b/testsuite/select-reg/test_v_float_v_float_v_float.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_v_float_v_float_v_float (output color Cout = 0)
 {

--- a/testsuite/select-reg/test_v_float_v_float_v_int.osl
+++ b/testsuite/select-reg/test_v_float_v_float_v_int.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader
 test_v_float_v_float_v_int (output color Cout = 0)
 {

--- a/testsuite/spline-reg/runspline.h
+++ b/testsuite/spline-reg/runspline.h
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 void init_knots (output float fltknots[16], float scale)
 {
    fltknots[ 0] =  0.0 * scale;

--- a/testsuite/spline-reg/test_deriv_spline_c_float_c_colorarray.osl
+++ b/testsuite/spline-reg/test_deriv_spline_c_float_c_colorarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runspline.h"
 
 shader test_deriv_spline_c_float_c_colorarray (

--- a/testsuite/splineinverse-knots-ascend-reg/runsplineinverse.h
+++ b/testsuite/splineinverse-knots-ascend-reg/runsplineinverse.h
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 
 #if 1
 void init_knots (output float fltknots[16], float scale)

--- a/testsuite/splineinverse-knots-descend-reg/runsplineinverse.h
+++ b/testsuite/splineinverse-knots-descend-reg/runsplineinverse.h
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 void init_knots (output float fltknots[16], float scale)
 {
    // splineinverse requires only increasing or decreasing values

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_c_float_c_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_c_float_c_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_c_float_c_floatarray (

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_c_float_u_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_c_float_u_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_c_float_u_floatarray (

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_c_float_v_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_c_float_v_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_c_float_v_floatarray (

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_u_float_c_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_u_float_c_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_u_float_c_floatarray (

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_u_float_u_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_u_float_u_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_u_float_u_floatarray (

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_u_float_v_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_u_float_v_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_u_float_v_floatarray (

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_v_float_c_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_v_float_c_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_v_float_c_floatarray (

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_v_float_u_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_v_float_u_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_v_float_u_floatarray (

--- a/testsuite/splineinverse-knots-descend-reg/test_splineinverse_v_float_v_floatarray.osl
+++ b/testsuite/splineinverse-knots-descend-reg/test_splineinverse_v_float_v_floatarray.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 #include "runsplineinverse.h"
 
 shader test_splineinverse_v_float_v_floatarray (

--- a/testsuite/struct-init-copy/Astruct.h
+++ b/testsuite/struct-init-copy/Astruct.h
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 
 struct Astruct {
     float s, t;

--- a/testsuite/struct-layers/defs.h
+++ b/testsuite/struct-layers/defs.h
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 struct coords {
     float s, t;
 };

--- a/testsuite/wavelength_color-reg/wavelength_u_lambda_masked.osl
+++ b/testsuite/wavelength_color-reg/wavelength_u_lambda_masked.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader wavelength_u_lambda_masked (output color Cout = 0)
 {
     float lambda = 1.0/(2*raytype("camera"));

--- a/testsuite/wavelength_color-reg/wavelength_v_lambda.osl
+++ b/testsuite/wavelength_color-reg/wavelength_v_lambda.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader wavelength_v_lambda (output color Cout = 0)
 {
     float lambda = 380+u*320; //Increase visibility

--- a/testsuite/wavelength_color-reg/wavelength_v_lambda_masked.osl
+++ b/testsuite/wavelength_color-reg/wavelength_v_lambda_masked.osl
@@ -1,3 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
 shader wavelength_v_lambda_masked (output color Cout = 0)
 {
     float lambda = 0.18*u;


### PR DESCRIPTION
Our latest license scan from LF reveailed that the usual copyright and license declaration was missing on many shader source files in testsuite. This was never intentional, it was simply overlooked for certain test files. Just add the standard notice to those files.

