### PR TITLE
build(deps): Raise minimum OpenImageIO version to 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             container: aswftesting/ci-osl:2019-clang9
             vfxyear: 2019
             cxx_std: 14
-            openimageio_ver: v2.3.17.0
+            openimageio_ver: v2.4.13.0
             python_ver: 2.7
             pybind11_ver: v2.4.2
           - desc: clang9/C++14 llvm9 oiio-release boost1.66 avx2 exr2.3 py2.7
@@ -63,7 +63,7 @@ jobs:
             container: aswftesting/ci-osl:2020
             vfxyear: 2020
             cxx_std: 14
-            openimageio_ver: v2.3.17.0
+            openimageio_ver: v2.4.13.0
             python_ver: 3.7
             pybind11_ver: v2.5.0
             simd: sse4.2
@@ -74,7 +74,7 @@ jobs:
             container: aswftesting/ci-osl:2021-clang11
             vfxyear: 2021
             cxx_std: 17
-            openimageio_ver: v2.3.21.0
+            openimageio_ver: v2.4.13.0
             python_ver: 3.7
             pybind11_ver: v2.7.0
             simd: avx2,f16c
@@ -164,7 +164,7 @@ jobs:
             container: aswftesting/ci-osl:2019-clang9
             vfxyear: 2019
             cxx_std: 14
-            openimageio_ver: v2.3.17.0
+            openimageio_ver: v2.4.13.0
             python_ver: 2.7
             pybind11_ver: v2.6.2
             simd: 0
@@ -306,7 +306,7 @@ jobs:
             cxx_compiler: g++-7
             cxx_std: 14
             openexr_ver: v2.4.3
-            openimageio_ver: v2.3.21.0
+            openimageio_ver: v2.4.13.0
             pybind11_ver: v2.6.2
             python_ver: 2.7
             simd: sse4.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@ Release 1.13 -- ?? 2023 ?? (compared to 1.12)
 Dependency and standards requirements changes:
 * OptiX 6.0 support has been removed. For GPU rendering with OptiX, a minimum
   of OptiX 7.0 is required.
-* The minimum version OpenImageIO has been raised from 2.2 to 2.3. #1591
-  (1.13.0.3)
+* The minimum version OpenImageIO has been raised from 2.2 to 2.4. #1591
+  (to 2.3 in 1.13.0.3, to 2.4 in 1.13.4.0)
 
 OSL Language and oslc compiler:
 * Bug fix: shader params whose default values involve "init ops" could be

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
    - Intel C++ compiler icc version 17 or newer or LLVM-based icx compiler
      version 2022 or newer.
 
-* **[OpenImageIO](http://openimageio.org) 2.3 or newer** (tested through 2.4)
+* **[OpenImageIO](http://openimageio.org) 2.4 or newer** (tested through 2.5 and master)
 
     OSL uses OIIO both for its texture mapping functionality as well as
     numerous utility classes.  If you are integrating OSL into an existing

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -105,7 +105,7 @@ endif ()
 
 # OpenImageIO
 checked_find_package (OpenImageIO REQUIRED
-                      VERSION_MIN 2.3.17
+                      VERSION_MIN 2.4
                       DEFINITIONS -DOIIO_HIDE_FORMAT=1)
 
 checked_find_package (pugixml REQUIRED

--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -272,6 +272,7 @@ macro (osl_add_all_tests)
                 function-overloads function-redef
                 geomath getattribute-camera getattribute-shader
                 getsymbol-nonheap gettextureinfo gettextureinfo-reg
+                gettextureinfo-udim gettextureinfo-udim-reg
                 globals-needed
                 group-outputs groupstring
                 hash hashnoise hex hyperb
@@ -380,11 +381,6 @@ macro (osl_add_all_tests)
                 vararray-deserialize vararray-param
                 vecctr vector vector-reg
                 wavelength_color wavelength_color-reg Werror xml xml-reg )
-
-    # Coordinate-aware gettextureinfo only works for TextureSystem >= 2.3.7
-    if (OpenImageIO_VERSION VERSION_GREATER_EQUAL 2.3.7)
-        TESTSUITE ( gettextureinfo-udim gettextureinfo-udim-reg )
-    endif ()
 
     # Only run the ocio test if the OIIO we are using has OCIO support
     if (OpenImageIO_HAS_OpenColorIO)

--- a/src/include/OSL/batched_texture.h
+++ b/src/include/OSL/batched_texture.h
@@ -41,9 +41,7 @@ template<int WidthT> struct VaryingTextureOptions {
     Block<float, WidthT> swidth;  ///< Multiplier for derivatives
     Block<float, WidthT> twidth;
     Block<float, WidthT> rwidth;  // For 3D volume texture lookups only:
-#if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
-    Block<float, WidthT> rnd;  // For stochastic sampling
-#endif
+    Block<float, WidthT> rnd;     // For stochastic sampling
 };
 static_assert(std::alignment_of<VaryingTextureOptions<16>>::value
                   == VecReg<16>::alignment,
@@ -69,9 +67,7 @@ template<int WidthT> struct BatchedTextureOptions {
         swidth,
         twidth,
         rwidth,
-#if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
         rnd,
-#endif
         firstchannel,
         subimage,
         subimagename,
@@ -123,10 +119,8 @@ static_assert(offsetof(OIIO::TextureOptBatch, twidth) % 64 == 0,
               "oops unaligned wide variable");
 static_assert(offsetof(OIIO::TextureOptBatch, rwidth) % 64 == 0,
               "oops unaligned wide variable");
-#    if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
 static_assert(offsetof(OIIO::TextureOptBatch, rnd) % 64 == 0,
               "oops unaligned wide variable");
-#    endif
 
 static_assert(sizeof(OIIO::TextureOptBatch)
                   == sizeof(BatchedTextureOptions<16>),

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -4262,11 +4262,9 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
     llvm::Value* swidth = wide_const_fone_value;
     llvm::Value* twidth = wide_const_fone_value;
     llvm::Value* rwidth = wide_const_fone_value;
-#if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
     // TODO: llvm_gen is not yet populating rnd, so neither will the batched
     //       version.  But below is where we would do so
     llvm::Value* rnd = wide_const_fzero_value;
-#endif
 
     llvm::Value* firstchannel = const_zero_value;
     llvm::Value* subimage     = const_zero_value;
@@ -4628,10 +4626,8 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
             rwidth,
             rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::rwidth)));
     }
-#if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
     rop.ll.op_unmasked_store(
         rnd, rop.ll.GEP(bto, 0, static_cast<float>(LLVMMemberIndex::rnd)));
-#endif
 
     return rop.ll.void_ptr(bto);
 }

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -712,9 +712,7 @@ BatchedBackendLLVM::llvm_type_batched_texture_options()
     sg_types.push_back(ll.type_wide_float());  // swidth
     sg_types.push_back(ll.type_wide_float());  // twidth
     sg_types.push_back(ll.type_wide_float());  // rwidth
