### PR TITLE
Change RendererServices::get_texture_handle back to ustring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required (VERSION 3.12)
 
-set (OSL_VERSION "1.13.4.0")
+set (OSL_VERSION "1.13.5.0")
 set (OSL_VERSION_OVERRIDE "" CACHE STRING
      "Version override (use with caution)!")
 mark_as_advanced (OSL_VERSION_OVERRIDE)

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -282,6 +282,9 @@ public:
     /// null, may be used in renderer-specific ways to specialize a handle
     /// based on certain texture option choices.
     virtual TextureHandle*
+    get_texture_handle(ustring filename, ShadingContext* context,
+                       const TextureOpt* options = nullptr);
+    virtual TextureHandle*
     get_texture_handle(ustringhash filename, ShadingContext* context,
                        const TextureOpt* options = nullptr);
 

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -231,18 +231,27 @@ RendererServices::filefmt(OSL::ShaderGlobals* sg,
 
 
 RendererServices::TextureHandle*
+RendererServices::get_texture_handle(ustring filename, ShadingContext* context,
+                                     const TextureOpt* options)
+{
+#ifdef OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE
+    return texturesys()->get_texture_handle(filename,
+                                            context->texture_thread_info(),
+                                            options);
+#else
+    return texturesys()->get_texture_handle(filename,
+                                            context->texture_thread_info());
+#endif
+}
+
+
+
+RendererServices::TextureHandle*
 RendererServices::get_texture_handle(ustringhash filename,
                                      ShadingContext* context,
                                      const TextureOpt* options)
 {
-#ifdef OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE
-    return texturesys()->get_texture_handle(ustring_from(filename),
-                                            context->texture_thread_info(),
-                                            options);
-#else
-    return texturesys()->get_texture_handle(ustring_from(filename),
-                                            context->texture_thread_info());
-#endif
+    return get_texture_handle(ustring_from(filename), context, options);
 }
 
 

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -976,7 +976,7 @@ OptixRaytracer::good(TextureHandle* handle OSL_MAYBE_UNUSED)
 /// Given the name of a texture, return an opaque handle that can be
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
-OptixRaytracer::get_texture_handle(ustringhash filename,
+OptixRaytracer::get_texture_handle(ustring filename,
                                    ShadingContext* /*shading_context*/,
                                    const TextureOpt* options)
 {
@@ -984,9 +984,9 @@ OptixRaytracer::get_texture_handle(ustringhash filename,
     if (itr == m_samplers.end()) {
         // Open image
         OIIO::ImageBuf image;
-        if (!image.init_spec(ustring_from(filename), 0, 0)) {
-            errhandler().errorfmt("Could not load: {} (hash {})",
-                                  ustring_from(filename), filename);
+        if (!image.init_spec(filename, 0, 0)) {
+            errhandler().errorfmt("Could not load: {} (hash {})", filename,
+                                  filename);
             return (TextureHandle*)nullptr;
         }
 
@@ -1033,7 +1033,9 @@ OptixRaytracer::get_texture_handle(ustringhash filename,
         cudaTextureObject_t cuda_tex = 0;
         CUDA_CHECK(
             cudaCreateTextureObject(&cuda_tex, &res_desc, &tex_desc, nullptr));
-        itr = m_samplers.emplace(std::move(filename), std::move(cuda_tex)).first;
+        itr = m_samplers
+                  .emplace(std::move(filename.hash()), std::move(cuda_tex))
+                  .first;
     }
     return reinterpret_cast<RendererServices::TextureHandle*>(itr->second);
 }

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -51,7 +51,7 @@ public:
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    TextureHandle* get_texture_handle(ustringhash filename,
+    TextureHandle* get_texture_handle(ustring filename,
                                       ShadingContext* shading_context,
                                       const TextureOpt* options) override;
 

--- a/src/testshade/optixgridrender.cpp
+++ b/src/testshade/optixgridrender.cpp
@@ -808,7 +808,7 @@ OptixGridRenderer::good(TextureHandle* handle OSL_MAYBE_UNUSED)
 /// Given the name of a texture, return an opaque handle that can be
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
-OptixGridRenderer::get_texture_handle(ustringhash filename,
+OptixGridRenderer::get_texture_handle(ustring filename,
                                       ShadingContext* /*shading_context*/,
                                       const TextureOpt* /*options*/)
 {
@@ -816,9 +816,9 @@ OptixGridRenderer::get_texture_handle(ustringhash filename,
     if (itr == m_samplers.end()) {
         // Open image
         OIIO::ImageBuf image;
-        if (!image.init_spec(ustring_from(filename), 0, 0)) {
-            errhandler().errorfmt("Could not load: {} (hash {})",
-                                  ustring_from(filename), filename);
+        if (!image.init_spec(filename, 0, 0)) {
+            errhandler().errorfmt("Could not load: {} (hash {})", filename,
+                                  filename);
             return (TextureHandle*)nullptr;
         }
 
@@ -868,7 +868,9 @@ OptixGridRenderer::get_texture_handle(ustringhash filename,
         cudaTextureObject_t cuda_tex = 0;
         CUDA_CHECK(
             cudaCreateTextureObject(&cuda_tex, &res_desc, &tex_desc, nullptr));
-        itr = m_samplers.emplace(std::move(filename), std::move(cuda_tex)).first;
+        itr = m_samplers
+                  .emplace(std::move(filename.hash()), std::move(cuda_tex))
+                  .first;
     }
     return reinterpret_cast<RendererServices::TextureHandle*>(itr->second);
 }

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -61,7 +61,7 @@ public:
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    TextureHandle* get_texture_handle(ustringhash filename,
+    TextureHandle* get_texture_handle(ustring filename,
                                       ShadingContext* shading_context,
                                       const TextureOpt* options) override;
 

--- a/testsuite/example-cuda/cuda_grid_renderer.cpp
+++ b/testsuite/example-cuda/cuda_grid_renderer.cpp
@@ -81,7 +81,7 @@ CudaGridRenderer::good(TextureHandle* handle)
 /// Given the name of a texture, return an opaque handle that can be
 /// used with texture calls to avoid the name lookups.
 RendererServices::TextureHandle*
-CudaGridRenderer::get_texture_handle(OSL::ustringhash filename,
+CudaGridRenderer::get_texture_handle(OSL::ustring filename,
                                      ShadingContext* shading_context,
                                      const TextureOpt* options)
 {
@@ -139,7 +139,7 @@ CudaGridRenderer::get_texture_handle(OSL::ustringhash filename,
         cudaTextureObject_t cuda_tex = 0;
         CUDA_CHECK(
             cudaCreateTextureObject(&cuda_tex, &res_desc, &tex_desc, nullptr));
-        itr = _samplers.emplace(filename, std::move(cuda_tex)).first;
+        itr = _samplers.emplace(filename.hash(), std::move(cuda_tex)).first;
     }
     return reinterpret_cast<RendererServices::TextureHandle*>(itr->second);
 }

--- a/testsuite/example-cuda/cuda_grid_renderer.h
+++ b/testsuite/example-cuda/cuda_grid_renderer.h
@@ -49,7 +49,7 @@ public:
 
     /// Given the name of a texture, return an opaque handle that can be
     /// used with texture calls to avoid the name lookups.
-    virtual TextureHandle* get_texture_handle(ustringhash filename,
+    virtual TextureHandle* get_texture_handle(ustring filename,
                                               ShadingContext* shading_context,
                                               const TextureOpt* options);
 


### PR DESCRIPTION
We were overzealous in switching everything to ustringhash.  The filename argument to get_texture_handle should allow taking a ustring.

