### PR TITLE
LLVM opaque pointers support

### DIFF
--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -128,7 +128,7 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
         set (CLANG_MSVC_FIX "${CLANG_MSVC_FIX} -Wno-ignored-attributes -Wno-unknown-attributes")
     endif ()
 
-    if (${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
+    if (NOT LLVM_OPAQUE_POINTERS AND ${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
         # Until we fully support opaque pointers, we need to disable
         # them when using LLVM 15.
         list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -161,6 +161,15 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 16.0)
     endif ()
 endif ()
 
+# Use opaque pointers starting with LLVM 15
+# Except when using OptiX, due to issue noted in BackendLLVM::llvm_store_value
+if (NOT OSL_USE_OPTIX AND ${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
+  set(LLVM_OPAQUE_POINTERS ON)
+  add_definitions (-DOSL_LLVM_OPAQUE_POINTERS)
+else()
+  set(LLVM_OPAQUE_POINTERS OFF)
+endif()
+
 checked_find_package (partio)
 
 

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -163,7 +163,7 @@ endif ()
 
 # Use opaque pointers starting with LLVM 15
 # Except when using OptiX, due to issue noted in BackendLLVM::llvm_store_value
-if (NOT OSL_USE_OPTIX AND ${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
+if (${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
   set(LLVM_OPAQUE_POINTERS ON)
   add_definitions (-DOSL_LLVM_OPAQUE_POINTERS)
 else()

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -161,9 +161,8 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 16.0)
     endif ()
 endif ()
 
-# Use opaque pointers starting with LLVM 15
-# Except when using OptiX, due to issue noted in BackendLLVM::llvm_store_value
-if (${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
+# Use opaque pointers starting with LLVM 16
+if (${LLVM_VERSION} VERSION_GREATER_EQUAL 16.0)
   set(LLVM_OPAQUE_POINTERS ON)
   add_definitions (-DOSL_LLVM_OPAQUE_POINTERS)
 else()

--- a/src/cmake/llvm_macros.cmake
+++ b/src/cmake/llvm_macros.cmake
@@ -72,7 +72,7 @@ function ( EMBED_LLVM_BITCODE_IN_CPP src_list suffix output_name list_to_append_
         list (TRANSFORM include_dirs PREPEND -I
             OUTPUT_VARIABLE ALL_INCLUDE_DIRS)
 
-        if (${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
+        if (NOT LLVM_OPAQUE_POINTERS AND ${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
             # Until we fully support opaque pointers, we need to disable
             # them when using LLVM 15.
             list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -903,7 +903,7 @@ public:
     llvm::Value* op_load(llvm::Type* type, llvm::Value* ptr,
                          const std::string& llname = {});
 
-    llvm::Value* op_gather(llvm::Type* ptr_type, llvm::Value* ptr,
+    llvm::Value* op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
                            llvm::Value* wide_index);
 
     /// Store to a dereferenced pointer
@@ -921,8 +921,8 @@ public:
     /// converting it to the native mask type for storage:   *ptr = llvm_mask_to_native(val);
     void op_store_mask(llvm::Value* llvm_mask, llvm::Value* native_mask_ptr);
 
-    void op_scatter(llvm::Value* wide_val, llvm::Type* ptr_type,
-                    llvm::Value* ptr, llvm::Value* wide_index);
+    void op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
+                    llvm::Value* src_ptr, llvm::Value* wide_index);
 
     // N.B. "GEP" -- GetElementPointer -- is a particular LLVM-ism that is
     // the means for retrieving elements from some kind of aggregate: the

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -633,6 +633,9 @@ public:
                             const std::string& name = "",
                             bool is_packed          = false);
 
+    // Return type of field at given index in a struct type.
+    llvm::Type* type_struct_field_at_index(llvm::Type* type, int index);
+
     /// Return the llvm::Type that is a pointer to the given llvm type.
     llvm::PointerType* type_ptr(llvm::Type* type);
 
@@ -899,10 +902,9 @@ public:
     /// type is the type of the thing being pointed to.
     llvm::Value* op_load(llvm::Type* type, llvm::Value* ptr,
                          const std::string& llname = {});
-    // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* op_load(llvm::Value* ptr, const std::string& llname = {});
 
-    llvm::Value* op_gather(llvm::Value* ptr, llvm::Value* index);
+    llvm::Value* op_gather(llvm::Type* ptr_type, llvm::Value* ptr,
+                           llvm::Value* wide_index);
 
     /// Store to a dereferenced pointer
     /// respecting the current mask & masking_enabled flag:   *ptr = val
@@ -919,8 +921,8 @@ public:
     /// converting it to the native mask type for storage:   *ptr = llvm_mask_to_native(val);
     void op_store_mask(llvm::Value* llvm_mask, llvm::Value* native_mask_ptr);
 
-    void op_scatter(llvm::Value* wide_val, llvm::Value* ptr,
-                    llvm::Value* wide_index);
+    void op_scatter(llvm::Value* wide_val, llvm::Type* ptr_type,
+                    llvm::Value* ptr, llvm::Value* wide_index);
 
     // N.B. "GEP" -- GetElementPointer -- is a particular LLVM-ism that is
     // the means for retrieving elements from some kind of aggregate: the
@@ -933,16 +935,10 @@ public:
     /// we're retrieving.
     llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, llvm::Value* elem,
                      const std::string& llname = {});
-    // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, llvm::Value* elem,
-                     const std::string& llname = {});
 
     /// Generate a GEP (get element pointer) with an integer element
     /// offset. `type` is the type of the data we're retrieving.
     llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem,
-                     const std::string& llname = {});
-    // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, int elem,
                      const std::string& llname = {});
 
     /// Generate a GEP (get element pointer) with two integer element
@@ -952,9 +948,14 @@ public:
     /// retrieving.
     llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2,
                      const std::string& llname = {});
-    // Blind pointer version that's deprecated as of LLVM13:
-    llvm::Value* GEP(llvm::Value* ptr, int elem1, int elem2,
-                     const std::string& llname = {});
+
+    /// Generate a GEP (get element pointer) with three integer element
+    /// offsets.  This is just a special (and common) case of GEP where
+    /// we have a 3-level hierarchy and we have fixed element indices
+    /// that are known at compile time.  `type` is the type of the data we're
+    /// retrieving.
+    llvm::Value* GEP(llvm::Type* type, llvm::Value* ptr, int elem1, int elem2,
+                     int elem3, const std::string& llname = {});
 
     // Arithmetic ops.  It auto-detects the type (int vs float).
     // ...

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -749,7 +749,8 @@ llvm::Value*
 BackendLLVM::layer_run_ref(int layer)
 {
     int fieldnum = 0;  // field 0 is the layer_run array
-    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum, layer);
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum, layer,
+                  llnamefmt("layer_runflags_ref"));
 }
 
 
@@ -759,7 +760,7 @@ BackendLLVM::userdata_initialized_ref(int userdata_index)
 {
     int fieldnum = 1;  // field 1 is the userdata_initialized array
     return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum,
-                  userdata_index);
+                  userdata_index, llnamefmt("userdata_init_flags_ref"));
 }
 
 

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -509,8 +509,8 @@ BackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type, int deriv,
         ptr = ll.GEP(element_type, ptr, 0, component);
 
     // Now grab the value
-    llvm::Type* scalar_type = llvm_type(t.scalartype());
-    llvm::Value* result     = ll.op_load(scalar_type, ptr, llname);
+    llvm::Type* component_type = llvm_type(t.scalartype());
+    llvm::Value* result        = ll.op_load(component_type, ptr, llname);
 
     if (type.is_closure_based())
         return result;

--- a/src/liboslexec/backendllvm.cpp
+++ b/src/liboslexec/backendllvm.cpp
@@ -212,7 +212,7 @@ BackendLLVM::llvm_global_symbol_ptr(ustring name)
     // the ShaderGlobals struct.
     int sg_index = ShaderGlobalNameToIndex(name);
     OSL_ASSERT(sg_index >= 0);
-    return ll.void_ptr(ll.GEP(sg_ptr(), 0, sg_index),
+    return ll.void_ptr(ll.GEP(llvm_type_sg(), sg_ptr(), 0, sg_index),
                        llnamefmt("glob_{}_voidptr", name));
 }
 
@@ -429,7 +429,7 @@ BackendLLVM::llvm_get_pointer(const Symbol& sym, int deriv,
             arrayindex = ll.op_add(arrayindex, ll.constant(d));
         else
             arrayindex = ll.constant(d);
-        result = ll.GEP(result, arrayindex);
+        result = ll.GEP(llvm_type(t.elementtype()), result, arrayindex);
     }
 
     return result;
@@ -493,22 +493,24 @@ BackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type, int deriv,
 
     // If it's an array or we're dealing with derivatives, step to the
     // right element.
-    TypeDesc t = type.simpletype();
+    TypeDesc t               = type.simpletype();
+    llvm::Type* element_type = llvm_type(t.elementtype());
     if (t.arraylen || deriv) {
         int d = deriv * std::max(1, t.arraylen);
         if (arrayindex)
             arrayindex = ll.op_add(arrayindex, ll.constant(d));
         else
             arrayindex = ll.constant(d);
-        ptr = ll.GEP(ptr, arrayindex);
+        ptr = ll.GEP(element_type, ptr, arrayindex);
     }
 
     // If it's multi-component (triple or matrix), step to the right field
     if (!type.is_closure_based() && t.aggregate > 1)
-        ptr = ll.GEP(ptr, 0, component);
+        ptr = ll.GEP(element_type, ptr, 0, component);
 
     // Now grab the value
-    llvm::Value* result = ll.op_load(ptr, llname);
+    llvm::Type* scalar_type = llvm_type(t.scalartype());
+    llvm::Value* result     = ll.op_load(scalar_type, ptr, llname);
 
     if (type.is_closure_based())
         return result;
@@ -597,10 +599,10 @@ BackendLLVM::llvm_load_component_value(const Symbol& sym, int deriv,
     OSL_DASSERT(sym.typespec().simpletype().aggregate != TypeDesc::SCALAR);
     // cast the Vec* to a float*
     result = ll.ptr_cast(result, ll.type_float_ptr());
-    result = ll.GEP(result, component);  // get the component
+    result = ll.GEP(ll.type_float(), result, component);  // get the component
 
     // Now grab the value
-    return ll.op_load(result);
+    return ll.op_load(ll.type_float(), result);
 }
 
 
@@ -664,21 +666,23 @@ BackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
 
     // If it's an array or we're dealing with derivatives, step to the
     // right element.
-    TypeDesc t = type.simpletype();
+    TypeDesc t               = type.simpletype();
+    llvm::Type* element_type = llvm_type(t.elementtype());
     if (t.arraylen || deriv) {
         int d = deriv * std::max(1, t.arraylen);
         if (arrayindex)
             arrayindex = ll.op_add(arrayindex, ll.constant(d));
         else
             arrayindex = ll.constant(d);
-        dst_ptr = ll.GEP(dst_ptr, arrayindex);
+        dst_ptr = ll.GEP(element_type, dst_ptr, arrayindex);
     }
 
     // If it's multi-component (triple or matrix), step to the right field
     if (!type.is_closure_based() && t.aggregate > 1)
-        dst_ptr = ll.GEP(dst_ptr, 0, component);
+        dst_ptr = ll.GEP(element_type, dst_ptr, 0, component);
 
     // Finally, store the value.
+    // TODO: this breaks OptiX, pointer type comparison no longer works with opaque pointers.
     if (t == TypeString && dst_ptr->getType() == ll.type_int64_ptr()
         && new_val->getType() == ll.type_char_ptr()) {
         // Special case: we are still ickily storing strings sometimes as a
@@ -711,7 +715,7 @@ BackendLLVM::llvm_store_component_value(llvm::Value* new_val, const Symbol& sym,
     OSL_DASSERT(sym.typespec().simpletype().aggregate != TypeDesc::SCALAR);
     // cast the Vec* to a float*
     result = ll.ptr_cast(result, ll.type_float_ptr());
-    result = ll.GEP(result, component);  // get the component
+    result = ll.GEP(ll.type_float(), result, component);  // get the component
 
     // Finally, store the value.
     ll.op_store(new_val, result);
@@ -723,7 +727,7 @@ BackendLLVM::llvm_store_component_value(llvm::Value* new_val, const Symbol& sym,
 llvm::Value*
 BackendLLVM::groupdata_field_ref(int fieldnum)
 {
-    return ll.GEP(groupdata_ptr(), 0, fieldnum,
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum,
                   llnamefmt("{}_ref", m_groupdata_field_names[fieldnum]));
 }
 
@@ -744,9 +748,8 @@ BackendLLVM::groupdata_field_ptr(int fieldnum, TypeDesc type)
 llvm::Value*
 BackendLLVM::layer_run_ref(int layer)
 {
-    int fieldnum           = 0;  // field 0 is the layer_run array
-    llvm::Value* layer_run = groupdata_field_ref(fieldnum);
-    return ll.GEP(layer_run, 0, layer);
+    int fieldnum = 0;  // field 0 is the layer_run array
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum, layer);
 }
 
 
@@ -755,8 +758,8 @@ llvm::Value*
 BackendLLVM::userdata_initialized_ref(int userdata_index)
 {
     int fieldnum = 1;  // field 1 is the userdata_initialized array
-    llvm::Value* userdata_initialized = groupdata_field_ref(fieldnum);
-    return ll.GEP(userdata_initialized, 0, userdata_index);
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum,
+                  userdata_index);
 }
 
 
@@ -943,11 +946,13 @@ BackendLLVM::llvm_assign_impl(Symbol& Result, Symbol& Src, int arrayindex,
                 if (Result.has_derivs()
                     && Result.typespec().elementtype().is_float_based()) {
                     // dx
-                    ll.op_memset(ll.GEP(llvm_void_ptr(Result, 1), dstcomp), 0,
-                                 1, rt.basesize());
+                    ll.op_memset(ll.GEP(ll.type_void_ptr(),
+                                        llvm_void_ptr(Result, 1), dstcomp),
+                                 0, 1, rt.basesize());
                     // dy
-                    ll.op_memset(ll.GEP(llvm_void_ptr(Result, 2), dstcomp), 0,
-                                 1, rt.basesize());
+                    ll.op_memset(ll.GEP(ll.type_void_ptr(),
+                                        llvm_void_ptr(Result, 2), dstcomp),
+                                 0, 1, rt.basesize());
                 }
             } else
                 llvm_zero_derivs(Result);

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -2097,7 +2097,13 @@ struct Analyzer {
     {
         bool previously_was_uniform = symbol_to_be_varying->is_uniform();
         if (previously_was_uniform | force) {
-            symbol_to_be_varying->make_varying();
+            // Interactive params are never varying, following getLLVMSymbolBase()
+            const bool force_uniform = symbol_to_be_varying->symtype()
+                                           == SymTypeParam
+                                       && symbol_to_be_varying->interactive();
+            if (!force_uniform) {
+                symbol_to_be_varying->make_varying();
+            }
             auto range = m_symbols_dependent_upon.equal_range(
                 symbol_to_be_varying);
             auto iter = range.first;

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -136,6 +136,7 @@ BatchedBackendLLVM::BatchedBackendLLVM(ShadingSystemImpl& shadingsys,
     , m_stat_llvm_opt_time(0)
     , m_stat_llvm_jit_time(0)
 {
+    m_name_llvm_syms  = shadingsys.m_llvm_output_bitcode;
     m_wide_arg_prefix = "W";
     switch (vector_width()) {
     case 16: m_true_mask_value = Mask<16>(true).value(); break;
@@ -1544,7 +1545,8 @@ BatchedBackendLLVM::llvm_conversion_store_uniform_status(llvm::Value* val,
 llvm::Value*
 BatchedBackendLLVM::groupdata_field_ref(int fieldnum)
 {
-    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum);
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum,
+                  llnamefmt("{}_ref", m_groupdata_field_names[fieldnum]));
 }
 
 
@@ -1616,7 +1618,8 @@ llvm::Value*
 BatchedBackendLLVM::layer_run_ref(int layer)
 {
     int fieldnum = 0;  // field 0 is the layer_run array
-    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum, layer);
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum, layer,
+                  llnamefmt("layer_runflags_ref"));
 }
 
 
@@ -1626,7 +1629,7 @@ BatchedBackendLLVM::userdata_initialized_ref(int userdata_index)
 {
     int fieldnum = 1;  // field 1 is the userdata_initialized array
     return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum,
-                  userdata_index);
+                  userdata_index, llnamefmt("userdata_init_flags_ref"));
 }
 
 

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -374,7 +374,7 @@ BatchedBackendLLVM::llvm_zero_derivs(const Symbol& sym, llvm::Value* count)
         llvm::BasicBlock* after_block = ll.new_basic_block("zero deriv after");
 
         ll.op_branch(cond_block);
-        llvm::Value* index_val           = ll.op_load(index_loc);
+        llvm::Value* index_val           = ll.op_load(ll.type_int(), index_loc);
         llvm::Value* windex_val          = ll.widen_value(index_val);
         llvm::Value* condition_mask      = ll.op_lt(windex_val, count);
         llvm::Value* post_condition_mask = ll.op_and(condition_mask,
@@ -427,7 +427,7 @@ BatchedBackendLLVM::llvm_global_symbol_ptr(ustring name, bool& is_uniform)
     // the ShaderGlobals struct.
     int sg_index = ShaderGlobalNameToIndex(name, is_uniform);
     OSL_ASSERT(sg_index >= 0);
-    return ll.void_ptr(ll.GEP(sg_ptr(), 0, sg_index));
+    return ll.void_ptr(ll.GEP(llvm_type_sg(), sg_ptr(), 0, sg_index));
 }
 
 
@@ -670,7 +670,12 @@ BatchedBackendLLVM::llvm_get_pointer(const Symbol& sym, int deriv,
             arrayindex = ll.op_add(arrayindex, ll.constant(d));
         else
             arrayindex = ll.constant(d);
-        result = ll.GEP(result, arrayindex);
+
+        llvm::Type* result_type = llvm_type(t.elementtype());
+        if (!sym.is_uniform()) {
+            result_type = ll.type_wide(result_type);
+        }
+        result = ll.GEP(result_type, result, arrayindex);
     }
 
     return result;
@@ -697,7 +702,7 @@ BatchedBackendLLVM::llvm_widen_value_into_temp(const Symbol& sym, int deriv)
         // NOTE: we use the passed deriv to load, but store to value (deriv==0)
         llvm::Value* v = llvm_load_value(sym, deriv, c, TypeDesc::UNKNOWN,
                                          /*is_uniform*/ false);
-        llvm_store_value(v, widePtr, t, 0, NULL, c);
+        llvm_store_value(v, widePtr, t, 0, NULL, c, /*is_uniform*/ false);
     }
     return ll.void_ptr(widePtr);
 }
@@ -784,8 +789,9 @@ BatchedBackendLLVM::llvm_load_value(const Symbol& sym, int deriv,
     OSL_DEV_ONLY(std::cout << "  llvm_load_value " << sym.typespec().string()
                            << " cast " << cast << std::endl);
     return llvm_load_value(llvm_get_pointer(sym), sym.typespec(), deriv,
-                           arrayindex, component, cast, op_is_uniform,
-                           index_is_uniform, sym.forced_llvm_bool());
+                           arrayindex, component, sym.is_uniform(), cast,
+                           op_is_uniform, index_is_uniform,
+                           sym.forced_llvm_bool());
 }
 
 
@@ -816,17 +822,37 @@ BatchedBackendLLVM::llvm_load_mask(const Symbol& cond)
 llvm::Value*
 BatchedBackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
                                     int deriv, llvm::Value* arrayindex,
-                                    int component, TypeDesc cast,
-                                    bool op_is_uniform, bool index_is_uniform,
+                                    int component, bool ptr_is_uniform,
+                                    TypeDesc cast, bool op_is_uniform,
+                                    bool index_is_uniform,
                                     bool symbol_forced_boolean)
 {
     if (!ptr)
         return NULL;  // Error
 
+    TypeDesc t = type.simpletype();
+    llvm::Type *ptr_type, *ptr_scalar_type;
+
+    if (symbol_forced_boolean) {
+        if (ptr_is_uniform) {
+            ptr_type        = ll.type_bool();
+            ptr_scalar_type = ll.type_bool();
+        } else {
+            ptr_type        = ll.type_native_mask();
+            ptr_scalar_type = ll.type_native_mask();
+        }
+    } else {
+        ptr_type        = llvm_type(t.elementtype());
+        ptr_scalar_type = llvm_type(t.scalartype());
+        if (!ptr_is_uniform) {
+            ptr_type        = ll.type_wide(ptr_type);
+            ptr_scalar_type = ll.type_wide(ptr_scalar_type);
+        }
+    }
+
     if (index_is_uniform) {
         // If it's an array or we're dealing with derivatives, step to the
         // right element.
-        TypeDesc t = type.simpletype();
         if (t.arraylen || deriv) {
             int d = deriv * std::max(1, t.arraylen);
             llvm::Value* elem;
@@ -834,19 +860,18 @@ BatchedBackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
                 elem = ll.op_add(arrayindex, ll.constant(d));
             else
                 elem = ll.constant(d);
-            ptr = ll.GEP(ptr, elem);
+            ptr = ll.GEP(ptr_type, ptr, elem);
         }
 
         // If it's multi-component (triple or matrix), step to the right field
         if (!type.is_closure_based() && t.aggregate > 1) {
             OSL_DEV_ONLY(std::cout << "step to the right field " << component
                                    << std::endl);
-            ptr = ll.GEP(ptr, 0, component);
+            ptr = ll.GEP(ptr_type, ptr, 0, component);
         }
 
         // Now grab the value
-        llvm::Value* result;
-        result = ll.op_load(ptr);
+        llvm::Value* result = ll.op_load(ptr_scalar_type, ptr);
 
         if (type.is_closure_based())
             return result;
@@ -928,18 +953,17 @@ BatchedBackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
         OSL_ASSERT(nullptr != arrayindex);
         // If it's an array or we're dealing with derivatives, step to the
         // right element.
-        TypeDesc t = type.simpletype();
         if (t.arraylen || deriv) {
             int d             = deriv * std::max(1, t.arraylen);
             llvm::Value* elem = ll.constant(d);
-            ptr               = ll.GEP(ptr, elem);
+            ptr               = ll.GEP(ptr_type, ptr, elem);
         }
 
         // If it's multi-component (triple or matrix), step to the right field
         if (!type.is_closure_based() && t.aggregate > 1) {
             OSL_DEV_ONLY(std::cout << "step to the right field " << component
                                    << std::endl);
-            ptr = ll.GEP(ptr, 0, component);
+            ptr = ll.GEP(ptr_type, ptr, 0, component);
 
             // Need to scale the indices by the stride
             // of the type
@@ -951,8 +975,7 @@ BatchedBackendLLVM::llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
         }
 
         // Now grab the value
-        llvm::Value* result;
-        result = ll.op_gather(ptr, arrayindex);
+        llvm::Value* result = ll.op_gather(ptr_scalar_type, ptr, arrayindex);
         // TODO:  possible optimization when we know the array size is small (<= 4)
         // instead of performing a gather, we could load each value of the the array,
         // compare the index array against that value's index and select/blend
@@ -1083,21 +1106,25 @@ BatchedBackendLLVM::llvm_load_component_value(const Symbol& sym, int deriv,
     OSL_ASSERT(t.aggregate != TypeDesc::SCALAR);
     // cast the Vec* to a float*
 
+    llvm::Type* pointer_type;
     if (sym.is_uniform()) {
-        pointer = ll.ptr_cast(pointer, ll.type_float_ptr());
+        pointer      = ll.ptr_cast(pointer, ll.type_float_ptr());
+        pointer_type = ll.type_float();
     } else {
-        pointer = ll.ptr_cast(pointer, ll.type_wide_float_ptr());
+        pointer      = ll.ptr_cast(pointer, ll.type_wide_float_ptr());
+        pointer_type = ll.type_wide_float();
     }
 
     llvm::Value* result;
     if (component_is_uniform) {
-        llvm::Value* component_pointer = ll.GEP(pointer, component);
+        llvm::Value* component_pointer = ll.GEP(pointer_type, pointer,
+                                                component);
 
         // Now grab the value
-        result = ll.op_load(component_pointer);
+        result = ll.op_load(pointer_type, component_pointer);
     } else {
         OSL_ASSERT(!op_is_uniform);
-        result = ll.op_gather(pointer, component);
+        result = ll.op_gather(pointer_type, pointer, component);
         // TODO:  possible optimization when we know the # of components is small (<= 4)
         // instead of performing a gather, we could load each value of the components,
         // compare the component index against that value's index and select/blend
@@ -1145,13 +1172,15 @@ BatchedBackendLLVM::llvm_load_arg(const Symbol& sym, bool derivs,
                                            op_is_uniform);
 
             // Have to have a place on the stack for the pointer to the wide constant to point to
-            const TypeSpec& t   = sym.typespec();
-            llvm::Value* tmpptr = getOrAllocateTemp(t, false /*derivs*/,
-                                                    false /*is_uniform*/);
+            const TypeSpec& t         = sym.typespec();
+            const bool tmp_is_uniform = false;
+            llvm::Value* tmpptr       = getOrAllocateTemp(t, false /*derivs*/,
+                                                          tmp_is_uniform);
 
             // Store our wide pointer on the stack
             auto disable_masked_stores = ll.create_masking_scope(false);
-            llvm_store_value(wide_constant_value, tmpptr, t, 0, NULL, 0);
+            llvm_store_value(wide_constant_value, tmpptr, t, 0, NULL, 0,
+                             tmp_is_uniform);
 
             // return pointer to our stacked wide constant
             return ll.void_ptr(tmpptr);
@@ -1178,7 +1207,8 @@ BatchedBackendLLVM::llvm_load_arg(const Symbol& sym, bool derivs,
                     llvm::Value* v = llvm_load_value(sym, d, arrayIndex, c,
                                                      TypeDesc::UNKNOWN,
                                                      op_is_uniform);
-                    llvm_store_value(v, tmpptr, t, d, arrayIndex, c);
+                    llvm_store_value(v, tmpptr, t, d, arrayIndex, c,
+                                     op_is_uniform);
                 }
             }
         }
@@ -1190,9 +1220,9 @@ BatchedBackendLLVM::llvm_load_arg(const Symbol& sym, bool derivs,
             else
                 zero = ll.wide_constant(0.0f);
             for (int c = 0; c < t.aggregate(); ++c)
-                llvm_store_value(zero, tmpptr, t, 1, NULL, c);
+                llvm_store_value(zero, tmpptr, t, 1, NULL, c, op_is_uniform);
             for (int c = 0; c < t.aggregate(); ++c)
-                llvm_store_value(zero, tmpptr, t, 2, NULL, c);
+                llvm_store_value(zero, tmpptr, t, 2, NULL, c, op_is_uniform);
         }
         return ll.void_ptr(tmpptr);
     }
@@ -1232,7 +1262,8 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, const Symbol& sym,
     }
 
     return llvm_store_value(new_val, llvm_get_pointer(sym), sym.typespec(),
-                            deriv, arrayindex, component, index_is_uniform);
+                            deriv, arrayindex, component, sym.is_uniform(),
+                            index_is_uniform);
 }
 
 
