### PR TITLE
Add missing members to ShaderGlobals in rend_lib.h

### DIFF
--- a/src/testrender/cuda/rend_lib.h
+++ b/src/testrender/cuda/rend_lib.h
@@ -99,6 +99,8 @@ struct ShaderGlobals {
     float3 Ps, dPsdx, dPsdy;
     void* renderstate;
     void* shadingStateUniform;
+    int thread_index;
+    int shade_index;
     void* tracedata;
     void* objdata;
     void* context;

--- a/src/testrender/cuda/rend_lib.h
+++ b/src/testrender/cuda/rend_lib.h
@@ -98,12 +98,12 @@ struct ShaderGlobals {
     float3 dPdtime;
     float3 Ps, dPsdx, dPsdy;
     void* renderstate;
-    void* shadingStateUniform;
-    int thread_index;
-    int shade_index;
     void* tracedata;
     void* objdata;
     void* context;
+    void* shadingStateUniform;
+    int thread_index;
+    int shade_index;
     void* renderer;
     void* object2common;
     void* shader2common;


### PR DESCRIPTION
## Description

There is a separate definition of `ShaderGlobals` in `testrender/cuda/rend_lib.h` that has drifted away from the definition in `include/OSL/shaderglobals.h`. Two new members were added in #1702 which changed the byte offset of the output closure `Ci`, which leads to incorrect shader output since the offset is baked into the PTX.

Adding the new members fixes the shading issue. But this should be regarded as a short-term fix, since the two `ShaderGlobals` definitions have diverged in other ways that might be significant.

## Tests

All OptiX tests passing with the exception of `testoptix.optix.opt`, which is a preexisting failure.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

