### PR TITLE
build: Bump Cuda minimum to 9.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,8 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 
 * (optional) For GPU rendering on NVIDIA GPUs:
     * [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) 7.0 or higher.
-    * [Cuda](https://developer.nvidia.com/cuda-downloads) 8.0 or higher.
+    * [Cuda](https://developer.nvidia.com/cuda-downloads) 9.0 or higher. It is
+      recommended that you use 11.0 or higher.
 
 * [Boost](https://www.boost.org) 1.55 or newer (tested through boost 1.81)
 * [Ilmbase or Imath](https://github.com/AcademySoftwareFoundation/openexr) 2.3

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -212,9 +212,9 @@ if (OSL_USE_OPTIX)
 
         checked_find_package (CUDA REQUIRED
                              VERSION_MIN 9.0
-                             RECOMMENDED_MIN 11.0
-                             RECOMMENDED_MIN_REASON
-                                "We don't actively test Cuda older than 11"
+                             RECOMMEND_MIN 11.0
+                             RECOMMEND_MIN_REASON
+                                "We don't actively test CUDA older than 11"
                              PRINT CUDA_INCLUDES)
         set (CUDA_INCLUDES ${CUDA_TOOLKIT_ROOT_DIR}/include)
         include_directories (BEFORE "${CUDA_INCLUDES}")

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -211,8 +211,11 @@ if (OSL_USE_OPTIX)
         endif ()
 
         checked_find_package (CUDA REQUIRED
-                            VERSION_MIN 8.0
-                            PRINT CUDA_INCLUDES)
+                             VERSION_MIN 9.0
+                             RECOMMENDED_MIN 11.0
+                             RECOMMENDED_MIN_REASON
+                                "We don't actively test Cuda older than 11"
+                             PRINT CUDA_INCLUDES)
         set (CUDA_INCLUDES ${CUDA_TOOLKIT_ROOT_DIR}/include)
         include_directories (BEFORE "${CUDA_INCLUDES}")
 


### PR DESCRIPTION
Based on Brecht's tests, we realize that OSL doesn't work at all with Cuda 8.0 (which didn't support the C++14 that we use), so we're raising the minimum to 9.0. And there are some flaky tests with 9 and 10, so we're making the recommended minimum be 11.0.

It's not our policy to change the minimum versions of dependencies on release branches, but I think we should backport this to the release branch. I believe what this change is doing is not removing actual support for old versions, but rather, correctly documenting what has been working (or not) for quite some time.
