### PR TITLE
LLVM 16 and opaque pointers support

### DIFF
--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -159,14 +159,19 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 17.0)
     endif ()
 endif ()
 
-# TODO: temporary for testing
-set(LLVM_OPAQUE_POINTERS ON)
+# TODO: decide on appropriate versions. Conservative choice would be to only
+# use these for LLVM 16+.
+if (${LLVM_VERSION} VERSION_GREATER_EQUAL 14.0)
+  set(LLVM_OPAQUE_POINTERS ON)
+  set(LLVM_NEW_PASS_MANAGER ON)
+else()
+  set(LLVM_OPAQUE_POINTERS OFF)
+  set(LLVM_NEW_PASS_MANAGER OFF)
+endif()
+
 if (LLVM_OPAQUE_POINTERS)
   add_definitions (-DOSL_LLVM_OPAQUE_POINTERS)
 endif()
-
-# TODO: temporary for testing
-set(LLVM_NEW_PASS_MANAGER ON)
 if (LLVM_NEW_PASS_MANAGER)
   add_definitions (-DOSL_LLVM_NEW_PASS_MANAGER)
 endif()

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -159,6 +159,12 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 17.0)
     endif ()
 endif ()
 
+# TODO: temporary for testing
+set(LLVM_OPAQUE_POINTERS OFF)
+if (LLVM_OPAQUE_POINTERS)
+  add_definitions (-DOSL_LLVM_OPAQUE_POINTERS)
+endif()
+
 checked_find_package (partio)
 
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -115,7 +115,7 @@ checked_find_package (pugixml REQUIRED
 # LLVM library setup
 checked_find_package (LLVM REQUIRED
                       VERSION_MIN 9.0
-                      VERSION_MAX 15.9
+                      VERSION_MAX 16.9
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES)
 # ensure include directory is added (in case of non-standard locations
 include_directories (BEFORE SYSTEM "${LLVM_INCLUDES}")
@@ -145,8 +145,8 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 15.0
          "If you are using LLVM 15 or higher, you should also use clang version "
          "15 or higher, or you may get build errors.${ColorReset}\n")
 endif ()
-if (LLVM_VERSION VERSION_GREATER_EQUAL 16.0)
-    message (ERROR "${ColorYellow}OSL is not yet compatible with LLVM 16.${ColorReset}\n")
+if (LLVM_VERSION VERSION_GREATER_EQUAL 17.0)
+    message (ERROR "${ColorYellow}OSL is not yet compatible with LLVM 17.${ColorReset}\n")
     if (CMAKE_CXX_STANDARD VERSION_LESS 17)
         message (WARNING "${ColorYellow}LLVM 16+ requires C++17 or higher. "
             "Please set CMAKE_CXX_STANDARD to 17 or higher.${ColorReset}\n")

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -160,9 +160,15 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 17.0)
 endif ()
 
 # TODO: temporary for testing
-set(LLVM_OPAQUE_POINTERS OFF)
+set(LLVM_OPAQUE_POINTERS ON)
 if (LLVM_OPAQUE_POINTERS)
   add_definitions (-DOSL_LLVM_OPAQUE_POINTERS)
+endif()
+
+# TODO: temporary for testing
+set(LLVM_NEW_PASS_MANAGER ON)
+if (LLVM_NEW_PASS_MANAGER)
+  add_definitions (-DOSL_LLVM_NEW_PASS_MANAGER)
 endif()
 
 checked_find_package (partio)

--- a/src/cmake/llvm_macros.cmake
+++ b/src/cmake/llvm_macros.cmake
@@ -80,12 +80,6 @@ function ( EMBED_LLVM_BITCODE_IN_CPP src_list suffix output_name list_to_append_
         list (TRANSFORM include_dirs PREPEND -I
             OUTPUT_VARIABLE ALL_INCLUDE_DIRS)
 
-        if (${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
-            # Until we fully support opaque pointers, we need to disable
-            # them when using LLVM 15.
-            list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)
-        endif ()
-
         # Command to turn the .cpp file into LLVM assembly language .s, into
         # LLVM bitcode .bc, then back into a C++ file with the bc embedded!
         add_custom_command ( OUTPUT ${src_bc}

--- a/src/cmake/llvm_macros.cmake
+++ b/src/cmake/llvm_macros.cmake
@@ -80,6 +80,12 @@ function ( EMBED_LLVM_BITCODE_IN_CPP src_list suffix output_name list_to_append_
         list (TRANSFORM include_dirs PREPEND -I
             OUTPUT_VARIABLE ALL_INCLUDE_DIRS)
 
+        if (NOT LLVM_OPAQUE_POINTERS AND ${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
+            # Until we fully support opaque pointers, we need to disable
+            # them when using LLVM 15.
+            list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)
+        endif ()
+
         # Command to turn the .cpp file into LLVM assembly language .s, into
         # LLVM bitcode .bc, then back into a C++ file with the bc embedded!
         add_custom_command ( OUTPUT ${src_bc}

--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -126,8 +126,9 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 9.0 AND (LLVM_SHARED_MODE STREQUAL "share
 endif ()
 
 foreach (COMPONENT clangFrontend clangDriver clangSerialization
-                   clangParse clangSema clangAnalysis clangAST clangBasic
-                   clangEdit clangLex clangSupport)
+                   clangParse clangSema clangAnalysis clangAST
+                   clangASTMatchers clangBasic clangEdit clangLex
+                   clangSupport)
     find_library ( _CLANG_${COMPONENT}_LIBRARY
                   NAMES ${COMPONENT}
                   PATHS ${LLVM_LIB_DIR})

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -888,7 +888,7 @@ public:
     llvm::Value* op_load(llvm::Type* type, llvm::Value* ptr,
                          const std::string& llname = {});
 
-    llvm::Value* op_gather(llvm::Type* ptr_element_type, llvm::Value* ptr,
+    llvm::Value* op_gather(llvm::Type* ptr_type, llvm::Value* ptr,
                            llvm::Value* wide_index);
 
     /// Store to a dereferenced pointer
@@ -906,7 +906,7 @@ public:
     /// converting it to the native mask type for storage:   *ptr = llvm_mask_to_native(val);
     void op_store_mask(llvm::Value* llvm_mask, llvm::Value* native_mask_ptr);
 
-    void op_scatter(llvm::Type* ptr_element_type, llvm::Value* wide_val,
+    void op_scatter(llvm::Value* wide_val, llvm::Type* ptr_type,
                     llvm::Value* ptr, llvm::Value* wide_index);
 
     // N.B. "GEP" -- GetElementPointer -- is a particular LLVM-ism that is

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -624,6 +624,9 @@ public:
                             const std::string& name = "",
                             bool is_packed          = false);
 
+    // Return type of field at given index in a struct type.
+    llvm::Type* type_struct_field_at_index(llvm::Type* type, int index);
+
     /// Return the llvm::Type that is a pointer to the given llvm type.
     llvm::PointerType* type_ptr(llvm::Type* type);
 
@@ -884,10 +887,9 @@ public:
     /// type is the type of the thing being pointed to.
     llvm::Value* op_load(llvm::Type* type, llvm::Value* ptr,
                          const std::string& llname = {});
-    // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* op_load(llvm::Value* ptr, const std::string& llname = {});
 
-    llvm::Value* op_gather(llvm::Value* ptr, llvm::Value* index);
+    llvm::Value* op_gather(llvm::Type* ptr_element_type, llvm::Value* ptr,
+                           llvm::Value* wide_index);
 
     /// Store to a dereferenced pointer
     /// respecting the current mask & masking_enabled flag:   *ptr = val
@@ -904,8 +906,8 @@ public:
     /// converting it to the native mask type for storage:   *ptr = llvm_mask_to_native(val);
     void op_store_mask(llvm::Value* llvm_mask, llvm::Value* native_mask_ptr);
 
-    void op_scatter(llvm::Value* wide_val, llvm::Value* ptr,
-                    llvm::Value* wide_index);
+    void op_scatter(llvm::Type* ptr_element_type, llvm::Value* wide_val,
+                    llvm::Value* ptr, llvm::Value* wide_index);
 
     // N.B. "GEP" -- GetElementPointer -- is a particular LLVM-ism that is
     // the means for retrieving elements from some kind of aggregate: the
@@ -918,16 +920,10 @@ public:
     /// we're retrieving.
     llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, llvm::Value* elem,
                      const std::string& llname = {});
-    // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, llvm::Value* elem,
-                     const std::string& llname = {});
 
     /// Generate a GEP (get element pointer) with an integer element
     /// offset. `type` is the type of the data we're retrieving.
     llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem,
-                     const std::string& llname = {});
-    // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, int elem,
                      const std::string& llname = {});
 
     /// Generate a GEP (get element pointer) with two integer element
@@ -937,9 +933,14 @@ public:
     /// retrieving.
     llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2,
                      const std::string& llname = {});
-    // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, int elem1, int elem2,
-                     const std::string& llname = {});
+
+    /// Generate a GEP (get element pointer) with three integer element
+    /// offsets.  This is just a special (and common) case of GEP where
+    /// we have a 3-level hierarchy and we have fixed element indices
+    /// that are known at compile time.  `type` is the type of the data we're
+    /// retrieving.
+    llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2,
+                     int elem3, const std::string& llname = {});
 
     // Arithmetic ops.  It auto-detects the type (int vs float).
     // ...

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -1029,6 +1029,7 @@ public:
 private:
     class MemoryManager;
     class IRBuilder;
