### PR TITLE
PR/FixPointCloud4MSVC

### DIFF
--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -139,7 +139,7 @@ RendererServices::pointcloud_search(ShaderGlobals* sg, ustringhash filename,
             = (SortedPointRecord*)sg->context->alloc_scratch(
                 count * sizeof(SortedPointRecord), sizeof(SortedPointRecord));
         for (int i = 0; i < count; ++i)
-            sorted[i] = SortedPointRecord(dist2[i], static_cast<uint32_t>(indices[i]));
+            sorted[i] = SortedPointRecord(dist2[i], indices[i]);
         std::sort(sorted, sorted + count, SortedPointCompare());
         for (int i = 0; i < count; ++i) {
             dist2[i]   = sorted[i].first;

--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -139,7 +139,7 @@ RendererServices::pointcloud_search(ShaderGlobals* sg, ustringhash filename,
             = (SortedPointRecord*)sg->context->alloc_scratch(
                 count * sizeof(SortedPointRecord), sizeof(SortedPointRecord));
         for (int i = 0; i < count; ++i)
-            sorted[i] = SortedPointRecord(dist2[i], indices[i]);
+            sorted[i] = SortedPointRecord(dist2[i], static_cast<uint32_t>(indices[i]));
         std::sort(sorted, sorted + count, SortedPointCompare());
         for (int i = 0; i < count; ++i) {
             dist2[i]   = sorted[i].first;

--- a/src/liboslexec/pointcloud.h
+++ b/src/liboslexec/pointcloud.h
@@ -21,10 +21,10 @@ public:
                bool write);
     ~PointCloud();
 
-    PointCloud(const PointCloud&) = delete;
-    PointCloud(const PointCloud&&) = delete;
-    PointCloud & operator=(const PointCloud&) = delete;
-    PointCloud & operator=(const PointCloud&&) = delete;
+    PointCloud(const PointCloud&)             = delete;
+    PointCloud(const PointCloud&&)            = delete;
+    PointCloud& operator=(const PointCloud&)  = delete;
+    PointCloud& operator=(const PointCloud&&) = delete;
 
     static PointCloud* get(ustringhash filename, bool write = false);
 
@@ -60,9 +60,8 @@ namespace {  // anon
 
 static ustring u_position("position");
 
-// some helper classes to make the sort easy, 
-// assume that indices of point cloud < 2^32
-typedef std::pair<float, uint32_t> SortedPointRecord;  // dist,index
+// some helper classes to make the sort easy
+typedef std::pair<float, Partio::ParticleIndex> SortedPointRecord;  // dist,index
 struct SortedPointCompare {
     bool operator()(const SortedPointRecord& a, const SortedPointRecord& b)
     {

--- a/src/liboslexec/pointcloud.h
+++ b/src/liboslexec/pointcloud.h
@@ -20,6 +20,12 @@ public:
     PointCloud(ustringhash filename, Partio::ParticlesDataMutable* partio_cloud,
                bool write);
     ~PointCloud();
+
+    PointCloud(const PointCloud&) = delete;
+    PointCloud(const PointCloud&&) = delete;
+    PointCloud & operator=(const PointCloud&) = delete;
+    PointCloud & operator=(const PointCloud&&) = delete;
+
     static PointCloud* get(ustringhash filename, bool write = false);
 
     typedef std::unordered_map<ustringhash,
@@ -54,8 +60,9 @@ namespace {  // anon
 
 static ustring u_position("position");
 
-// some helper classes to make the sort easy
-typedef std::pair<float, int> SortedPointRecord;  // dist,index
+// some helper classes to make the sort easy, 
+// assume that indices of point cloud < 2^32
+typedef std::pair<float, uint32_t> SortedPointRecord;  // dist,index
 struct SortedPointCompare {
     bool operator()(const SortedPointRecord& a, const SortedPointRecord& b)
     {


### PR DESCRIPTION
Fixes Issue #1755: Build error on MSVC with Partio

## Description

Explicitly mark unsupport/unused PointCloud copy/move constuctors and assignment operators as deleted. Change SortedPointRecord indice type from int to uint32_t and add static_cast during construction to avoid a warning.

## Tests

Existing testsuite covers changes

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
