### PR TITLE
fix: Recent journaling changes break with some fmtlib versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
             os: ubuntu-22.04
             cxx_compiler: g++-11
             cxx_std: 17
-            fmt_ver: 9.1.0
+            fmt_ver: 10.1.0
             openexr_ver: v3.1.7
             openimageio_ver: master
             pybind11_ver: v2.10.0

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -46,7 +46,7 @@ ScopeExit print_node_counts([]() {
     for (int i = 0; i < ASTNode::_last_node; ++i)
         if (node_counts[i] > 0)
             Strutil::print("ASTNode type {:2}: {:5}   (peak {:5})\n", i,
-                           node_counts[i], node_counts_peak[i]);
+                           node_counts[i].load(), node_counts_peak[i].load());
 });
 }  // namespace
 #endif

--- a/src/liboslexec/journal.cpp
+++ b/src/liboslexec/journal.cpp
@@ -338,13 +338,13 @@ Reader::process()
     if (m_org.additional_bytes_required != 0) {
         std::string overfill_message = OSL::fmtformat(
             "Journal sized {} bytes couldn't capture all prints, warnings, and errors.  Additional {} bytes would be required",
-            m_org.buf_size, m_org.additional_bytes_required);
+            m_org.buf_size, m_org.additional_bytes_required.load());
         m_reporter.report_warning(-1, -1, overfill_message);
     }
     if (m_org.exceeded_page_size != 0) {
         std::string exceeded_message = OSL::fmtformat(
             "Journal page size {} exceeded, largest individual message sized {} bytes.  Consider increasing your page size.",
-            m_org.page_size, m_org.exceeded_page_size);
+            m_org.page_size, m_org.exceeded_page_size.load());
         m_reporter.report_warning(-1, -1, exceeded_message);
     }
 }


### PR DESCRIPTION
Certain fmt library versions don't automatically know how to format atomics. Explicitly load them to turn into regular ints to avoid new build errors introduced by the recent journaling changes.

