### PR TITLE
Restore stubs for printf (fixes OptiX problems with 1702)

### DIFF
--- a/src/liboslexec/builtindecl.h
+++ b/src/liboslexec/builtindecl.h
@@ -126,6 +126,12 @@ DECL(osl_gen_warningfmt, "xXhiXiX")
 DECL(osl_split, "isXsii")
 DECL(osl_incr_layers_executed, "xX")
 
+// For legacy printf support
+DECL(osl_printf, "xXs*")
+DECL(osl_fprintf, "xXss*")
+DECL(osl_error, "xXs*")
+DECL(osl_warning, "xXs*")
+
 NOISE_IMPL(cellnoise)
 //NOISE_DERIV_IMPL(cellnoise)
 NOISE_IMPL(hashnoise)

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -12,6 +12,7 @@
 
 #include <cstdarg>
 
+#include <OpenImageIO/filesystem.h>
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/strutil.h>
 
@@ -161,6 +162,8 @@ osl_format(const char* format_str, ...)
     return ustring(s).c_str();
 }
 
+
+
 OSL_SHADEOP int
 osl_split(const char* str, ustring* results, const char* sep, int maxsplit,
           int resultslen)
@@ -173,6 +176,38 @@ osl_split(const char* str, ustring* results, const char* sep, int maxsplit,
         results[i] = ustring(splits[i]);
     return n;
 }
+
+
+
+////////
+// The osl_printf, osl_error, osl_warning, and osl_fprintf are deprecated but
+// the stubs are needed for now to prevent breaking OptiX-based renderers who
+// aren't quite ready to refactor around the journaling print family of
+// functions. They eventually can be removed when we're happy that all the
+// compliant renderers have adapted.
+
+OSL_SHADEOP void
+osl_printf(ShaderGlobals* sg, const char* format_str, ...)
+{
+}
+
+OSL_SHADEOP void
+osl_error(ShaderGlobals* sg, const char* format_str, ...)
+{
+}
+
+OSL_SHADEOP void
+osl_warning(ShaderGlobals* sg, const char* format_str, ...)
+{
+}
+
+OSL_SHADEOP void
+osl_fprintf(ShaderGlobals* /*sg*/, const char* filename, const char* format_str,
+            ...)
+{
+}
+
+////////
 
 
 }  // end namespace pvt


### PR DESCRIPTION
The recently merged PR 1702 fails all the OptiX tests. I tracked down the problem and it's that the patch was a bit too aggressive about removing things no longer needed. The intent was that even if you don't use the new journaling, nothing should break. But it does break for OptiX, and this patch restores some of the functions 1702 removed (like the implementation of osl_printf) and some other necessary stubs.

This takes us from failing all ~150 OptiX oriented tests to failing only 4, which I believe are unrelated to 1702 and are merely revealed by them. I will fix those in a separate PR.