+    struct NewPassManager;
 
     void SetupLLVM();
     IRBuilder& builder();
@@ -1046,6 +1047,7 @@ private:
     llvm::Function* m_current_function;
     llvm::legacy::PassManager* m_llvm_module_passes;
     llvm::legacy::FunctionPassManager* m_llvm_func_passes;
+    NewPassManager* m_new_pass_manager;
     llvm::ExecutionEngine* m_llvm_exec;
     TargetISA m_target_isa = TargetISA::UNKNOWN;
 
@@ -1208,6 +1210,9 @@ private:
                                        llvm::Value* half_vec_2);
     llvm::Value* op_combine_4x_vectors(llvm::Value* half_vec_1,
                                        llvm::Value* half_vec_2);
+
+    void setup_legacy_optimization_passes(int optlevel, bool target_host);
+    void setup_new_optimization_passes(int optlevel, bool target_host);
 };
 
 

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -668,7 +668,7 @@ BackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
         dst_ptr = ll.GEP(element_type, dst_ptr, 0, component);
 
     // Finally, store the value.
-    // TODO: broken, pointer type comparison no longer works with opaque pointers.
+    // TODO: this breaks OptiX, pointer type comparison no longer works with opaque pointers.
     if (t == TypeString && dst_ptr->getType() == ll.type_int64_ptr()
         && new_val->getType() == ll.type_char_ptr()) {
         // Special case: we are still ickily storing strings sometimes as a

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -1117,15 +1117,9 @@ public:
     }
 
 #ifdef OSL_DEV
-    OSL_FORCEINLINE int op_num() const
-    {
-        return m_op_num;
-    }
+    OSL_FORCEINLINE int op_num() const { return m_op_num; }
 
-    OSL_FORCEINLINE int loop_op_index() const
-    {
-        return m_loop_op_index;
-    }
+    OSL_FORCEINLINE int loop_op_index() const { return m_loop_op_index; }
 #endif
 };
 
@@ -2008,7 +2002,13 @@ struct Analyzer {
     {
         bool previously_was_uniform = symbol_to_be_varying->is_uniform();
         if (previously_was_uniform | force) {
-            symbol_to_be_varying->make_varying();
+            // Interactive params are never varying, following getLLVMSymbolBase()
+            const bool force_uniform = symbol_to_be_varying->symtype()
+                                           == SymTypeParam
+                                       && symbol_to_be_varying->interactive();
+            if (!force_uniform) {
+                symbol_to_be_varying->make_varying();
+            }
             auto range = m_symbols_dependent_upon.equal_range(
                 symbol_to_be_varying);
             auto iter = range.first;
@@ -2201,7 +2201,7 @@ struct Analyzer {
 #endif
                     const auto& early_out = *earlyOutIter;
                     auto begin_dep_iter   = m_conditional_symbol_stack.begin_at(
-                          early_out.dtt_pos);
+                        early_out.dtt_pos);
                     auto end_dep_iter = m_conditional_symbol_stack.end();
 
                     const Opcode& opcode = m_opcodes[op_index];

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -1117,9 +1117,15 @@ public:
     }
 
 #ifdef OSL_DEV
-    OSL_FORCEINLINE int op_num() const { return m_op_num; }
+    OSL_FORCEINLINE int op_num() const
+    {
+        return m_op_num;
+    }
 
-    OSL_FORCEINLINE int loop_op_index() const { return m_loop_op_index; }
+    OSL_FORCEINLINE int loop_op_index() const
+    {
+        return m_loop_op_index;
+    }
 #endif
 };
 
@@ -2201,7 +2207,7 @@ struct Analyzer {
 #endif
                     const auto& early_out = *earlyOutIter;
                     auto begin_dep_iter   = m_conditional_symbol_stack.begin_at(
-                        early_out.dtt_pos);
+                          early_out.dtt_pos);
                     auto end_dep_iter = m_conditional_symbol_stack.end();
 
                     const Opcode& opcode = m_opcodes[op_index];

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -378,7 +378,7 @@ BatchedBackendLLVM::llvm_zero_derivs(const Symbol& sym, llvm::Value* count)
         llvm::Value* post_condition_mask = ll.op_and(condition_mask,
                                                      pre_condition_mask);
         llvm::Value* cond_val            = ll.test_if_mask_is_non_zero(
-            post_condition_mask);
+                       post_condition_mask);
 
         // Jump to either LoopBody or AfterLoop
         ll.op_branch(cond_val, body_block, after_block);
@@ -599,6 +599,8 @@ BatchedBackendLLVM::getOrAllocateLLVMSymbol(const Symbol& sym)
     }
     return map_iter->second;
 }
