### PR TITLE
ci: Fix GPU job not actually enabling OptiX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
             pybind11_ver: v2.10.0
             simd: avx2,f16c
             skip_tests: 1
-            setenvs: export OSL_CMAKE_FLAGS="-DUSE_OPTIX=1" OPTIX_VERSION=7.0
+            setenvs: export OSL_CMAKE_FLAGS="-DOSL_USE_OPTIX=1" OPTIX_VERSION=7.0
                             OPENIMAGEIO_CMAKE_FLAGS=-DBUILD_FMT_VERSION=9.1.0
           - desc: oldest everything gcc6/C++14 llvm9 py2.7 boost1.66 oiio2.3 no-simd exr2.3
             nametag: linux-oldest

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -73,7 +73,7 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
     foreach (def ${CURRENT_DEFINITIONS})
         set (LLVM_COMPILE_FLAGS ${LLVM_COMPILE_FLAGS} "-D${def}")
     endforeach()
-    set (LLVM_COMPILE_FLAGS ${LLVM_COMPILE_FLAGS} ${SIMD_COMPILE_FLAGS} ${CSTD_FLAGS})
+    set (LLVM_COMPILE_FLAGS ${LLVM_COMPILE_FLAGS} ${CSTD_FLAGS})
 
     # Setup the bitcode generator
     if (NOT LLVM_BC_GENERATOR)


### PR DESCRIPTION
## Description

In #1668 USE_OPTIX changed to OSL_USE_OPTIX, but CI was not updated.

And fix CPU SIMD flags being used for CUDA compilation, making the build fail.

## Tests

N/A

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.