-#if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
     sg_types.push_back(ll.type_wide_float());  // rnd
-#endif
 
     // Uniform values of the batch
     sg_types.push_back(ll.type_int());                 // firstchannel
@@ -2559,10 +2557,8 @@ BatchedBackendLLVM::build_offsets_of_BatchedTextureOptions(
         varying_offset + offsetof(VaryingTextureOptions<WidthT>, twidth));
     offset_by_index.push_back(
         varying_offset + offsetof(VaryingTextureOptions<WidthT>, rwidth));
-#if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
     offset_by_index.push_back(varying_offset
                               + offsetof(VaryingTextureOptions<WidthT>, rnd));
-#endif
     offset_by_index.push_back(uniform_offset
                               + offsetof(UniformTextureOptions, firstchannel));
     offset_by_index.push_back(uniform_offset

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -437,7 +437,6 @@ RendererServices::get_texture_info(ustringhash filename,
 {
     ShadingContext* shading_context
         = (ShadingContext*)((ShaderGlobals*)sg)->context;
-#if OIIO_VERSION >= 20307
     // Newer versions of the TextureSystem interface are able to determine the
     // specific UDIM tile we're using.
     if (!texture_thread_info)
@@ -456,7 +455,6 @@ RendererServices::get_texture_info(ustringhash filename,
             texture_handle = udim_handle;
         }
     }
-#endif
     return get_texture_info(filename, texture_handle, texture_thread_info, sg,
                             subimage, dataname, datatype, data, errormessage);
 }

--- a/src/liboslexec/shadeimage.cpp
+++ b/src/liboslexec/shadeimage.cpp
@@ -33,15 +33,9 @@ shade_image(ShadingSystem& shadingsys, ShaderGroup& group,
     if (!roi.defined())
         roi = buf.roi();
     if (buf.spec().format != TypeDesc::FLOAT) {
-#if OIIO_VERSION >= 20300
         buf.errorfmt(
             "Cannot OSL::shade_image() into a {} buffer, float is required",
             buf.spec().format);
-#else
-        buf.error(
-            "Cannot OSL::shade_image() into a %s buffer, float is required",
-            buf.spec().format);
-#endif
         return false;
     }
 

--- a/src/liboslexec/wide/wide_optexture.cpp
+++ b/src/liboslexec/wide/wide_optexture.cpp
@@ -90,10 +90,7 @@ default_texture(BatchedRendererServices* bsr, ustring filename,
         opt.tblur  = vary_opt.tblur[lane];
         opt.swidth = vary_opt.swidth[lane];
         opt.twidth = vary_opt.twidth[lane];
-
-#if OIIO_VERSION_GREATER_EQUAL(2, 4, 0)
-        opt.rnd = vary_opt.rnd[lane];
-#endif
+        opt.rnd    = vary_opt.rnd[lane];
 
         // For 3D volume texture lookups only:
         //opt.rblur = vary_opt.rblur[lane];


### PR DESCRIPTION
This is just for future-looking OSL 1.13 releases, it won't be backported to the 1.12 release branch.

Remember that by the time we release OSL 1.13 as a supported release family, OIIO will also have done its annual release, of 2.5. So our minimum of OIIO 2.4 means that we will be supporting the current release, as well as the prior year's release (and, of course, we always stay compatible with OIIO's trunk as it evolves). So we're really keeping compatibility with 3 major releases, which seems like plenty to juggle.

We discussed doing this a few TSC meetings ago, and nobody raised any objections to our raising the OIIO floor to 2.4 for the upcoming OSL 1.13 release. But if anyone is bothered by this, please speak up on this PR.