+
+
 
 llvm::Value*
 BatchedBackendLLVM::llvm_get_pointer(const Symbol& sym, int deriv,

--- a/src/liboslexec/batched_backendllvm.h
+++ b/src/liboslexec/batched_backendllvm.h
@@ -114,7 +114,7 @@ public:
     /// (no conversion is performed if cast is the default of UNKNOWN).
     llvm::Value* llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
                                  int deriv, llvm::Value* arrayindex,
-                                 int component,
+                                 int component, bool ptr_is_uniform,
                                  TypeDesc cast              = TypeDesc::UNKNOWN,
                                  bool op_is_uniform         = true,
                                  bool index_is_uniform      = true,
@@ -194,7 +194,7 @@ public:
     bool llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
                           const TypeSpec& type, int deriv,
                           llvm::Value* arrayindex, int component,
-                          bool index_is_uniform = true);
+                          bool dst_is_uniform, bool index_is_uniform = true);
 
     /// Non-array version of llvm_store_value, with default deriv &
     /// component.

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -4268,7 +4268,7 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
     llvm::Value* wide_const_fone_value  = rop.ll.wide_constant(1.0f);
     llvm::Value* const_zero_value       = rop.ll.constant(0);
     llvm::Value* wrap_default_value     = rop.ll.constant(
-        static_cast<int>(Tex::Wrap::Default));
+            static_cast<int>(Tex::Wrap::Default));
 
     llvm::Value* sblur  = wide_const_fzero_value;
     llvm::Value* tblur  = wide_const_fzero_value;
@@ -4287,7 +4287,7 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
     llvm::Value* twrap        = wrap_default_value;
     llvm::Value* rwrap        = wrap_default_value;
     llvm::Value* mipmode      = rop.ll.constant(
-        static_cast<int>(Tex::MipMode::Default));
+             static_cast<int>(Tex::MipMode::Default));
     llvm::Value* interpmode = rop.ll.constant(
         static_cast<int>(Tex::InterpMode::SmartBicubic));
     llvm::Value* anisotropic         = rop.ll.constant(32);
@@ -7091,7 +7091,7 @@ LLVMGEN(llvm_gen_spline)
                                                                leadLane);
             args[splineNameArgumentIndex]  = scalar_splineName;
             lanesMatchingSplineName        = rop.ll.op_lanes_that_match_masked(
-                scalar_splineName, splineNameVal, remainingMask);
+                       scalar_splineName, splineNameVal, remainingMask);
 
             OSL_ASSERT(lanesMatchingSplineName);
             //rop.llvm_print_mask("lanesMatchingSplineName", lanesMatchingSplineName);
@@ -7337,7 +7337,7 @@ LLVMGEN(llvm_gen_closure)
 
             llvm::Value* dest_base = rop.ll.offset_ptr(mem_void_ptr, p.offset);
             llvm::Type* dest_type  = rop.ll.llvm_type(
-                static_cast<const TypeSpec&>(p.type).simpletype());
+                 static_cast<const TypeSpec&>(p.type).simpletype());
             dest_base = rop.ll.ptr_to_cast(dest_base, dest_type);
 
             if (num_elements > 1) {

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -115,7 +115,7 @@ BatchedBackendLLVM::llvm_call_layer(int layer, bool unconditional)
     llvm::Value* lanes_requiring_execution_value = nullptr;
     if (!unconditional) {
         llvm::Value* previously_executed = ll.int_as_mask(
-            ll.op_load(layerfield));
+            ll.op_load(ll.type_wide_bool(), layerfield));
         llvm::Value* lanes_requiring_execution
             = ll.op_select(previously_executed, ll.wide_constant_bool(false),
                            ll.current_mask());
@@ -511,7 +511,8 @@ LLVMGEN(llvm_gen_printf)
         rop.ll.op_branch(cond_block);
         {
             // Condition
-            llvm::Value* lane_index = rop.ll.op_load(loc_of_lane_index);
+            llvm::Value* lane_index = rop.ll.op_load(rop.ll.type_wide_int(),
+                                                     loc_of_lane_index);
             llvm::Value* more_lanes_to_process
                 = rop.ll.op_lt(lane_index, rop.ll.constant(rop.vector_width()));
 
@@ -547,7 +548,7 @@ LLVMGEN(llvm_gen_printf)
             rop.ll.op_branch(step_block);
 
             // Step
-            //lane_index = rop.ll.op_load(loc_of_lane_index);
+            //lane_index = rop.ll.op_load(rop.ll.type_wide_int(), loc_of_lane_index);
             llvm::Value* next_lane_index = rop.ll.op_add(lane_index,
                                                          rop.ll.constant(1));
             rop.ll.op_unmasked_store(next_lane_index, loc_of_lane_index);
@@ -645,7 +646,8 @@ LLVMGEN(llvm_gen_aref)
             rop.ll.call_function(rop.build_name(FuncSpec("range_check").mask()),
                                  args);
             // Use the range check indices
-            index = rop.ll.op_load(loc_clamped_wide_index);
+            index = rop.ll.op_load(rop.ll.type_wide_int(),
+                                   loc_clamped_wide_index);
         }
     }
 
@@ -727,7 +729,8 @@ LLVMGEN(llvm_gen_aassign)
             rop.ll.call_function(rop.build_name(FuncSpec("range_check").mask()),
                                  args);
             // Use the range check indices
-            index = rop.ll.op_load(loc_clamped_wide_index);
+            index = rop.ll.op_load(rop.ll.type_wide_int(),
+                                   loc_clamped_wide_index);
         }
     }
 
@@ -2348,7 +2351,7 @@ LLVMGEN(llvm_gen_compref)
             // Although as our implementation below doesn't use any
             // out of range values, clamping the indices here
             // is of questionable value
-            c = rop.ll.op_load(loc_clamped_wide_index);
+            c = rop.ll.op_load(rop.ll.type_wide_int(), loc_clamped_wide_index);
         }
 
         // As the index is logically bound to 0, 1, or 2
@@ -2463,7 +2466,7 @@ LLVMGEN(llvm_gen_compassign)
             // Although as our implementation below doesn't use any
             // out of range values, clamping the indices here
             // is of questionable value
-            c = rop.ll.op_load(loc_clamped_wide_index);
+            c = rop.ll.op_load(rop.ll.type_wide_int(), loc_clamped_wide_index);
         }
 
 
@@ -2577,13 +2580,15 @@ LLVMGEN(llvm_gen_mxcompref)
                 FuncSpec("range_check").mask());
             rop.ll.call_function(func_name, args);
             // Use the range check row
-            row = rop.ll.op_load(loc_clamped_wide_index);
+            row = rop.ll.op_load(rop.ll.type_wide_int(),
+                                 loc_clamped_wide_index);
 
             // copy the indices into our temporary
             rop.ll.op_unmasked_store(col, loc_clamped_wide_index);
             rop.ll.call_function(func_name, args);
             // Use the range check col
-            col = rop.ll.op_load(loc_clamped_wide_index);
+            col = rop.ll.op_load(rop.ll.type_wide_int(),
+                                 loc_clamped_wide_index);
         }
     }
 
@@ -2679,13 +2684,15 @@ LLVMGEN(llvm_gen_mxcompassign)
                 FuncSpec("range_check").mask());
             rop.ll.call_function(func_name, args);
             // Use the range check row
