### PR TITLE
build: Fixes to build and test against OpenImageIO 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             openimageio_ver: v2.2.17.0
             python_ver: 2.7
             pybind11_ver: v2.4.2
-          - desc: clang9/C++14 llvm9 oiio-release boost1.66 avx2 exr2.3 py2.7
+          - desc: clang9/C++14 llvm9 oiio-release boost1.66 avx2 exr2.4 py2.7
             nametag: linux-clang9-llvm9
             os: ubuntu-20.04
             container: aswftesting/ci-osl:2019-clang9
@@ -53,16 +53,19 @@ jobs:
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 14
+            openexr_ver: v2.4.3
             openimageio_ver: release
             python_ver: 2.7
             # pybind11_ver: v2.9.0
             simd: avx
-          - desc: GPU Cuda10 gcc6/C++14 llvm10 py2.7 boost-1.70 exr-2.3 OIIO-master avx2
+            setenvs: export CMAKE_VERSION=3.15.5
+          - desc: GPU Cuda10 gcc6/C++14 llvm10 py2.7 boost-1.70 exr-2.4 OIIO-master avx2
             nametag: linux-optix7-2019
             os: ubuntu-latest
             container: aswftesting/ci-osl:2019-clang10
             vfxyear: 2019
             cxx_std: 14
+            openexr_ver: v2.4.3
             openimageio_ver: master
             python_ver: 2.7
             # pybind11_ver: v2.9.0
@@ -70,6 +73,7 @@ jobs:
             skip_tests: 1
             setenvs: export OSL_CMAKE_FLAGS="-DUSE_OPTIX=1" OPTIX_VERSION=7.0
                             OPENIMAGEIO_CMAKE_FLAGS=-DBUILD_FMT_VERSION=8.1.1
+                            CMAKE_VERSION=3.15.5
           - desc: gcc6/C++14 llvm10 py3.7 boost1.70 exr2.4 oiio2.2 sse4
             nametag: linux-vfx2020
             os: ubuntu-latest
@@ -191,6 +195,7 @@ jobs:
                             OSL_OPTIONS=llvm_debugging_symbols=1
                             TESTRENDER_AA=1
                             OSL_TESTSUITE_SKIP_DIFF=1
+                            OPENIMAGEIO_CMAKE_FLAGS=-DBUILD_FMT_VERSION=9.1.0
             # Sanitizer notes:
             # - There are a handful of tests we disable entirely with
             #   CTEST_EXCLUSIONS because they are irrelevant or just cannot be

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -125,6 +125,10 @@ else
     source src/build-scripts/build_llvm.bash
 fi
 
+if [[ "$CMAKE_VERSION" != "" ]] ; then
+    source src/build-scripts/build_cmake.bash
+fi
+cmake --version
 
 
 if [[ "$OPTIX_VERSION" != "" ]] ; then

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -102,7 +102,11 @@ using OIIO::TextureOpt;
 // And some other things we borrow from OIIO...
 using OIIO::ErrorHandler;
 using OIIO::ustring;
+#ifdef OIIO_USTRING_HAS_STDHASH
+using ustringHash = std::hash<ustring>;
+#else
 using OIIO::ustringHash;
+#endif
 using OIIO::string_view;
 using OIIO::span;
 using OIIO::cspan;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -58,7 +58,6 @@ using OIIO::ParamValueList;
 using OIIO::RefCnt;
 using OIIO::spin_lock;
 using OIIO::spin_mutex;
-using OIIO::ustringHash;
 namespace Strutil = OIIO::Strutil;
 
 

--- a/src/testrender/optix_stringtable.h
+++ b/src/testrender/optix_stringtable.h
@@ -14,8 +14,7 @@
 
 OSL_NAMESPACE_ENTER
 
-typedef std::unordered_map<OIIO::ustring, int64_t, OIIO::ustringHash>
-    StringTableMap;
+typedef std::unordered_map<OIIO::ustring, int64_t, ustringHash> StringTableMap;
 
 
 // The OptiXStringTable manages a block of CUDA device memory designated

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -133,9 +133,9 @@ private:
 #endif
 
     std::string m_materials_ptx;
-    std::unordered_map<OIIO::ustring, optix::TextureSampler, OIIO::ustringHash>
+    std::unordered_map<OIIO::ustring, optix::TextureSampler, ustringHash>
         m_samplers;
-    std::unordered_map<OIIO::ustring, uint64_t, OIIO::ustringHash> m_globals_map;
+    std::unordered_map<OIIO::ustring, uint64_t, ustringHash> m_globals_map;
 };
 
 

--- a/src/testshade/optixgridrender.h
+++ b/src/testshade/optixgridrender.h
@@ -139,9 +139,9 @@ private:
     std::unordered_map<uint64_t, const char*> m_hash_map;
 #endif
     std::string m_materials_ptx;
-    std::unordered_map<OIIO::ustring, optix::TextureSampler, OIIO::ustringHash>
+    std::unordered_map<OIIO::ustring, optix::TextureSampler, ustringHash>
         m_samplers;
-    std::unordered_map<OIIO::ustring, uint64_t, OIIO::ustringHash> m_globals_map;
+    std::unordered_map<OIIO::ustring, uint64_t, ustringHash> m_globals_map;
 
     OSL::Matrix44 m_shader2common;  // "shader" space to "common" space matrix
     OSL::Matrix44 m_object2common;  // "object" space to "common" space matrix

--- a/testsuite/example-cuda/cuda_grid_renderer.h
+++ b/testsuite/example-cuda/cuda_grid_renderer.h
@@ -12,9 +12,9 @@
 #include "cuda_string_table.h"
 
 using GlobalsMap
-    = std::unordered_map<OIIO::ustring, uint64_t, OIIO::ustringHash>;
+    = std::unordered_map<OIIO::ustring, uint64_t, ustringHash>;
 using TextureSamplerMap
-    = std::unordered_map<OIIO::ustring, cudaTextureObject_t, OIIO::ustringHash>;
+    = std::unordered_map<OIIO::ustring, cudaTextureObject_t, ustringHash>;
 
 // Just use 4x4 matrix for transformations
 typedef OSL::Matrix44 Transformation;

--- a/testsuite/example-cuda/cuda_string_table.h
+++ b/testsuite/example-cuda/cuda_string_table.h
@@ -13,8 +13,7 @@
 #include <OSL/oslexec.h>
 #include <OpenImageIO/ustring.h>
 
-typedef std::unordered_map<OIIO::ustring, int64_t, OIIO::ustringHash>
-    StringTableMap;
+typedef std::unordered_map<OIIO::ustring, int64_t, ustringHash> StringTableMap;
 
 // The CudaStringTable manages a block of CUDA device memory designated
 // to hold all of the string constants that a shader might access during


### PR DESCRIPTION
The newly released OIIO 2.5 (and changes in master) adjusts a few of its minimum dependencies (cmake, openexr, fmt) in ways that break some of our CI test cases for OSL 1.12, and also deprecated a helper method called ustringHash that OSL referenced in a few places.

These have already been addressed in the OSL main branch (what will soon be OSL 1.13), and in some cases OSL-next has also bumped some of the very same dependencies.

But this PR is dealing with the 1.12 branch, in which we cannot raise minimum dependencies that OSL requires. So here we are only adjusting which versions of those dependencies we are using or building for the specific tests in our CI matrix that use the sufficiently new OIIO that it needs the updated changes.
