### PR TITLE
Fix struct align/pack for MSVC

### DIFF
--- a/src/include/OSL/fmt_util.h
+++ b/src/include/OSL/fmt_util.h
@@ -21,19 +21,19 @@ namespace pvt {
 // PackedArgs is similar to tuple but packs its data back to back
 // in memory layout, which is what we need to build up payload
 // to the fmt reporting system
-OSL_PACKED_ALIGN_BEGIN
-template<int IndexT, typename TypeT> struct OSL_PACKED_ALIGN PackedArg {
+OSL_PACK_STRUCTS_BEGIN
+template<int IndexT, typename TypeT> struct alignas(1) PackedArg {
     explicit PackedArg(const TypeT& a_value) : m_value(a_value) {}
     TypeT m_value;
 };
-OSL_PACKED_ALIGN_END
+OSL_PACK_STRUCTS_END
 
 template<typename IntSequenceT, typename... TypeListT> struct PackedArgsBase;
 // Specialize to extract a parameter pack of the IntegerSquence
 // so it can be expanded alongside the TypeListT parameter pack
-OSL_PACKED_ALIGN_BEGIN
+OSL_PACK_STRUCTS_BEGIN
 template<int... IntegerListT, typename... TypeListT>
-struct OSL_PACKED_ALIGN
+struct alignas(1)
     PackedArgsBase<std::integer_sequence<int, IntegerListT...>, TypeListT...>
     : public PackedArg<IntegerListT, TypeListT>... {
     explicit PackedArgsBase(const TypeListT&... a_values)
@@ -43,7 +43,7 @@ struct OSL_PACKED_ALIGN
     {
     }
 };
-OSL_PACKED_ALIGN_END
+OSL_PACK_STRUCTS_END
 
 template<typename... TypeListT> struct PackedArgs {
     typedef std::make_integer_sequence<int, sizeof...(TypeListT)>
@@ -59,6 +59,8 @@ template<typename... TypeListT> struct PackedArgs {
 static_assert(sizeof(PackedArgs<int, char, int>)
                   == sizeof(int) + sizeof(char) + sizeof(int),
               "PackedArgs<> type is not packed");
+static_assert(alignof(PackedArgs<int, char, int>) == 1,
+              "PackedArgs<> type is not aligned to 1");
 
 }  // namespace pvt
 

--- a/src/include/OSL/fmt_util.h
+++ b/src/include/OSL/fmt_util.h
@@ -21,16 +21,20 @@ namespace pvt {
 // PackedArgs is similar to tuple but packs its data back to back
 // in memory layout, which is what we need to build up payload
 // to the fmt reporting system
-template<int IndexT, typename TypeT> struct PackedArg {
+OSL_PACKED_ALIGN_BEGIN
+template<int IndexT, typename TypeT> struct OSL_PACKED_ALIGN PackedArg {
     explicit PackedArg(const TypeT& a_value) : m_value(a_value) {}
     TypeT m_value;
-} __attribute__((packed, aligned(1)));
+};
+OSL_PACKED_ALIGN_END
 
 template<typename IntSequenceT, typename... TypeListT> struct PackedArgsBase;
 // Specialize to extract a parameter pack of the IntegerSquence
 // so it can be expanded alongside the TypeListT parameter pack
+OSL_PACKED_ALIGN_BEGIN
 template<int... IntegerListT, typename... TypeListT>
-struct PackedArgsBase<std::integer_sequence<int, IntegerListT...>, TypeListT...>
+struct OSL_PACKED_ALIGN
+    PackedArgsBase<std::integer_sequence<int, IntegerListT...>, TypeListT...>
     : public PackedArg<IntegerListT, TypeListT>... {
     explicit PackedArgsBase(const TypeListT&... a_values)
         // multiple inheritance of individual components
@@ -38,7 +42,8 @@ struct PackedArgsBase<std::integer_sequence<int, IntegerListT...>, TypeListT...>
         : PackedArg<IntegerListT, TypeListT>(a_values)...
     {
     }
-} __attribute__((packed, aligned(1)));
+};
+OSL_PACKED_ALIGN_END
 
 template<typename... TypeListT> struct PackedArgs {
     typedef std::make_integer_sequence<int, sizeof...(TypeListT)>
@@ -50,6 +55,11 @@ template<typename... TypeListT> struct PackedArgs {
     {
     }
 };
+
+static_assert(sizeof(PackedArgs<int, char, int>)
+                  == sizeof(int) + sizeof(char) + sizeof(int),
+              "PackedArgs<> type is not packed");
+
 }  // namespace pvt
 
 

--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -565,8 +565,8 @@ template<> OSL_FORCEINLINE double bitcast<double, int64_t>(const int64_t& val) n
 ///     char x, y, z;
 /// };
 /// OSL_PACK_STRUCTS_END
-#define OSL_PACK_STRUCTS_BEGIN _Pragma("pack(push, 1)")
-#define OSL_PACK_STRUCTS_END _Pragma("pack(pop)")
+#define OSL_PACK_STRUCTS_BEGIN OSL_PRAGMA(pack(push, 1))
+#define OSL_PACK_STRUCTS_END OSL_PRAGMA(pack(pop))
 
 
 #if OSL_CPLUSPLUS_VERSION >= 20

--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -556,6 +556,28 @@ template<> OSL_FORCEINLINE double bitcast<double, int64_t>(const int64_t& val) n
 #endif
 
 
+/// OSL_PACKED_ALIGN* is used to pack a struct or class tightly and align it
+/// to 1 byte. Use it like the following example to ensure portability across
+/// GCC and MSVC. Other placement of OSL_PACKED_ALIGN might work on GCC but
+/// fail on MSVC. Failure to add begin and end macros will work on GCC but
+/// fail to pack the struct on MSVC.
+///
+/// OSL_PACKED_ALIGN_BEGIN
+/// struct OSL_PACKED_ALIGN Foo {
+///     char x, y, z;
+/// };
+/// OSL_PACKED_ALIGN_END
+#if defined(_MSC_VER)
+#    define OSL_PACKED_ALIGN __declspec(align(1))
+#    define OSL_PACKED_ALIGN_BEGIN __pragma(pack(push, 1))
+#    define OSL_PACKED_ALIGN_END __pragma(pack(pop))
+#else
+#    define OSL_PACKED_ALIGN __attribute__((packed, aligned(1)))
+#    define OSL_PACKED_ALIGN_BEGIN
+#    define OSL_PACKED_ALIGN_END
+#endif
+
+
 
 #if OSL_CPLUSPLUS_VERSION >= 20
 using std::assume_aligned;

--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -556,27 +556,17 @@ template<> OSL_FORCEINLINE double bitcast<double, int64_t>(const int64_t& val) n
 #endif
 
 
-/// OSL_PACKED_ALIGN* is used to pack a struct or class tightly and align it
-/// to 1 byte. Use it like the following example to ensure portability across
-/// GCC and MSVC. Other placement of OSL_PACKED_ALIGN might work on GCC but
-/// fail on MSVC. Failure to add begin and end macros will work on GCC but
-/// fail to pack the struct on MSVC.
+/// OSL_PACK_STRUCTS_* is used to pack a struct or class tightly. Use it like
+/// the following example. To set the alignment of the struct use the
+/// alignas(x) directive.
 ///
-/// OSL_PACKED_ALIGN_BEGIN
-/// struct OSL_PACKED_ALIGN Foo {
+/// OSL_PACK_STRUCTS_BEGIN
+/// struct alignas(1) Foo {
 ///     char x, y, z;
 /// };
-/// OSL_PACKED_ALIGN_END
-#if defined(_MSC_VER)
-#    define OSL_PACKED_ALIGN __declspec(align(1))
-#    define OSL_PACKED_ALIGN_BEGIN __pragma(pack(push, 1))
-#    define OSL_PACKED_ALIGN_END __pragma(pack(pop))
-#else
-#    define OSL_PACKED_ALIGN __attribute__((packed, aligned(1)))
-#    define OSL_PACKED_ALIGN_BEGIN
-#    define OSL_PACKED_ALIGN_END
-#endif
-
+/// OSL_PACK_STRUCTS_END
+#define OSL_PACK_STRUCTS_BEGIN _Pragma("pack(push, 1)")
+#define OSL_PACK_STRUCTS_END _Pragma("pack(pop)")
 
 
 #if OSL_CPLUSPLUS_VERSION >= 20


### PR DESCRIPTION
## Description
This PR fixes a build error due to MSVC not supporting `__attribute__((packed, aligned(1)))` that GCC and Clang use.

## Tests

I wrote a `static_assert` which checks the sizeof a struct which contains fields `int, char, int` to ensure it is not padded.
I have verified this test fails (on both GCC and MSVC) if the packed attribute/pragma is not present.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
