### PR TITLE
testrender: Fix wrong offset of MxSheen param

### DIFF
--- a/src/testrender/shading.cpp
+++ b/src/testrender/shading.cpp
@@ -396,7 +396,7 @@ register_closures(OSL::ShadingSystem* shadingsys)
           { CLOSURE_VECTOR_PARAM(MxSheenParams, N),
             CLOSURE_COLOR_PARAM(MxSheenParams, albedo),
             CLOSURE_FLOAT_PARAM(MxSheenParams, roughness),
-            CLOSURE_STRING_KEYPARAM(MxSubsurfaceParams, label, "label"),
+            CLOSURE_STRING_KEYPARAM(MxSheenParams, label, "label"),
             CLOSURE_FINISH_PARAM(MxSheenParams) } },
         { "uniform_edf",
           MX_UNIFORM_EDF_ID,


### PR DESCRIPTION
## Description

Fix a typo in the MxSheen builtin closure parameter for testrender.

## Tests

I think this bug could read or write outside the intended struct memory when a MxSheen closure is used but I haven't tried to provoke this for a test.

## Checklist

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.

## Test results
All tests passed except `osl-imageio*`. But they failed on main branch as well for me so I think I'm doing something wrong. I don't think they are relevant to this fix.

```
99% tests passed, 3 tests failed out of 623

Label Time Summary:
batchregression    =  35.15 sec*proc (3 tests)
noise              =  34.52 sec*proc (48 tests)
render             =  96.00 sec*proc (22 tests)
texture            =  26.50 sec*proc (54 tests)

Total Test time (real) =  20.50 sec

The following tests FAILED:
        367 - osl-imageio (Failed)
        368 - osl-imageio.opt (Failed)
        369 - osl-imageio.opt.rs_bitcode (Failed)
```

All three tests failed in the same way:
```
Output was:
--------
Compiled ramp.osl -> ramp.oso
oiiotool ERROR: read : File does not exist: "ramp.oso?RES=64"
Full command line was:
> oiiotool ramp.oso?RES=64 -d uint8 -o ramp-oso-default.tif
```