### PR TITLE
Draft: Remove more unnecessary conditional run layer calls

### DIFF
--- a/src/liboslexec/backendllvm.h
+++ b/src/liboslexec/backendllvm.h
@@ -61,6 +61,7 @@ public:
     // Create llvm functions for OptiX callables
     std::vector<llvm::Function*> build_llvm_optix_callables();
     llvm::Function* build_llvm_fused_callable();
+    llvm::Function* build_check_layer_skip_stub();
 
     /// Build up LLVM IR code for the given range [begin,end) or
     /// opcodes, putting them (initially) into basic block bb (or the

--- a/src/liboslexec/opstring.cpp
+++ b/src/liboslexec/opstring.cpp
@@ -175,7 +175,6 @@ osl_printf(ShaderGlobals* sg, const char* format_str, ...)
     sg->context->messagefmt("{}", s);
 }
 
-
 OSL_SHADEOP void
 osl_error(ShaderGlobals* sg, const char* format_str, ...)
 {


### PR DESCRIPTION
This PR is a work-in-progress that I've hit a (hopefully) minor stumbling block on.

#### Overview
@tgrant-nv was looking at some of our shader ptx awhile ago and pointed out that a surprisingly high amount of the total instructions were just conditional layer call checks (due to all the stores and loads surrounding calls). The concern was that this was slowing down OptiX module compilation.

OSL has some basic checks in place to remove unnecessary conditional layer calls, but this patch takes things further. The high level strategy is:

* Mark all our conditional layer calls during llvm generation
* Run a custom llvm optimization pass that associates calls with their basic blocks
* For each call, walk up llvm's dominator tree to find basic blocks guaranteed to have already run
* If a guaranteed basic block already contains the same call as the current one, remove the current one

It doesn't help the compilation times for every shader, but we've seen improvements as speedups as 5x on some of our most expensive shaders.

#### Work in progress
The problem I've run into is that the optimization pass introduces quite a bit of overhead to the ptx generation. Most assets take 10-20% longer to generate ptx with this patch. For us, it's probably still a good trade to turn on for GPU, but I was hoping some more eyes could help improve things. Especially since I've never written a LLVM pass before, maybe I'm doing things particularly inefficiently.

Any feedback or ideas would be appreciated!


## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project.

