### PR TITLE
ci: Test ABI compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,30 @@ jobs:
             setenvs: export BUILDTARGET=clang-format
                             OPENIMAGEIO_CMAKE_FLAGS=-DUSE_PYTHON=0
 
+          # Test ABI stability. `abi_check` is the version or commit that we
+          # believe is the current standard against which we don't want to
+          # break the ABI. Basically, we will build that version as well as
+          # the current one, and compare the resulting libraries.
+          - desc: abi check
+            nametag: linux-vfx2023
+            runner: ubuntu-latest
+            container: aswftesting/ci-osl:2023-clang15
+            vfxyear: 2023
+            cc_compiler: gcc
+            cxx_compiler: g++
+            cxx_std: 17
+            # openimageio_ver: release
+            python_ver: "3.10"
+            simd: "avx2,f16c"
+            batched: b8_AVX2
+            fmt_ver: 10.1.1
+            pybind11_ver: v2.10.0
+            skip_tests: 1
+            abi_check: 8374278a07d88358a6931dc2492f98ca49b21038
+            setenvs: export OSL_CMAKE_FLAGS="-DOSL_BUILD_TESTS=0 -DBUILD_TESTING=OFF -DUSE_QT=0"
+                            OPENIMAGEIO_CMAKE_FLAGS="-DUSE_PYTHON=0"
+                            CMAKE_BUILD_TYPE=RelWithDebInfo
+
     runs-on: ${{matrix.runner}}
     container:
         image: ${{ matrix.container }}
@@ -250,6 +274,7 @@ jobs:
       PYTHON_VERSION: ${{matrix.python_ver}}
       USE_BATCHED: ${{matrix.batched}}
       USE_SIMD: ${{matrix.simd}}
+      ABI_CHECK: ${{matrix.abi_check}}
     steps:
       # We would like to use harden-runner, but it flags too many false
       # positives, every time we download a dependency. We should use it only
@@ -290,11 +315,31 @@ jobs:
       - name: Testsuite
         if: matrix.skip_tests != '1'
         run: src/build-scripts/ci-test.bash
+      - name: Check out ABI standard
+        if: matrix.abi_check != ''
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          ref: ${{matrix.abi_check}}
+          path: abi_standard
+      - name: Build ABI standard
+        if: matrix.abi_check != ''
+        run: |
+            mkdir -p abi_standard/build
+            pushd abi_standard
+            src/build-scripts/ci-build.bash
+            popd
+      - name: Check ABI
+        if: matrix.abi_check != ''
+        run: |
+            src/build-scripts/ci-abicheck.bash ./build abi_standard/build \
+                  liboslexec liboslcomp liboslquery liboslnoise
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         if: failure()
         with:
           name: osl-${{github.job}}-${{matrix.nametag}}
           path: |
+            build/cmake-save
+            build/compat_reports
             build/*.cmake
             build/CMake*
             build/testsuite/*/*.*
@@ -433,6 +478,7 @@ jobs:
         with:
           name: osl-${{github.job}}-${{matrix.nametag}}
           path: |
+            build/cmake-save
             build/*.cmake
             build/CMake*
             build/testsuite/*/*.*
@@ -520,6 +566,7 @@ jobs:
         with:
           name: osl-${{github.job}}-${{matrix.nametag}}
           path: |
+            build/cmake-save
             build/*.cmake
             build/CMake*
             build/testsuite/*/*.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ add_subdirectory (src/liboslnoise)
 add_subdirectory (src/oslc)
 add_subdirectory (src/oslinfo)
 
-if (OSL_BUILD_TESTS)
+if (OSL_BUILD_TESTS AND BUILD_TESTING)
     add_subdirectory (src/testshade)
     add_subdirectory (src/testrender)
 endif ()
@@ -228,7 +228,7 @@ if (OSL_BUILD_PLUGINS)
     add_subdirectory (src/osl.imageio)
 endif ()
 
-if (USE_QT AND (Qt5_FOUND OR Qt6_FOUND))
+if (USE_QT AND (Qt5_FOUND OR Qt6_FOUND) AND NOT DISABLE_OSLTOY)
     add_subdirectory (src/osltoy)
 endif ()
 
@@ -309,7 +309,7 @@ install (EXPORT OSL_EXPORTED_TARGETS
         FILE ${OSL_TARGETS_EXPORT_NAME}
         NAMESPACE ${PROJECT_NAME}::)
 
-if (${PROJECT_NAME}_BUILD_TESTS AND PROJECT_IS_TOP_LEVEL)
+if (PROJECT_IS_TOP_LEVEL AND BUILD_TESTING AND ${PROJECT_NAME}_BUILD_TESTS)
 	osl_add_all_tests()
 endif ()
 

