### PR TITLE
RS::get_texture_info make robust to empty shaderglobals param

### DIFF
--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -405,13 +405,15 @@ RendererServices::get_texture_info(ustringhash filename,
                                    ustringhash dataname, TypeDesc datatype,
                                    void* data, ustringhash* errormessage)
 {
-    ShadingContext* shading_context
-        = (ShadingContext*)((ShaderGlobals*)sg)->context;
-    if (!texture_thread_info)
-        texture_thread_info = shading_context->texture_thread_info();
-    if (!texture_handle)
+    if (!texture_handle) {
+        if (!texture_thread_info && sg) {
+            ShadingContext* shading_context
+                = (ShadingContext*)((ShaderGlobals*)sg)->context;
+            texture_thread_info = shading_context->texture_thread_info();
+        }
         texture_handle = texturesys()->get_texture_handle(ustring_from(filename),
                                                           texture_thread_info);
+    }
     bool status = texturesys()->get_texture_info(texture_handle,
                                                  texture_thread_info, subimage,
                                                  ustring_from(dataname),


### PR DESCRIPTION
The unconditional dereferencing of the sg pointer is only necessary if texture_thread_info is not supplied. And for that matter, the texture_thread_info is only necessary if the texture_handle is not supplied.

So rearranging the nesting skips a bunch of the work, and the need for the caller to supply the sg if they have the texture_thread_info, nor for them to need texture_thread_info if they already have the handle.
