### PR TITLE
admin: Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,9 @@
 <!-- Put an 'x' in the boxes as you complete the checklist items -->
 
 - [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
-- [ ] I have previously submitted a [Contributor License Agreement](http://opensource.imageworks.com/cla/).
 - [ ] I have updated the documentation, if applicable.
 - [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
-- [ ] My code follows the prevailing code style of this project.
-
+- [ ] My code follows the prevailing code style of this project. If I haven't
+  already run clang-format before submitting, I definitely will look at the CI
+  test that runs clang-format and fix anything that it highlights as being
+  nonconforming.


### PR DESCRIPTION
It gave a VERY old link to the SPI CLA, which we no longer use.  In fact, because we have CLA enforcement through the CLA bot, there is not really a need to have it in the checklist... nobody can forget.