-            row = rop.ll.op_load(loc_clamped_wide_index);
+            row = rop.ll.op_load(rop.ll.type_wide_int(),
+                                 loc_clamped_wide_index);
 
             // copy the indices into our temporary
             rop.ll.op_unmasked_store(col, loc_clamped_wide_index);
             rop.ll.call_function(func_name, args);
             // Use the range check col
-            col = rop.ll.op_load(loc_clamped_wide_index);
+            col = rop.ll.op_load(rop.ll.type_wide_int(),
+                                 loc_clamped_wide_index);
         }
     }
 
@@ -3163,9 +3170,13 @@ LLVMGEN(llvm_gen_regex)
         rop.llvm_store_value(ret, Result);
         if (!match_is_uniform) {
             OSL_ASSERT(temp_match_array);
+            // TODO: may be the wrong type
+            llvm::Type* elem_type = rop.ll.llvm_type(
+                Match.typespec().elementtype().simpletype());
             for (int ai = 0; ai < Match.typespec().arraylength(); ++ai) {
-                llvm::Value* elem_ptr  = rop.ll.GEP(temp_match_array, ai);
-                llvm::Value* elem      = rop.ll.op_load(elem_ptr);
+                llvm::Value* elem_ptr  = rop.ll.GEP(elem_type, temp_match_array,
+                                                    ai);
+                llvm::Value* elem      = rop.ll.op_load(elem_type, elem_ptr);
                 llvm::Value* wide_elem = rop.ll.widen_value(elem);
                 rop.llvm_store_value(wide_elem, Match, 0 /*deriv*/,
                                      rop.ll.constant(ai) /*arrayindex*/,
@@ -4243,7 +4254,8 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
                              llvm::Value*& errormessage,
                              llvm::Value*& missingcolor_buffer)
 {
-    llvm::Value* bto = rop.temp_batched_texture_options_ptr();
+    llvm::Value* bto     = rop.temp_batched_texture_options_ptr();
+    llvm::Type* bto_type = rop.llvm_type_batched_texture_options();
 
     // The BatchedTextureOptions & missingcolor_buffer are local alloca,
     // so no need to mask off non-active lanes
@@ -4254,7 +4266,7 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
     llvm::Value* wide_const_fone_value  = rop.ll.wide_constant(1.0f);
     llvm::Value* const_zero_value       = rop.ll.constant(0);
     llvm::Value* wrap_default_value     = rop.ll.constant(
-            static_cast<int>(Tex::Wrap::Default));
+        static_cast<int>(Tex::Wrap::Default));
 
     llvm::Value* sblur  = wide_const_fzero_value;
     llvm::Value* tblur  = wide_const_fzero_value;
@@ -4273,7 +4285,7 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
     llvm::Value* twrap        = wrap_default_value;
     llvm::Value* rwrap        = wrap_default_value;
     llvm::Value* mipmode      = rop.ll.constant(
-             static_cast<int>(Tex::MipMode::Default));
+        static_cast<int>(Tex::MipMode::Default));
     llvm::Value* interpmode = rop.ll.constant(
         static_cast<int>(Tex::InterpMode::SmartBicubic));
     llvm::Value* anisotropic         = rop.ll.constant(32);
@@ -4523,7 +4535,8 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
             llvm::Value* val = rop.llvm_load_value(Val);
             // Depending on how render services handles channels, might need to be 3 period.
             rop.ll.op_unmasked_store(val,
-                                     rop.ll.GEP(missingcolor_buffer, nchans));
+                                     rop.ll.GEP(rop.ll.type_triple(),
+                                                missingcolor_buffer, nchans));
             continue;
         }
 
@@ -4553,81 +4566,92 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
     if (is_firstchannel_uniform)
         rop.ll.op_unmasked_store(
             firstchannel,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::firstchannel)));
+            rop.ll.GEP(bto_type, bto, 0,
+                       static_cast<int>(LLVMMemberIndex::firstchannel)));
     if (is_subimage_uniform)
         rop.ll.op_unmasked_store(
-            subimage,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::subimage)));
+            subimage, rop.ll.GEP(bto_type, bto, 0,
+                                 static_cast<int>(LLVMMemberIndex::subimage)));
 
     if (is_subimagename_uniform)
         rop.ll.op_unmasked_store(
             subimagename,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::subimagename)));
+            rop.ll.GEP(bto_type, bto, 0,
+                       static_cast<int>(LLVMMemberIndex::subimagename)));
 
     if (is_swrap_uniform)
         rop.ll.op_unmasked_store(
-            swrap,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::swrap)));
+            swrap, rop.ll.GEP(bto_type, bto, 0,
+                              static_cast<int>(LLVMMemberIndex::swrap)));
     if (is_twrap_uniform)
         rop.ll.op_unmasked_store(
-            twrap,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::twrap)));
+            twrap, rop.ll.GEP(bto_type, bto, 0,
+                              static_cast<int>(LLVMMemberIndex::twrap)));
     if (is_rwrap_uniform)
         rop.ll.op_unmasked_store(
-            rwrap,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::rwrap)));
+            rwrap, rop.ll.GEP(bto_type, bto, 0,
+                              static_cast<int>(LLVMMemberIndex::rwrap)));
 
     // No way to set mipmode option from OSL
     rop.ll.op_unmasked_store(
-        mipmode,
-        rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::mipmode)));
+        mipmode, rop.ll.GEP(bto_type, bto, 0,
+                            static_cast<int>(LLVMMemberIndex::mipmode)));
 
     if (is_interpmode_uniform)
-        rop.ll.op_unmasked_store(
-            interpmode,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::interpmode)));
+        rop.ll.op_unmasked_store(interpmode,
+                                 rop.ll.GEP(bto_type, bto, 0,
+                                            static_cast<int>(
+                                                LLVMMemberIndex::interpmode)));
 
     // No way to set anisotropic option from OSL
-    rop.ll.op_unmasked_store(
-        anisotropic,
-        rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::anisotropic)));
+    rop.ll.op_unmasked_store(anisotropic,
+                             rop.ll.GEP(bto_type, bto, 0,
+                                        static_cast<int>(
+                                            LLVMMemberIndex::anisotropic)));
 
     // No way to set conservative_filter option from OSL
     rop.ll.op_unmasked_store(
         conservative_filter,
-        rop.ll.GEP(bto, 0,
+        rop.ll.GEP(bto_type, bto, 0,
                    static_cast<int>(LLVMMemberIndex::conservative_filter)));
 
     if (is_fill_uniform)
-        rop.ll.op_unmasked_store(
-            fill, rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::fill)));
+        rop.ll.op_unmasked_store(fill, rop.ll.GEP(bto_type, bto, 0,
+                                                  static_cast<int>(
+                                                      LLVMMemberIndex::fill)));
 
     // For uniform and varying we point the missingcolor to nullptr or the missingcolor_buffer,
     // The varying options will copy the lead lane's missing color value into the missingcolor_buffer
-    rop.ll.op_unmasked_store(
-        missingcolor,
-        rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::missingcolor)));
+    rop.ll.op_unmasked_store(missingcolor,
+                             rop.ll.GEP(bto_type, bto, 0,
+                                        static_cast<int>(
+                                            LLVMMemberIndex::missingcolor)));
 
     // blur's and width's are always communicated as wide, we we will handle them here
