### PR TITLE
ci: Fix python-oslquery test failure on macOS

### DIFF
--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -125,9 +125,7 @@ else :
     if not os.path.exists("./data") :
         os.symlink (test_source_dir, "./data")
 
-pythonbin = 'python'
-if os.getenv("PYTHON_VERSION") :
-    pythonbin += os.getenv("PYTHON_VERSION")
+pythonbin = sys.executable
 #print ("pythonbin = ", pythonbin)
 
 ###########################################################################


### PR DESCRIPTION
## Description

Use the absolute path to the Python executable to avoid picking up a different executable with the same version.

## Tests

N/A

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.