@@ -1241,28 +1272,36 @@ bool
 BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
                                      const TypeSpec& type, int deriv,
                                      llvm::Value* arrayindex, int component,
-                                     bool index_is_uniform)
+                                     bool dst_is_uniform, bool index_is_uniform)
 {
     if (!dst_ptr)
         return false;  // Error
 
+    TypeDesc t                  = type.simpletype();
+    llvm::Type* dst_type        = llvm_type(t.elementtype());
+    llvm::Type* dst_scalar_type = llvm_type(t.scalartype());
+    if (!dst_is_uniform) {
+        dst_type        = ll.type_wide(dst_type);
+        dst_scalar_type = ll.type_wide(dst_scalar_type);
+    }
+
     if (index_is_uniform) {
         // If it's an array or we're dealing with derivatives, step to the
         // right element.
-        TypeDesc t = type.simpletype();
         if (t.arraylen || deriv) {
             int d = deriv * std::max(1, t.arraylen);
             if (arrayindex)
                 arrayindex = ll.op_add(arrayindex, ll.constant(d));
             else
                 arrayindex = ll.constant(d);
-            dst_ptr = ll.GEP(dst_ptr, arrayindex);
+            dst_ptr = ll.GEP(dst_type, dst_ptr, arrayindex);
         }
 
         // If it's multi-component (triple or matrix), step to the right field
         if (!type.is_closure_based() && t.aggregate > 1)
-            dst_ptr = ll.GEP(dst_ptr, 0, component);
+            dst_ptr = ll.GEP(dst_type, dst_ptr, 0, component);
 
+#ifndef OSL_LLVM_OPAQUE_POINTERS
         if ((const llvm::Type*)ll.type_ptr(ll.llvm_typeof(new_val))
             != ll.llvm_typeof(dst_ptr)) {
             std::cerr << " new_val type=";
@@ -1279,6 +1318,7 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
         }
         OSL_ASSERT((const llvm::Type*)ll.type_ptr(ll.llvm_typeof(new_val))
                    == ll.llvm_typeof(dst_ptr));
+#endif
 
         // Finally, store the value.
         ll.op_store(new_val, dst_ptr);
@@ -1288,18 +1328,17 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
 
         // If it's an array or we're dealing with derivatives, step to the
         // right element.
-        TypeDesc t = type.simpletype();
         if (t.arraylen || deriv) {
             int d             = deriv * std::max(1, t.arraylen);
             llvm::Value* elem = ll.constant(d);
-            dst_ptr           = ll.GEP(dst_ptr, elem);
+            dst_ptr           = ll.GEP(dst_type, dst_ptr, elem);
         }
 
         // If it's multi-component (triple or matrix), step to the right field
         if (!type.is_closure_based() && t.aggregate > 1) {
             OSL_DEV_ONLY(std::cout << "step to the right field " << component
                                    << std::endl);
-            dst_ptr = ll.GEP(dst_ptr, 0, component);
+            dst_ptr = ll.GEP(dst_type, dst_ptr, 0, component);
 
             // Need to scale the indices by the stride
             // of the type
@@ -1311,7 +1350,7 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
         }
 
         // Finally, store the value.
-        ll.op_scatter(new_val, dst_ptr, arrayindex);
+        ll.op_scatter(new_val, dst_scalar_type, dst_ptr, arrayindex);
         // TODO:  possible optimization when we know the array size is small (<= 4)
         // instead of performing a scatter, we could load each value of the the array,
         // compare the index array against that value's index and select/blend
@@ -1362,21 +1401,24 @@ BatchedBackendLLVM::llvm_store_component_value(llvm::Value* new_val,
     // cast the Vec* to a float*
 
     bool symbolsIsUniform = sym.is_uniform();
+    llvm::Type* pointer_type;
     if (symbolsIsUniform) {
-        pointer = ll.ptr_cast(pointer, ll.type_float_ptr());
+        pointer      = ll.ptr_cast(pointer, ll.type_float_ptr());
+        pointer_type = ll.type_float();
     } else {
-        pointer = ll.ptr_cast(pointer, ll.type_wide_float_ptr());
+        pointer      = ll.ptr_cast(pointer, ll.type_wide_float_ptr());
+        pointer_type = ll.type_wide_float();
     }
 
     if (component_is_uniform) {
         llvm::Value* component_pointer
-            = ll.GEP(pointer, component);  // get the component
+            = ll.GEP(pointer_type, pointer, component);  // get the component
 
         // Finally, store the value.
         ll.op_store(new_val, component_pointer);
     } else {
         OSL_ASSERT(!symbolsIsUniform);
-        ll.op_scatter(new_val, pointer, component);
+        ll.op_scatter(new_val, pointer_type, pointer, component);
     }
     return true;
 }
@@ -1415,11 +1457,10 @@ BatchedBackendLLVM::llvm_broadcast_uniform_value_from_mem(
                 // Load the uniform component from the temporary
                 // base passing false for op_is_uniform, the llvm_load_value will
                 // automatically broadcast the uniform value to a vector type
-                llvm::Value* wide_component_value
-                    = llvm_load_value(pointerTotempUniform, dest_type,
-                                      derivIndex, llvm_array_index,
-                                      componentIndex, TypeDesc::UNKNOWN,
-                                      false /*op_is_uniform*/);
+                llvm::Value* wide_component_value = llvm_load_value(
+                    pointerTotempUniform, dest_type, derivIndex,
+                    llvm_array_index, componentIndex, true /*ptr_is_uniform*/,
+                    TypeDesc::UNKNOWN, false /*op_is_uniform*/);
                 bool success = llvm_store_value(wide_component_value,
                                                 Destination, derivIndex,
                                                 llvm_array_index,
@@ -1501,7 +1542,7 @@ BatchedBackendLLVM::llvm_conversion_store_uniform_status(llvm::Value* val,
 llvm::Value*
 BatchedBackendLLVM::groupdata_field_ref(int fieldnum)
 {
-    return ll.GEP(groupdata_ptr(), 0, fieldnum);
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum);
 }
 
 
@@ -1572,9 +1613,8 @@ BatchedBackendLLVM::temp_batched_trace_options_ptr()
 llvm::Value*
 BatchedBackendLLVM::layer_run_ref(int layer)
 {
-    int fieldnum           = 0;  // field 0 is the layer_run array
-    llvm::Value* layer_run = groupdata_field_ref(fieldnum);
-    return ll.GEP(layer_run, 0, layer);
+    int fieldnum = 0;  // field 0 is the layer_run array
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum, layer);
 }
 
 
@@ -1583,8 +1623,8 @@ llvm::Value*
 BatchedBackendLLVM::userdata_initialized_ref(int userdata_index)
 {
     int fieldnum = 1;  // field 1 is the userdata_initialized array
-    llvm::Value* userdata_initiazlied = groupdata_field_ref(fieldnum);
-    return ll.GEP(userdata_initiazlied, 0, userdata_index);
+    return ll.GEP(llvm_type_groupdata(), groupdata_ptr(), 0, fieldnum,
+                  userdata_index);
 }
 
 
@@ -1672,7 +1712,8 @@ BatchedBackendLLVM::llvm_call_function(const FuncSpec& name,
                                 s, /*deriv=*/d, /*component*/ c,
                                 TypeDesc::UNKNOWN, function_is_uniform);
                             // Store our wide pointer on the stack
-                            llvm_store_value(wide_value, tmpptr, t, d, NULL, c);
+                            llvm_store_value(wide_value, tmpptr, t, d, NULL, c,
+                                             /*dst_is_uniform*/ false);
                         }
                     }
 
@@ -1705,8 +1746,8 @@ BatchedBackendLLVM::llvm_call_function(const FuncSpec& name,
                         = llvm_load_constant_value(s, 0, a, TypeDesc::UNKNOWN,
                                                    function_is_uniform);
                     // Store our wide pointer on the stack
-                    llvm_store_value(wide_constant_value, tmpptr, t, 0, NULL,
-                                     a);
+                    llvm_store_value(wide_constant_value, tmpptr, t, 0, NULL, a,
+                                     /*dst_is_uniform*/ false);
                 }
 
                 // return pointer to our stacked wide constant
@@ -1809,13 +1850,10 @@ BatchedBackendLLVM::llvm_test_nonzero(const Symbol& val, bool test_derivs)
     if (t == TypeDesc::TypeInt) {
         // Because we allow temporaries and local results of comparison operations
         // to use the native bool type of i1, we will need to build an matching constant 0
-        // for comparisons.  We can just interrogate the underlying llvm symbol to see if
-        // it is a bool
-        llvm::Value* llvmValue = llvm_get_pointer(val);
+        // for comparisons.
         //OSL_DEV_ONLY(std::cout << "llvmValue type=" << ll.llvm_typenameof(llvmValue) << std::endl);
 
-        if (ll.llvm_typeof(llvmValue)
-            == (const llvm::Type*)ll.type_ptr(ll.type_bool())) {
+        if (val.forced_llvm_bool()) {
             return ll.op_ne(llvm_load_value(val), ll.constant_bool(0));
         } else {
             return ll.op_ne(llvm_load_value(val), ll.constant(0));

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -833,22 +833,22 @@ BatchedBackendLLVM::llvm_load_value(llvm::Value* src_ptr, const TypeSpec& type,
         return NULL;  // Error
 
     TypeDesc t = type.simpletype();
-    llvm::Type *src_type, *src_scalar_type;
+    llvm::Type *src_type, *src_component_type;
 
     if (symbol_forced_boolean) {
         if (src_is_uniform) {
-            src_type        = ll.type_bool();
-            src_scalar_type = ll.type_bool();
+            src_type           = ll.type_bool();
+            src_component_type = ll.type_bool();
         } else {
-            src_type        = ll.type_native_mask();
-            src_scalar_type = ll.type_native_mask();
+            src_type           = ll.type_native_mask();
+            src_component_type = ll.type_native_mask();
         }
     } else {
-        src_type        = llvm_type(t.elementtype());
-        src_scalar_type = llvm_type(t.scalartype());
+        src_type           = llvm_type(t.elementtype());
+        src_component_type = llvm_type(t.scalartype());
         if (!src_is_uniform) {
-            src_type        = ll.type_wide(src_type);
-            src_scalar_type = ll.type_wide(src_scalar_type);
+            src_type           = ll.type_wide(src_type);
+            src_component_type = ll.type_wide(src_component_type);
         }
     }
 
@@ -873,7 +873,7 @@ BatchedBackendLLVM::llvm_load_value(llvm::Value* src_ptr, const TypeSpec& type,
         }
 
         // Now grab the value
-        llvm::Value* result = ll.op_load(src_scalar_type, src_ptr);
+        llvm::Value* result = ll.op_load(src_component_type, src_ptr);
 
         if (type.is_closure_based())
             return result;
@@ -977,7 +977,7 @@ BatchedBackendLLVM::llvm_load_value(llvm::Value* src_ptr, const TypeSpec& type,
         }
 
         // Now grab the value
-        llvm::Value* result = ll.op_gather(src_scalar_type, src_ptr,
+        llvm::Value* result = ll.op_gather(src_component_type, src_ptr,
                                            arrayindex);
         // TODO:  possible optimization when we know the array size is small (<= 4)
         // instead of performing a gather, we could load each value of the the array,
@@ -1280,12 +1280,12 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
     if (!dst_ptr)
         return false;  // Error
 
-    TypeDesc t                  = type.simpletype();
-    llvm::Type* dst_type        = llvm_type(t.elementtype());
-    llvm::Type* dst_scalar_type = llvm_type(t.scalartype());
+    TypeDesc t                     = type.simpletype();
+    llvm::Type* dst_type           = llvm_type(t.elementtype());
+    llvm::Type* dst_component_type = llvm_type(t.scalartype());
     if (!dst_is_uniform) {
-        dst_type        = ll.type_wide(dst_type);
-        dst_scalar_type = ll.type_wide(dst_scalar_type);
+        dst_type           = ll.type_wide(dst_type);
+        dst_component_type = ll.type_wide(dst_component_type);
     }
 
     if (index_is_uniform) {
@@ -1353,7 +1353,7 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
         }
 
         // Finally, store the value.
-        ll.op_scatter(new_val, dst_scalar_type, dst_ptr, arrayindex);
+        ll.op_scatter(new_val, dst_component_type, dst_ptr, arrayindex);
         // TODO:  possible optimization when we know the array size is small (<= 4)
         // instead of performing a scatter, we could load each value of the the array,
         // compare the index array against that value's index and select/blend

--- a/src/liboslexec/batched_backendllvm.h
+++ b/src/liboslexec/batched_backendllvm.h
@@ -112,9 +112,9 @@ public:
     /// and it's a scalar, return the scalar -- this allows automatic
     /// casting to triples.  Finally, auto-cast int<->float if requested
     /// (no conversion is performed if cast is the default of UNKNOWN).
-    llvm::Value* llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
+    llvm::Value* llvm_load_value(llvm::Value* src_ptr, const TypeSpec& type,
                                  int deriv, llvm::Value* arrayindex,
-                                 int component, bool ptr_is_uniform,
+                                 int component, bool src_is_uniform,
                                  TypeDesc cast              = TypeDesc::UNKNOWN,
                                  bool op_is_uniform         = true,
                                  bool index_is_uniform      = true,

--- a/src/liboslexec/batched_backendllvm.h
+++ b/src/liboslexec/batched_backendllvm.h
@@ -114,7 +114,7 @@ public:
     /// (no conversion is performed if cast is the default of UNKNOWN).
     llvm::Value* llvm_load_value(llvm::Value* ptr, const TypeSpec& type,
                                  int deriv, llvm::Value* arrayindex,
-                                 int component,
+                                 int component, bool ptr_is_uniform,
                                  TypeDesc cast              = TypeDesc::UNKNOWN,
                                  bool op_is_uniform         = true,
                                  bool index_is_uniform      = true,
@@ -194,7 +194,7 @@ public:
     bool llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
                           const TypeSpec& type, int deriv,
                           llvm::Value* arrayindex, int component,
-                          bool index_is_uniform = true);
+                          bool dst_is_uniform, bool index_is_uniform = true);
 
     /// Non-array version of llvm_store_value, with default deriv &
     /// component.

--- a/src/liboslexec/batched_backendllvm.h
+++ b/src/liboslexec/batched_backendllvm.h
@@ -730,6 +730,18 @@ public:
     int vector_width() const { return m_width; }
     int true_mask_value() const { return m_true_mask_value; }
 
+    // Utility for constructing names for llvm symbols. It creates a formatted
+    // string if the shading system's "llvm_output_bitcode" option is set,
+    // otherwise it takes a shortcut and returns an empty string (since nobody
+    // is going to see the pretty bitcode anyway).
+    template<typename Str, typename... Args>
+    OSL_NODISCARD inline std::string llnamefmt(const Str& fmt,
+                                               Args&&... args) const
+    {
+        return m_name_llvm_syms ? fmtformat(fmt, std::forward<Args>(args)...)
+                                : std::string();
+    }
+
 private:
     void append_arg_to(llvm::raw_svector_ostream& OS, const FuncSpec::Arg& arg);
 
@@ -811,7 +823,11 @@ private:
     llvm::Type* m_llvm_type_batched_trace_options;
     llvm::PointerType* m_llvm_type_prepare_closure_func;
     llvm::PointerType* m_llvm_type_setup_closure_func;
-    int m_llvm_local_mem;  // Amount of memory we use for locals
+    int m_llvm_local_mem;   // Amount of memory we use for locals
+    bool m_name_llvm_syms;  // Whether to name LLVM symbols
+
+    // Name of each indexed field in the groupdata, mostly for debugging.
+    std::vector<std::string> m_groupdata_field_names;
 
     friend class ShadingSystemImpl;
 };

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -7867,7 +7867,8 @@ LLVMGEN(llvm_gen_pointcloud_write)
         llvm::Value* type_value = rop.ll.constant(
             valsym->typespec().simpletype());
         rop.llvm_store_value(type_value, types, typesArrayType, /*deriv*/ 0,
-                             arrayindex, /*component*/ 0, valsym->is_uniform());
+                             arrayindex, /*component*/ 0,
+                             /*dst_is_uniform*/ true);
 
         // value[i]
         llvm::Value* attr_value_ptr = rop.llvm_load_arg(*valsym,
@@ -7875,7 +7876,7 @@ LLVMGEN(llvm_gen_pointcloud_write)
                                                         false /*is_uniform*/);
         rop.llvm_store_value(attr_value_ptr, values, valuesArrayType,
                              /*deriv*/ 0, arrayindex, /*component*/ 0,
-                             valsym->is_uniform());
+                             /*dst_is_uniform*/ true);
     }
 
     constexpr int fileNameArgumentIndex = 1;

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -1521,11 +1521,7 @@ BatchedBackendLLVM::llvm_generate_debug_uninit(const Opcode& op)
         // Because we allow temporaries and local results of comparison operations
         // to use the native bool type of i1, we can just skip checking these
         // as they should always be assigned a value.
-        // We can just interrogate the underlying llvm symbol to see if
-        // it is a bool
-        llvm::Value* llvmValue = llvm_get_pointer(sym);
-        if (ll.llvm_typeof(llvmValue) == ll.type_ptr(ll.type_bool())
-            || ll.llvm_typeof(llvmValue) == ll.type_ptr(ll.type_wide_bool())) {
+        if (sym.typespec().is_int_based() && sym.forced_llvm_bool()) {
             continue;
         }
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -650,8 +650,8 @@ BackendLLVM::llvm_assign_initial_value(const Symbol& sym, bool force)
             // If the call to osl_bind_interpolated_param returns 0, the default
             // value needs to be loaded from a CUDA variable.
             llvm::Value* cuda_var     = getOrAllocateCUDAVariable(sym);
-            llvm::Type* cuda_var_type = llvm_typedesc(
-                sym.typespec().elementtype());
+            TypeSpec elemtype         = sym.typespec().elementtype();
+            llvm::Type* cuda_var_type = llvm_type(elemtype);
             // memcpy the initial value from the CUDA variable
             llvm::Value* src = ll.ptr_cast(ll.GEP(cuda_var_type, cuda_var, 0),
                                            ll.type_void_ptr());

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -649,9 +649,11 @@ BackendLLVM::llvm_assign_initial_value(const Symbol& sym, bool force)
                    && !sym.lockgeom()) {
             // If the call to osl_bind_interpolated_param returns 0, the default
             // value needs to be loaded from a CUDA variable.
-            llvm::Value* cuda_var = getOrAllocateCUDAVariable(sym);
+            llvm::Value* cuda_var     = getOrAllocateCUDAVariable(sym);
+            llvm::Type* cuda_var_type = llvm_typedesc(
+                sym.typespec().elementtype());
             // memcpy the initial value from the CUDA variable
-            llvm::Value* src = ll.ptr_cast(ll.GEP(cuda_var, 0),
+            llvm::Value* src = ll.ptr_cast(ll.GEP(cuda_var_type, cuda_var, 0),
                                            ll.type_void_ptr());
             llvm::Value* dst = llvm_void_ptr(sym);
             TypeDesc t       = sym.typespec().simpletype();
@@ -1254,8 +1256,8 @@ BackendLLVM::build_llvm_instance(bool groupentry)
                 fmtformat("checking for already-run layer {} {} {}",
                           this->layer(), inst()->layername(),
                           inst()->shadername()));
-        llvm::Value* executed         = ll.op_eq(ll.op_load(layerfield),
-                                                 ll.constant_bool(true));
+        llvm::Value* executed = ll.op_eq(ll.op_load(ll.type_bool(), layerfield),
+                                         ll.constant_bool(true));
         llvm::BasicBlock* then_block  = ll.new_basic_block();
         llvm::BasicBlock* after_block = ll.new_basic_block();
         ll.op_branch(executed, then_block, after_block);

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -3559,7 +3559,7 @@ LLVM_Util::llvm_type(const TypeDesc& typedesc)
         lt = type_void();
     else if (t == TypeDesc::UINT8)
         lt = type_char();
-    else if (t == TypeDesc::UINT64)
+    else if (t == TypeDesc::UINT64 || t == TypeDesc::INT64)
         lt = type_longlong();
     else if (t == TypeDesc::PTR)
         lt = type_void_ptr();

--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -109,7 +109,7 @@ test_triple_func()
     OSL::pvt::LLVM_Util::PerThreadInfo pti;
     OSL::pvt::LLVM_Util ll(pti);
 
-    // Make a function with prototype:   int myadd (int arg1, int arg2)
+    // Make a function with prototype:   Vec3 myadd (Vec3 *arg1, float arg2)
     // and make it the current function.
     auto func = ll.make_function("myaddv",        // name
                                  false,           // fastcall
@@ -124,9 +124,12 @@ test_triple_func()
     llvm::Value* aptr = ll.current_function_arg(1);
     llvm::Value* b    = ll.current_function_arg(2);
     for (int i = 0; i < 3; ++i) {
-        llvm::Value* r_elptr = ll.GEP(rptr, 0, i);
-        llvm::Value* a_elptr = ll.GEP(aptr, 0, i);
-        llvm::Value* product = ll.op_mul(ll.op_load(a_elptr), b);
+        llvm::Value* r_elptr = ll.GEP((llvm::Type*)ll.type_triple(), rptr, 0,
+                                      i);
+        llvm::Value* a_elptr = ll.GEP((llvm::Type*)ll.type_triple(), aptr, 0,
+                                      i);
+        llvm::Value* product = ll.op_mul(ll.op_load(ll.type_float(), a_elptr),
+                                         b);
         ll.op_store(product, r_elptr);
     }
     ll.op_return();


### PR DESCRIPTION
## Description

New LLVM versions require opaque pointers, that is you can no longer tell from a pointer value which data type it points to.

* Remove deprecated `GEP` and `op_load` methods without type, and refactor code to always pass the type.
* Add element type argument to `op_scatter` and `op_gather`.
* Eliminate pointer type comparisons which no longer work with opaque pointers.
* Some useful asserts to verify correct pointer types must unfortunately be disabled with opaque pointers.
* Keep interactive params marked as uniform in batched analysis, so we can deduce uniform/varying correctly from just the symbol.
* Enable opaque pointers on LLVM 16+.

OptiX opaque pointers might not be working yet due to the conversion in`BackendLLVM::llvm_store_value` between `int64` and `char*`, where we can no longer compare the pointer type. This function is called from many places and it's unclear to me when this happens.

According to a4e779c4 this code is only temporary, so this may resolve itself as the ustring refactoring gets completed.

## Tests

No new tests added, entire testsuite tests this.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.