-    rop.ll.op_unmasked_store(
-        sblur, rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::sblur)));
-    rop.ll.op_unmasked_store(
-        tblur, rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::tblur)));
-    rop.ll.op_unmasked_store(
-        swidth, rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::swidth)));
-    rop.ll.op_unmasked_store(
-        twidth, rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::twidth)));
+    rop.ll.op_unmasked_store(sblur, rop.ll.GEP(bto_type, bto, 0,
+                                               static_cast<int>(
+                                                   LLVMMemberIndex::sblur)));
+    rop.ll.op_unmasked_store(tblur, rop.ll.GEP(bto_type, bto, 0,
+                                               static_cast<int>(
+                                                   LLVMMemberIndex::tblur)));
+    rop.ll.op_unmasked_store(swidth, rop.ll.GEP(bto_type, bto, 0,
+                                                static_cast<int>(
+                                                    LLVMMemberIndex::swidth)));
+    rop.ll.op_unmasked_store(twidth, rop.ll.GEP(bto_type, bto, 0,
+                                                static_cast<int>(
+                                                    LLVMMemberIndex::twidth)));
 
     if (tex3d) {
         rop.ll.op_unmasked_store(
-            rblur,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::rblur)));
+            rblur, rop.ll.GEP(bto_type, bto, 0,
+                              static_cast<int>(LLVMMemberIndex::rblur)));
         rop.ll.op_unmasked_store(
-            rwidth,
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::rwidth)));
+            rwidth, rop.ll.GEP(bto_type, bto, 0,
+                               static_cast<int>(LLVMMemberIndex::rwidth)));
     }
-    rop.ll.op_unmasked_store(
-        rnd, rop.ll.GEP(bto, 0, static_cast<float>(LLVMMemberIndex::rnd)));
+    rop.ll.op_unmasked_store(rnd, rop.ll.GEP(bto_type, bto, 0,
+                                             static_cast<float>(
+                                                 LLVMMemberIndex::rnd)));
 
     return rop.ll.void_ptr(bto);
 }
@@ -4641,7 +4665,8 @@ llvm_batched_texture_varying_options(BatchedBackendLLVM& rop, int opnum,
                                      llvm::Value* leadLane,
                                      llvm::Value* missingcolor_buffer)
 {
-    llvm::Value* bto = rop.temp_batched_texture_options_ptr();
+    llvm::Value* bto     = rop.temp_batched_texture_options_ptr();
+    llvm::Type* bto_type = rop.llvm_type_batched_texture_options();
 
     // The BatchedTextureOptions & missingcolor_buffer are local alloca,
     // so no need to mask off non-active lanes
@@ -4708,17 +4733,19 @@ llvm_batched_texture_varying_options(BatchedBackendLLVM& rop, int opnum,
             llvm::Value* wrap_code
                 = rop.ll.call_function("osl_texture_decode_wrapmode",
                                        scalar_value);
-            rop.ll.op_unmasked_store(
-                wrap_code,
-                rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::swrap)));
-            rop.ll.op_unmasked_store(
-                wrap_code,
-                rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::twrap)));
+            rop.ll.op_unmasked_store(wrap_code,
+                                     rop.ll.GEP(bto_type, bto, 0,
+                                                static_cast<int>(
+                                                    LLVMMemberIndex::swrap)));
+            rop.ll.op_unmasked_store(wrap_code,
+                                     rop.ll.GEP(bto_type, bto, 0,
+                                                static_cast<int>(
+                                                    LLVMMemberIndex::twrap)));
 
             if (tex3d)
                 rop.ll.op_unmasked_store(
                     wrap_code,
-                    rop.ll.GEP(bto, 0,
+                    rop.ll.GEP(bto_type, bto, 0,
                                static_cast<int>(LLVMMemberIndex::rwrap)));
 
             remainingMask = rop.ll.op_lanes_that_match_masked(scalar_value,
@@ -4735,9 +4762,10 @@ llvm_batched_texture_varying_options(BatchedBackendLLVM& rop, int opnum,
         llvm::Value* scalar_value = rop.ll.op_extract(wide_value, leadLane);   \
         llvm::Value* scalar_code  = rop.ll.call_function(#llvm_decoder,        \
                                                          scalar_value);        \
-        rop.ll.op_unmasked_store(                                              \
-            scalar_code,                                                       \
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::fieldname))); \
+        rop.ll.op_unmasked_store(scalar_code,                                  \
+                                 rop.ll.GEP(bto_type, bto, 0,                  \
+                                            static_cast<int>(                  \
+                                                LLVMMemberIndex::fieldname))); \
         remainingMask = rop.ll.op_lanes_that_match_masked(scalar_value,        \
                                                           wide_value,          \
                                                           remainingMask);      \
@@ -4763,9 +4791,10 @@ llvm_batched_texture_varying_options(BatchedBackendLLVM& rop, int opnum,
                                                               remainingMask);
             if (valtype == TypeDesc::INT)
                 scalar_value = rop.ll.op_int_to_float(scalar_value);
-            rop.ll.op_unmasked_store(
-                scalar_value,
-                rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::fill)));
+            rop.ll.op_unmasked_store(scalar_value,
+                                     rop.ll.GEP(bto_type, bto, 0,
+                                                static_cast<int>(
+                                                    LLVMMemberIndex::fill)));
             continue;
         }
 
