### PR TITLE
ci: test against LLVM 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
             setenvs: export LLVM_VERSION=10.0.0
                             OPENIMAGEIO_CMAKE_FLAGS="-DBUILD_FMT_VERSION=7.0.1"
                             PUGIXML_VERSION=v1.10
-          - desc: latest releases gcc11/C++17 llvm15 boost1.71 exr3.2 py3.9 avx2 batch-b16avx512
+          - desc: latest releases gcc11/C++17 llvm16 boost1.71 exr3.2 py3.9 avx2 batch-b16avx512
             nametag: linux-latest-releases
             runner: ubuntu-22.04
             cxx_compiler: g++-11
@@ -392,11 +392,11 @@ jobs:
             python_ver: "3.10"
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
-            setenvs: export LLVM_VERSION=15.0.6
-                            LLVM_DISTRO_NAME=ubuntu-18.04
+            setenvs: export LLVM_VERSION=16.0.4
+                            LLVM_DISTRO_NAME=ubuntu-22.04
                             OPENCOLORIO_VERSION=v2.2.0
                             PUGIXML_VERSION=v1.13
-          - desc: bleeding edge gcc12/C++17 llvm16 oiio/ocio/exr/pybind-master boost1.71 py3.10 avx2 batch-b16avx512
+          - desc: bleeding edge gcc12/C++17 llvm17 oiio/ocio/exr/pybind-master boost1.71 py3.10 avx2 batch-b16avx512
             nametag: linux-bleeding-edge
             runner: ubuntu-22.04
             cxx_compiler: g++-12
@@ -408,7 +408,7 @@ jobs:
             python_ver: "3.10"
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
-            setenvs: export LLVM_VERSION=16.0.4
+            setenvs: export LLVM_VERSION=17.0.6
                             LLVM_DISTRO_NAME=ubuntu-22.04
                             OPENCOLORIO_VERSION=main
                             PUGIXML_VERSION=master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,23 +486,12 @@ jobs:
 
 
   macos:
-    name: "${{matrix.runner}} appleclang${{matrix.aclang}}/C++${{matrix.cxx_std}} py${{matrix.python_ver}} ${{matrix.desc}}"
+    name: "${{matrix.runner}} C++${{matrix.cxx_std}} py${{matrix.python_ver}} ${{matrix.desc}}"
     strategy:
       fail-fast: false
       matrix:
         include:
-          # - desc: MacOS-11
-          #   runner: macos-11
-          #   nametag: macos11-py310
-          #   cc_compiler: /usr/local/opt/llvm@14/bin/clang
-          #   cxx_compiler: /usr/local/opt/llvm@14/bin/clang++
-          #   cxx_std: 17
-          #   python_ver: "3.10"
-          #   aclang: 13
-          #   setenvs: export LLVMBREWVER="@14" DO_BREW_UPDATE=1
-          #                   OPENIMAGEIO_VERSION=release
-          #                   QT_BREW_VERSION="@5"
-          - desc: MacOS-12
+          - desc: llvm15
             runner: macos-12
             nametag: macos12-p310
             cc_compiler: /usr/local/opt/llvm@15/bin/clang
@@ -512,15 +501,15 @@ jobs:
             aclang: 13
             setenvs: export LLVMBREWVER="@15" DO_BREW_UPDATE=1
                             OPENIMAGEIO_VERSION=master
-          - desc: MacOS-13
+          - desc: llvm17
             runner: macos-13
             nametag: macos13-p311
-            cc_compiler: /usr/local/opt/llvm@15/bin/clang
-            cxx_compiler: /usr/local/opt/llvm@15/bin/clang++
+            cc_compiler: /usr/local/opt/llvm/bin/clang
+            cxx_compiler: /usr/local/opt/llvm/bin/clang++
             cxx_std: 17
             python_ver: "3.11"
             aclang: 14
-            setenvs: export LLVMBREWVER="@15" DO_BREW_UPDATE=1
+            setenvs: export DO_BREW_UPDATE=1
                             OPENIMAGEIO_VERSION=master
 
     runs-on: ${{matrix.runner}}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     $OpenImageIO_ROOT/lib to be in your LD_LIBRARY_PATH (or
     DYLD_LIBRARY_PATH on OS X).
 
-* [LLVM](http://www.llvm.org) 9, 10, 11, 12, 13, 14, 15, or 16, including
+* [LLVM](http://www.llvm.org) 9, 10, 11, 12, 13, 14, 15, 16, or 17, including
   clang libraries.
 
 * (optional) For GPU rendering on NVIDIA GPUs:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
 
 * A suitable C++14 or C++17 compiler to build OSL itself, which may be any of:
    - GCC 6.1 or newer (tested through gcc 12.1)
-   - Clang 3.4 or newer (tested through clang 16)
+   - Clang 3.4 or newer (tested through clang 17)
    - Microsoft Visual Studio 2017 or newer
    - Intel C++ compiler icc version 17 or newer or LLVM-based icx compiler
      version 2022 or newer.
@@ -64,7 +64,7 @@ NEW or CHANGED dependencies since the last major release are **bold**.
   be operative.
 * (optional) Python: If you are building the Python bindings or running the
   testsuite:
-    * Python >= 2.7 (tested against 2.7, 3.7, 3.8, 3.9, 3.10)
+    * Python >= 2.7 (tested against 2.7, 3.7, 3.8, 3.9, 3.10, 3.11)
       NOTE: It is likely that 1.13 is the last release that will support
       Python 2.7.
     * pybind11 >= 2.4.2 (Tested through 2.11. Note that pybind11 v2.10+ does

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -44,6 +44,7 @@ brew install --display-times -q partio pugixml
 brew install --display-times -q pybind11 numpy || true
 brew install --display-times -q tbb || true
 brew install --display-times -q flex bison
+brew install --display-times -q fmt
 brew install --display-times -q llvm${LLVMBREWVER}
 brew install --display-times -q qt${QT_BREW_VERSION}
 


### PR DESCRIPTION
Bump the "bleeding edge" test to LLVM 17, the "stable latest releases" test to 16.

