### PR TITLE
Fix tests passing when test commands fail

### DIFF
--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -22,7 +22,7 @@ export OSL_ROOT=$PWD/dist
 export DYLD_LIBRARY_PATH=$OSL_ROOT/lib:$DYLD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$OSL_ROOT/lib:$LD_LIBRARY_PATH
 export OIIO_LIBRARY_PATH=$OSL_ROOT/lib:${OIIO_LIBRARY_PATH}
-export LSAN_OPTIONS=suppressions=$PWD/src/build-scripts/nosanitize.txt:exitcode=0
+export LSAN_OPTIONS=suppressions=$PWD/src/build-scripts/nosanitize.txt
 export ASAN_OPTIONS=print_suppressions=0:detect_odr_violation=1
 
 export USE_PYTHON=${USE_PYTHON:=1}

--- a/src/build-scripts/ci-startup.bash
+++ b/src/build-scripts/ci-startup.bash
@@ -22,7 +22,7 @@ export OSL_ROOT=$PWD/dist
 export DYLD_LIBRARY_PATH=$OSL_ROOT/lib:$DYLD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$OSL_ROOT/lib:$LD_LIBRARY_PATH
 export OIIO_LIBRARY_PATH=$OSL_ROOT/lib:${OIIO_LIBRARY_PATH}
-export LSAN_OPTIONS=suppressions=$PWD/src/build-scripts/nosanitize.txt
+export LSAN_OPTIONS=suppressions=$PWD/src/build-scripts/nosanitize.txt:exitcode=0
 export ASAN_OPTIONS=print_suppressions=0:detect_odr_violation=1
 
 export USE_PYTHON=${USE_PYTHON:=1}

--- a/src/build-scripts/nosanitize.txt
+++ b/src/build-scripts/nosanitize.txt
@@ -1,0 +1,3 @@
+# Small leaks that make CI fail, suppress until cause is identified.
+leak:__cxa_thread_atexit
+leak:std::string::_Rep::_S_create

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -368,7 +368,7 @@ main(int argc, const char* argv[])
 
     // We're done with the shading system now, destroy it
     rend->clear();
-    delete shadingsys;
     delete rend;
+    delete shadingsys;
     return EXIT_SUCCESS;
 }

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -80,7 +80,7 @@ command = ""
 outputs = [ "out.txt" ]    # default
 
 # Control image differencing
-failureok = 1
+failureok = 0
 failthresh = 0.004
 hardfail = 0.01
 failpercent = 0.02


### PR DESCRIPTION
## Description

37cbab5b accidentally changed tests to accept failing commands by default.

This can cause tests to pass even though the program crashed, when a previous run created the correct output file.

This reveals existing asan and lsan errors. The asan error was fixed. The memory leaks remain ignored, as the exact cause is unclear.

## Tests

N/A

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.