@@ -4775,9 +4804,10 @@ llvm_batched_texture_varying_options(BatchedBackendLLVM& rop, int opnum,
             = rop.llvm_load_value(Val, /*deriv=*/0, /*component=*/0,           \
                                   TypeDesc::UNKNOWN, /*op_is_uniform=*/false); \
         llvm::Value* scalar_value = rop.ll.op_extract(wide_val, leadLane);     \
-        rop.ll.op_unmasked_store(                                              \
-            scalar_value,                                                      \
-            rop.ll.GEP(bto, 0, static_cast<int>(LLVMMemberIndex::fieldname))); \
+        rop.ll.op_unmasked_store(scalar_value,                                 \
+                                 rop.ll.GEP(bto_type, bto, 0,                  \
+                                            static_cast<int>(                  \
+                                                LLVMMemberIndex::fieldname))); \
         remainingMask = rop.ll.op_lanes_that_match_masked(scalar_value,        \
                                                           wide_val,            \
                                                           remainingMask);      \
@@ -4803,7 +4833,8 @@ llvm_batched_texture_varying_options(BatchedBackendLLVM& rop, int opnum,
                     = rop.ll.op_extract(wide_component, leadLane);
                 // The missingcolor_buffer is a local alloca, so no need to mask off non-active lanes
                 rop.ll.op_unmasked_store(scalar_component,
-                                         rop.ll.GEP(missingcolor_buffer, i));
+                                         rop.ll.GEP(rop.ll.type_triple(),
+                                                    missingcolor_buffer, i));
 
                 remainingMask = rop.ll.op_lanes_that_match_masked(
                     scalar_component, wide_component, remainingMask);
@@ -4822,7 +4853,8 @@ llvm_batched_texture_varying_options(BatchedBackendLLVM& rop, int opnum,
                 = rop.ll.op_extract(wide_missingalpha, leadLane);
             // Depending on how render services handles channels, might need to be 3 period.
             rop.ll.op_unmasked_store(scalar_missingalpha,
-                                     rop.ll.GEP(missingcolor_buffer, nchans));
+                                     rop.ll.GEP(rop.ll.type_triple(),
+                                                missingcolor_buffer, nchans));
 
             remainingMask = rop.ll.op_lanes_that_match_masked(
                 scalar_missingalpha, wide_missingalpha, remainingMask);
@@ -5451,8 +5483,9 @@ static llvm::Value*
 llvm_batched_trace_options(BatchedBackendLLVM& rop, int opnum,
                            int first_optional_arg)
 {
-    using TraceOpt   = RendererServices::TraceOpt;
-    llvm::Value* bto = rop.temp_batched_trace_options_ptr();
+    using TraceOpt       = RendererServices::TraceOpt;
+    llvm::Value* bto     = rop.temp_batched_trace_options_ptr();
+    llvm::Type* bto_type = rop.llvm_type_batched_trace_options();
 
     // Explicitly assign a default value or an optional parameter value to every data member
     // of TraceOpt.
@@ -5513,25 +5546,25 @@ llvm_batched_trace_options(BatchedBackendLLVM& rop, int opnum,
     if (is_mindist_uniform)
         rop.ll.op_unmasked_store(
             mindist,
-            rop.ll.GEP(bto, 0,
+            rop.ll.GEP(bto_type, bto, 0,
                        static_cast<int>(TraceOpt::LLVMMemberIndex::mindist)));
 
     if (is_maxdist_uniform)
         rop.ll.op_unmasked_store(
             maxdist,
-            rop.ll.GEP(bto, 0,
+            rop.ll.GEP(bto_type, bto, 0,
                        static_cast<int>(TraceOpt::LLVMMemberIndex::maxdist)));
 
     if (is_shade_uniform)
         rop.ll.op_unmasked_store(
             shade,
-            rop.ll.GEP(bto, 0,
+            rop.ll.GEP(bto_type, bto, 0,
                        static_cast<int>(TraceOpt::LLVMMemberIndex::shade)));
 
     if (is_traceset_uniform)
         rop.ll.op_unmasked_store(
             traceset,
-            rop.ll.GEP(bto, 0,
+            rop.ll.GEP(bto_type, bto, 0,
                        static_cast<int>(TraceOpt::LLVMMemberIndex::traceset)));
 
     return rop.ll.void_ptr(bto);
@@ -5545,8 +5578,9 @@ llvm_batched_trace_varying_options(BatchedBackendLLVM& rop, int opnum,
                                    llvm::Value* remainingMask,
                                    llvm::Value* leadLane)
 {
-    using TraceOpt   = RendererServices::TraceOpt;
-    llvm::Value* bto = rop.temp_batched_trace_options_ptr();
+    using TraceOpt       = RendererServices::TraceOpt;
+    llvm::Value* bto     = rop.temp_batched_trace_options_ptr();
+    llvm::Type* bto_type = rop.llvm_type_batched_trace_options();
 
     // The BatchedTraceOptions is local alloca,
     // so no need to mask off non-active lanes
@@ -5586,7 +5620,7 @@ llvm_batched_trace_varying_options(BatchedBackendLLVM& rop, int opnum,
         llvm::Value* scalar_value = rop.ll.op_extract(wide_val, leadLane);     \
         rop.ll.op_unmasked_store(                                              \
             scalar_value,                                                      \
-            rop.ll.GEP(bto, 0,                                                 \
+            rop.ll.GEP(bto_type, bto, 0,                                       \
                        static_cast<int>(                                       \
                            TraceOpt::LLVMMemberIndex::paramname)));            \
         remainingMask = rop.ll.op_lanes_that_match_masked(scalar_value,        \
@@ -6454,7 +6488,9 @@ LLVMGEN(llvm_gen_gettextureinfo)
                     rop.ll.current_mask());
                 rop.ll.call_function(resolve_udim_name.c_str(),
                                      resolve_udim_args);
-                udim_texture_handles = rop.ll.op_load(loc_texture_handles);
+                udim_texture_handles
+                    = rop.ll.op_load(rop.ll.type_wide_void_ptr(),
+                                     loc_texture_handles);
             }
         }
     }
@@ -6536,7 +6572,9 @@ LLVMGEN(llvm_gen_gettextureinfo)
                         lanesMatching);
                     rop.ll.call_function(resolve_udim_name.c_str(),
                                          resolve_udim_args);
-                    udim_texture_handles = rop.ll.op_load(loc_texture_handles);
+                    udim_texture_handles
+                        = rop.ll.op_load(rop.ll.type_wide_void_ptr(),
+                                         loc_texture_handles);
                 }
             }
             OSL_ASSERT(lanesMatching);
@@ -6841,8 +6879,11 @@ LLVMGEN(llvm_gen_get_simple_SG_field)
     bool is_uniform;
     int sg_index = rop.ShaderGlobalNameToIndex(op.opname(), is_uniform);
     OSL_ASSERT(sg_index >= 0);
-    llvm::Value* sg_field = rop.ll.GEP(rop.sg_ptr(), 0, sg_index);
-    llvm::Value* r        = rop.ll.op_load(sg_field);
+    llvm::Value* sg_field = rop.ll.GEP(rop.llvm_type_sg(), rop.sg_ptr(), 0,
+                                       sg_index);
+    llvm::Type* sg_field_type
+        = rop.ll.type_struct_field_at_index(rop.llvm_type_sg(), sg_index);
+    llvm::Value* r = rop.ll.op_load(sg_field_type, sg_field);
     rop.llvm_store_value(r, Result);
 
     return true;
@@ -7047,7 +7088,7 @@ LLVMGEN(llvm_gen_spline)
                                                                leadLane);
             args[splineNameArgumentIndex]  = scalar_splineName;
             lanesMatchingSplineName        = rop.ll.op_lanes_that_match_masked(
-                       scalar_splineName, splineNameVal, remainingMask);
+                scalar_splineName, splineNameVal, remainingMask);
 
             OSL_ASSERT(lanesMatchingSplineName);
             //rop.llvm_print_mask("lanesMatchingSplineName", lanesMatchingSplineName);
@@ -7121,11 +7162,12 @@ llvm_gen_keyword_fill(BatchedBackendLLVM& rop, Opcode& op,
                 llvm::Value* dest_base = rop.ll.offset_ptr(mem_void_ptr,
                                                            p.offset);
                 dest_base              = rop.llvm_ptr_cast(dest_base, p.type);
+                llvm::Type* dest_type  = rop.ll.llvm_type(p.type);
 
                 for (int c = 0; c < num_components; c++) {
                     llvm::Value* dest_elem;
                     if (num_components > 1)
-                        dest_elem = rop.ll.GEP(dest_base, 0, c);
+                        dest_elem = rop.ll.GEP(dest_type, dest_base, 0, c);
                     else
                         dest_elem = dest_base;
 
@@ -7231,7 +7273,9 @@ LLVMGEN(llvm_gen_closure)
     llvm::Value* comp_wide_ptr_ptr = rop.ll.ptr_cast(
         comp_void_ptr,
         rop.ll.type_ptr(rop.llvm_type_closure_component_wide_ptr()));
-    llvm::Value* comp_wide_ptr = rop.ll.op_load(comp_wide_ptr_ptr);
+    llvm::Value* comp_wide_ptr
+        = rop.ll.op_load(rop.llvm_type_closure_component_wide_ptr(),
+                         comp_wide_ptr_ptr);
 
     llvm::Value* mask = rop.ll.current_mask();
     // This is an unrolled vector-width loop.  It was unrolled because it's
@@ -7240,8 +7284,8 @@ LLVMGEN(llvm_gen_closure)
     for (int lane_index = 0; lane_index < rop.vector_width(); ++lane_index) {
         llvm::Value* comp_ptr = rop.ll.op_extract(comp_wide_ptr, lane_index);
         // Get the address of the primitive buffer, which is the 2nd field
-        llvm::Value* mem_void_ptr = rop.ll.GEP(comp_ptr, 0, 2);
-        ;
+        llvm::Value* mem_void_ptr
+            = rop.ll.GEP(rop.llvm_type_closure_component(), comp_ptr, 0, 2);
         mem_void_ptr = rop.ll.ptr_cast(mem_void_ptr, rop.ll.type_void_ptr());
 
         // For the weighted closures, we need a surrounding "if" so that it's safe
@@ -7290,7 +7334,7 @@ LLVMGEN(llvm_gen_closure)
 
             llvm::Value* dest_base = rop.ll.offset_ptr(mem_void_ptr, p.offset);
             llvm::Type* dest_type  = rop.ll.llvm_type(
-                 static_cast<const TypeSpec&>(p.type).simpletype());
+                static_cast<const TypeSpec&>(p.type).simpletype());
             dest_base = rop.ll.ptr_to_cast(dest_base, dest_type);
 
             if (num_elements > 1) {
@@ -7718,7 +7762,8 @@ LLVMGEN(llvm_gen_pointcloud_get)
 
             llvm::Value* binned_found_mask_value
                 = rop.ll.call_function(funcName, args);
-            found_mask_value = rop.ll.op_load(loc_of_foundMaskVal);
+            found_mask_value = rop.ll.op_load(rop.ll.type_int(),
+                                              loc_of_foundMaskVal);
             found_mask_value = rop.ll.op_or(found_mask_value,
                                             binned_found_mask_value);
             rop.ll.op_store(found_mask_value, loc_of_foundMaskVal);
@@ -7736,7 +7781,8 @@ LLVMGEN(llvm_gen_pointcloud_get)
         }
         // Continue on with the previous flow
         rop.ll.set_insert_point(after_block);
-        found_mask_value = rop.ll.op_load(loc_of_foundMaskVal);
+        found_mask_value = rop.ll.op_load(rop.ll.type_int(),
+                                          loc_of_foundMaskVal);
     } else {
         args[maskArgumentIndex] = rop.ll.mask_as_int(rop.ll.current_mask());
         found_mask_value        = rop.ll.call_function(funcName, args);
@@ -7886,7 +7932,8 @@ LLVMGEN(llvm_gen_pointcloud_write)
 
             llvm::Value* binned_success_mask_value
                 = rop.ll.call_function(funcName, args);
-            success_mask_value = rop.ll.op_load(loc_of_successesMaskVal);
+            success_mask_value = rop.ll.op_load(rop.ll.type_int(),
+                                                loc_of_successesMaskVal);
             success_mask_value = rop.ll.op_or(success_mask_value,
                                               binned_success_mask_value);
             rop.ll.op_store(success_mask_value, loc_of_successesMaskVal);
@@ -7904,7 +7951,8 @@ LLVMGEN(llvm_gen_pointcloud_write)
         }
         // Continue on with the previous flow
         rop.ll.set_insert_point(after_block);
-        success_mask_value = rop.ll.op_load(loc_of_successesMaskVal);
+        success_mask_value = rop.ll.op_load(rop.ll.type_int(),
+                                            loc_of_successesMaskVal);
     } else {
         args[maskArgumentIndex] = rop.ll.mask_as_int(rop.ll.current_mask());
         success_mask_value      = rop.ll.call_function(funcName, args);
@@ -8312,9 +8360,13 @@ LLVMGEN(llvm_gen_split)
         ret = rop.ll.widen_value(ret);
 
         OSL_ASSERT(temp_results_array);
+        // TODO: may be the wrong type
+        llvm::Type* elem_type = rop.ll.llvm_type(
+            Results.typespec().elementtype().simpletype());
         for (int ai = 0; ai < Results.typespec().arraylength(); ++ai) {
-            llvm::Value* elem_ptr  = rop.ll.GEP(temp_results_array, ai);
-            llvm::Value* elem      = rop.ll.op_load(elem_ptr);
+            llvm::Value* elem_ptr  = rop.ll.GEP(elem_type, temp_results_array,
+                                                ai);
+            llvm::Value* elem      = rop.ll.op_load(elem_type, elem_ptr);
             llvm::Value* wide_elem = rop.ll.widen_value(elem);
             rop.llvm_store_value(wide_elem, Results, 0 /*deriv*/,
                                  rop.ll.constant(ai) /*arrayindex*/,

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -1024,7 +1024,6 @@ BatchedBackendLLVM::llvm_assign_initial_value(
             // Because we allow temporaries and local results of comparison operations
             // to use the native bool type of i1, we can just skip initializing these
             // as they should always be assigned a value.
-            // TODO: is this equivalent to the old pointer type check? probably not
             if (!sym.forced_llvm_bool()) {
                 u = sym.is_uniform()
                         ? ll.constant(std::numeric_limits<int>::min())
@@ -1103,7 +1102,6 @@ BatchedBackendLLVM::llvm_assign_initial_value(
                 = ll.ptr_cast(ll.offset_ptr(m_llvm_userdata_base_ptr,
                                             sym_offset),
                               type.scalartype());
-            // TODO: may be the wrong type
             llvm::Type* userdata_type = ll.llvm_type(type.scalartype());
             bool isBase32bit          = (symloc->type != TypeDesc::STRING);
             int bytesPerElem          = isBase32bit ? 4 : 8;
@@ -1974,7 +1972,7 @@ BatchedBackendLLVM::build_llvm_instance(bool groupentry)
 
     llvm::Value* previously_executed_value = nullptr;
     if (!group().is_last_layer(layer())) {
-        previously_executed_value = ll.op_load(ll.type_wide_bool(), layerfield);
+        previously_executed_value = ll.op_load(ll.type_int(), layerfield);
     }
 
     if (is_entry_layer && !group().is_last_layer(layer())) {
@@ -2266,8 +2264,6 @@ BatchedBackendLLVM::build_llvm_instance(bool groupentry)
             continue;  // types didn't match
         }
         auto type = s.typespec().simpletype();
-        // TODO: may be the wrong type
-        auto scalar_type = ll.llvm_type(s.typespec().simpletype().scalartype());
 
         //const int deriv_count = (symloc->derivs && s.has_derivs()) ? 3 : 1;
         const int output_deriv_count = symloc->derivs ? 3 : 1;
@@ -2277,8 +2273,9 @@ BatchedBackendLLVM::build_llvm_instance(bool groupentry)
         llvm::Value* output_sym_base_ptr
             = ll.ptr_cast(ll.offset_ptr(m_llvm_output_base_ptr, sym_offset),
                           type.scalartype());
-        bool isBase32bit = (symloc->type != TypeDesc::STRING);
-        int bytesPerElem = isBase32bit ? 4 : 8;
+        auto sym_base_ptr_type = ll.llvm_type(type.scalartype());
+        bool isBase32bit       = (symloc->type != TypeDesc::STRING);
+        int bytesPerElem       = isBase32bit ? 4 : 8;
         // TODO:  could move assert inside SymLocation
         OSL_ASSERT((symloc->stride % bytesPerElem) == 0);
 
@@ -2318,8 +2315,8 @@ BatchedBackendLLVM::build_llvm_instance(bool groupentry)
                         wide_index = ll.op_add(wide_index_to_output,
                                                ll.wide_constant(c));
                     }
-                    ll.op_scatter(scalar_type, wide_val, output_sym_base_ptr,
-                                  wide_index);
+                    ll.op_scatter(wide_val, sym_base_ptr_type,
+                                  output_sym_base_ptr, wide_index);
                 }
             }
         }

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -326,7 +326,10 @@ public:
     {
         mm->registerEHFrames(Addr, LoadAddr, Size);
     }
-    void deregisterEHFrames() override { mm->deregisterEHFrames(); }
+    void deregisterEHFrames() override
+    {
+        mm->deregisterEHFrames();
+    }
 
     uint64_t getSymbolAddress(const std::string& Name) override
     {
@@ -735,17 +738,17 @@ LLVM_Util::debug_push_inlined_function(OIIO::ustring function_name,
         llvm::DINode::FlagPrototyped | llvm::DINode::FlagNoReturn);
     llvm::DISubprogram* function = nullptr;
     function                     = m_llvm_debug_builder->createFunction(
-        mDebugCU,               // Scope
-        function_name.c_str(),  // Name
-        // We are inlined function so not sure supplying a linkage name
-        // makes sense
-        /*function_name.c_str()*/ llvm::StringRef(),  // Linkage Name
-        file,                                   // File
-        static_cast<unsigned int>(sourceline),  // Line Number
-        mSubTypeForInlinedFunction,  // subroutine type
-        method_scope_line,           // Scope Line,
-        fnFlags,
-        llvm::DISubprogram::toSPFlags(true /*isLocalToUnit*/,
+                            mDebugCU,               // Scope
+                            function_name.c_str(),  // Name
+                            // We are inlined function so not sure supplying a linkage name
+                            // makes sense
+                            /*function_name.c_str()*/ llvm::StringRef(),  // Linkage Name
+                            file,                                   // File
+                            static_cast<unsigned int>(sourceline),  // Line Number
+                            mSubTypeForInlinedFunction,  // subroutine type
+                            method_scope_line,           // Scope Line,
+                            fnFlags,
+                            llvm::DISubprogram::toSPFlags(true /*isLocalToUnit*/,
                                                           true /*isDefinition*/,
                                                           true /*false*/ /*isOptimized*/));
 
@@ -4224,8 +4227,8 @@ LLVM_Util::op_gather(llvm::Type* ptr_type, llvm::Value* ptr,
 
             llvm::Value* unmasked_value = wide_constant(0.0f);
             llvm::Value* args[]         = {
-                unmasked_value, void_ptr(ptr), wide_index, int_mask,
-                constant(4)  // not sure why the scale
+                        unmasked_value, void_ptr(ptr), wide_index, int_mask,
+                        constant(4)  // not sure why the scale
             };
             return builder().CreateCall(func_avx512_gather_ps,
                                         toArrayRef(args));
@@ -5160,9 +5163,9 @@ LLVM_Util::apply_return_to(llvm::Value* existing_mask)
     OSL_ASSERT(masked_function_context().return_count > 0);
 
     llvm::Value* loc_of_return_mask = masked_function_context().location_of_mask;
-    llvm::Value* rs_mask = op_load_mask(loc_of_return_mask);
-    llvm::Value* result  = builder().CreateSelect(rs_mask, existing_mask,
-                                                  rs_mask);
+    llvm::Value* rs_mask            = op_load_mask(loc_of_return_mask);
+    llvm::Value* result = builder().CreateSelect(rs_mask, existing_mask,
+                                                 rs_mask);
     return result;
 }
 

--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -109,7 +109,7 @@ test_triple_func()
     OSL::pvt::LLVM_Util::PerThreadInfo pti;
     OSL::pvt::LLVM_Util ll(pti);
 
-    // Make a function with prototype:   int myadd (int arg1, int arg2)
+    // Make a function with prototype:   Vec3 myadd (Vec3 *arg1, float arg2)
     // and make it the current function.
     auto func = ll.make_function("myaddv",        // name
                                  false,           // fastcall
@@ -124,9 +124,12 @@ test_triple_func()
     llvm::Value* aptr = ll.current_function_arg(1);
     llvm::Value* b    = ll.current_function_arg(2);
     for (int i = 0; i < 3; ++i) {
-        llvm::Value* r_elptr = ll.GEP(rptr, 0, i);
-        llvm::Value* a_elptr = ll.GEP(aptr, 0, i);
-        llvm::Value* product = ll.op_mul(ll.op_load(a_elptr), b);
+        llvm::Value* r_elptr = ll.GEP((llvm::Type*)ll.type_triple(), rptr, 0,
+                                      i);
+        llvm::Value* a_elptr = ll.GEP((llvm::Type*)ll.type_triple(), aptr, 0,
+                                      i);
+        llvm::Value* product = ll.op_mul(ll.op_load(ll.type_float(), a_elptr),
+                                         b);
         ll.op_store(product, r_elptr);
     }
     ll.op_return();


### PR DESCRIPTION
## Description

LLVM 16 was released a while ago but OSL does not support it yet. The main challenge is that this version requires opaque pointers, that is you can no longer tell from a pointer value which data type it points to.

Changes made:

* Bump minimum supported LLVM version to 16.
* Enable opaque pointers on LLVM 15 and 16.
* Remove deprecated `GEP` and `op_load` methods without type, and refactor code to always pass the type.
* Add element type argument to `op_scatter` and `op_gather`.
* Eliminate some pointer type comparison which no longer work with opaque pointers. Some asserts remain which pass but are not so useful with opaque pointers.
* Add `clangASTMatchers` library for LLVM 16, will be skipped for older LLVM version.
* Rename `makeArrayRef` to `toArrayRef` to `llvm::makeArrayRef` deprecation warnings.
* Minor required changes related to `llvm::Align`.
* Add support for new pass manager, as the legacy pass manager no longer supports default optimization levels.
* The legacy pass manager is still used for custom optimization levels 10-13.

Remaining work:

* OptiX support was not tested yet. It is likely broken due to the sneaky conversion in `BackendLLVM::llvm_store_value` between `int64` and `char*`, but we can no longer compare the pointer type. This function is called from many places and it's unclear to me when this happens. According to a4e779c4 this code is only temporary.

## Tests

No new tests as the whole testsuite covers this.

Some tests are failing currently as this is work in progress.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