--- a/src/build-scripts/build_abi_tools.bash
+++ b/src/build-scripts/build_abi_tools.bash
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Utility script to download and build abi checking tools
+#
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+# Exit the whole script if any command fails.
+set -ex
+
+# Where to install the final results
+: ${LOCAL_DEPS_DIR:=${PWD}/ext}
+: ${ABITOOLS_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
+
+mkdir -p ${LOCAL_DEPS_DIR}
+pushd ${LOCAL_DEPS_DIR}
+
+git clone https://github.com/lvc/vtable-dumper
+pushd vtable-dumper ; make install prefix=${ABITOOLS_INSTALL_DIR} ; popd
+
+git clone https://github.com/lvc/abi-dumper
+pushd abi-dumper ; make install prefix=${ABITOOLS_INSTALL_DIR} ; popd
+
+git clone https://github.com/lvc/abi-compliance-checker
+pushd abi-compliance-checker ; make install prefix=${ABITOOLS_INSTALL_DIR} ; popd
+
+popd
+
+# ls -R ${LOCAL_DEPS_DIR}
+export PATH=${PATH}:${ABITOOLS_INSTALL_DIR}/bin

--- a/src/build-scripts/ci-abicheck.bash
+++ b/src/build-scripts/ci-abicheck.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+# Important: set -ex causes this whole script to terminate with error if
+# any command in it fails. This is crucial for CI tests.
+set -e
+
+# Arguments to this script are: 
+#      BUILDDIR_NEW BUILDDIR_OLD LIBRARIES...
+
+BUILDDIR_NEW=$1
+shift
+BUILDDIR_OLD=$1
+shift
+LIBS=$*
+
+#
+# First, create ABI dumps from both builds
+#
+ABI_ARGS="-bin-only -skip-cxx -public-headers $PWD/dist/include/OSL "
+echo "ABI_CHECK: PWD=${PWD} "
+ls -l $BUILDDIR_NEW
+ls -l $BUILDDIR_OLD
+for dir in $BUILDDIR_NEW $BUILDDIR_OLD ; do
+    for lib in $LIBS ; do
+        abi-dumper $ABI_ARGS ${dir}/lib/${lib}.so -o ${dir}/abi-${lib}.dump
+    done
+done
+echo "Saved ABI dumps"
+
+#
+# Run the ABI compliance checker, saving the outputs to files
+#
+for lib in $LIBS ; do
+    abi-compliance-checker -l $lib -old $BUILDDIR_OLD/abi-$lib.dump -new $BUILDDIR_NEW/abi-$lib.dump | tee ${lib}-abi-results.txt || true
+    echo -e "\x1b[33;1m"
+    echo -e "$lib"
+    fgrep "Binary compatibility:" ${lib}-abi-results.txt
+    echo -e "\x1b[33;0m"
+done
+
+#
+# If the "Binary compatibility" summary results say anything other than 100%,
+# we fail!
+#
+for lib in $LIBS ; do
+    if [[ `fgrep "Binary compatibility:" ${lib}-abi-results.txt | grep -v 100\%` != "" ]] ; then
+        cp -r compat_reports ${BUILDDIR_NEW}/compat_reports
+        exit 1
+    fi
+done

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -186,13 +186,17 @@ if [[ "$OPENIMAGEIO_VERSION" != "" ]] ; then
     # Don't let warnings in OIIO break OSL's CI run
     export OPENIMAGEIO_CMAKE_FLAGS+=" -DSTOP_ON_WARNING=OFF"
     export OPENIMAGEIO_CMAKE_FLAGS+=" -DUSE_OPENGL=0"
-    if [[ $OPENIMAGEIO_VERSION == master && "${OPENIMAGEIO_UNITY:-1}" != "0" ]] ; then
+    export OPENIMAGEIO_CMAKE_FLAGS+=" -DUSE_OPENCV=0 -DUSE_FFMPEG=0 -DUSE_QT=0"
+    if [[ "${OPENIMAGEIO_UNITY:-1}" != "0" ]] ; then
         # Speed up the OIIO build by doing a "unity" build. (Note: this is
-        # only a savings in CI where there are only 1-2 cores available, and
-        # is only supported for OIIO 2.3.14 and later)
+        # only a savings in CI where there are only 1-2 cores available.)
         export OPENIMAGEIO_CMAKE_FLAGS+=" -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_MODE=BATCH"
     fi
     source src/build-scripts/build_openimageio.bash
+fi
+
+if [[ "$ABI_CHECK" != "" ]] ; then
+    source src/build-scripts/build_abi_tools.bash
 fi
 
 # Save the env for use by other stages

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -592,7 +592,7 @@ endforeach(batched_target_lib)
 install_targets (${local_lib})
 
 # Unit tests
-if (OSL_BUILD_TESTS)
+if (OSL_BUILD_TESTS AND BUILD_TESTING)
     add_executable (accum_test accum_test.cpp)
     target_link_libraries (accum_test PRIVATE oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     set_target_properties (accum_test PROPERTIES FOLDER "Unit Tests")

--- a/src/liboslnoise/CMakeLists.txt
+++ b/src/liboslnoise/CMakeLists.txt
@@ -51,7 +51,7 @@ set_target_properties (${local_lib}
 install_targets (${local_lib})
 
 
-if (OSL_BUILD_TESTS)
+if (OSL_BUILD_TESTS AND BUILD_TESTING)
     add_executable (oslnoise_test oslnoise_test.cpp)
     set_target_properties (oslnoise_test PROPERTIES FOLDER "Unit Tests")
     target_link_libraries (oslnoise_test PRIVATE oslnoise)


### PR DESCRIPTION
This patch adds a new test to the CI matrix: verifying that we do not break the ABI during releases. This is based on similar work done a couple months ago in OpenImageIO.

Basically, in addition to building the current checkout, it also builds a checkout of the designated "ABI standard" (generally, the first non-beta release of a major version), then generates ABI dumps of both versions and runs the ABI compliance checker using the tools from https://github.com/lvc

Making two builds sounds expensive, but both builds are rigged to be minimal, since only the libraries are needed for ABI checks (we can turn off the binary tools, unit tests, python bindings, etc.), and of course the test suite need not run. So actually, it's less expensive than most of the test matrix entries, and it helps ensure that we don't accidentally break ABI when we don't mean to.

I'm not sure how many false positives we'll have. We might need to adjust the methodology slightly as we gain experience with this.

