### PR TITLE
fix: SymOverrideInfo bitfields should be the same type

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1468,11 +1468,11 @@ public:
     /// instance overrides from the master copy.
     struct SymOverrideInfo {
         // Using bit fields to keep the data in 8 bytes in total.
-        unsigned char m_valuesource : 3;
-        bool m_connected_down : 1;
-        bool m_interpolated : 1;
-        bool m_interactive : 1;
-        int m_arraylen : 26;
+        unsigned int m_valuesource : 3;
+        unsigned int m_connected_down : 1;
+        unsigned int m_interpolated : 1;
+        unsigned int m_interactive : 1;
+        unsigned int m_arraylen : 26;
         int m_data_offset;
 
         SymOverrideInfo()

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -1468,6 +1468,8 @@ public:
     /// instance overrides from the master copy.
     struct SymOverrideInfo {
         // Using bit fields to keep the data in 8 bytes in total.
+        // Note: it's important that all the bitfields are the same type
+        // (unsigned int), or MSVS won't merge them properly into one int.
         unsigned int m_valuesource : 3;
         unsigned int m_connected_down : 1;
         unsigned int m_interpolated : 1;


### PR DESCRIPTION
Stephen Friedman alerted me to the fact that on Windows, bit fields within a struct will only be combined if they are the same type.  We were a bit sloppy in the defintion of SymOverrideInfo, and that was causing the struct to end up a different size in Windows.  I think the solution is that all those bit fields should be `unsigned int`.

