### PR TITLE
build: handle case where OIIO uses a different Imath than OSL

### DIFF
--- a/src/testrender/cuda/rend_lib.h
+++ b/src/testrender/cuda/rend_lib.h
@@ -4,6 +4,16 @@
 
 #pragma once
 
+#include <OSL/oslconfig.h>
+
+#if defined(__has_include) && __has_include(<Imath/half.h>)
+#    include <Imath/half.h>
+#elif OSL_USING_IMATH >= 3
+#    include <Imath/half.h>
+#else
+#    include <OpenEXR/half.h>
+#endif
+
 #include "../../liboslexec/string_hash.h"
 #include <OSL/oslexec.h>
 


### PR DESCRIPTION
This can come up if, for example, you build an OIIO using a static Imath library that's more recent (3.x) than what you're forced to use for your OSL build (2.4). (Don't ask, you don't want to know.) So OSL needs to see half.h before we include any OIIO headers. But it's the OIIO headers that adjudicated where we get half.h from, so we need to be a little more explicit in, of all places, rend_lib.h of testrender.

