### PR TITLE
style: Raise our formatting standard to clang-format 17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,6 @@
 
 Language:        Cpp
 BasedOnStyle:  WebKit
-SpaceBeforeParens: ControlStatements
 
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,6 @@
 - [ ] I have updated the documentation, if applicable.
 - [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
 - [ ] My code follows the prevailing code style of this project. If I haven't
-  already run clang-format before submitting, I definitely will look at the CI
-  test that runs clang-format and fix anything that it highlights as being
-  nonconforming.
+  already run clang-format v17 before submitting, I definitely will look at
+  the CI test that runs clang-format and fix anything that it highlights as
+  being nonconforming.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,25 +217,6 @@ jobs:
             #   texture system adequately and is able to ignore the benign
             #   "leaks."
 
-            # Test formatting. This test entry doesn't do a full build, it
-            # just runs clang-format on everything, and passes if nothing is
-            # misformatted. Upon failure, the build artifact will be the full
-            # source code with the formatting fixed (diffs will also appear in
-            # the console output).
-          - desc: "clang-format"
-            nametag: clang-format
-            runner: ubuntu-latest
-            container: aswftesting/ci-osl:2022-clang14
-            vfxyear: 2022
-            cxx_std: 17
-            openimageio_ver: release
-            python_ver: 3.9
-            simd: avx2,f16c
-            batched: b8_AVX2
-            skip_tests: 1
-            setenvs: export BUILDTARGET=clang-format
-                            OPENIMAGEIO_CMAKE_FLAGS=-DUSE_PYTHON=0
-
           # Test ABI stability. `abi_check` is the version or commit that we
           # believe is the current standard against which we don't want to
           # break the ABI. Basically, we will build that version as well as
@@ -429,6 +410,27 @@ jobs:
                             LLVM_DISTRO_NAME=ubuntu-18.04
                             OPENCOLORIO_VERSION=v2.1.2
                             PUGIXML_VERSION=v1.11.4
+            # Test formatting. This test entry doesn't do a full build, it
+            # just runs clang-format on everything, and passes if nothing is
+            # misformatted. Upon failure, the build artifact will be the full
+            # source code with the formatting fixed (diffs will also appear in
+            # the console output).
+          - desc: "clang-format"
+            nametag: clang-format
+            runner: ubuntu-latest
+            container: aswftesting/ci-osl:2022-clang14
+            cxx_std: 17
+            extra_artifacts: "src/*.*"
+            openimageio_ver: release
+            python_ver: "3.10"
+            simd: avx2,f16c
+            batched: b8_AVX2
+            skip_tests: 1
+            setenvs: export BUILDTARGET=clang-format
+                            LLVM_VERSION=17.0.6
+                            LLVM_DISTRO_NAME=ubuntu-22.04
+                            OPENIMAGEIO_CMAKE_FLAGS=-DUSE_PYTHON=0
+                            QT_VERSION=0
 
     runs-on: ${{matrix.runner}}
     env:
@@ -483,6 +485,7 @@ jobs:
             build/*.cmake
             build/CMake*
             build/testsuite/*/*.*
+            ${{ matrix.extra_artifacts }}
 
 
   macos:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,8 @@ own repository on GitHub, and then clone it to get a repository on your
 local machine.
 
 2. Edit, compile, and test your changes.  Run clang-format (see the
-instructions on coding style below).
+instructions on coding style below). Our current formatting standard,
+as checked by our CI, uses clang-format 17.0.
 
 3. Push your changes to your fork (each unrelated pull request to a separate
 "topic branch", please).
@@ -170,14 +171,14 @@ file in which it appears.
 
 #### Formatting
 
-We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
+We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) v17
 to uniformly format our source code prior to PR submission. Make sure that
 clang-format is installed on your local machine, and just run
 
     make clang-format
 
 and it will automatically reformat your code according to the configuration
-file found in the `.clang-format` file at the root directory of the OIIO
+file found in the `.clang-format` file at the root directory of the OSL
 source code checkout.
 
 One of the CI test matrix entries runs clang-format and fails if any

--- a/src/include/OSL/device_ptr.h
+++ b/src/include/OSL/device_ptr.h
@@ -32,36 +32,21 @@ public:
 #ifdef __CUDA_ARCH__
     /// On device, act as a pointer. None of these things are allowed on the
     /// host.
-    T* operator->() const
-    {
-        return m_ptr;
-    }
-    T& operator*() const
-    {
-        return *m_ptr;
-    }
+    T* operator->() const { return m_ptr; }
+    T& operator*() const { return *m_ptr; }
 #endif
 
     /// Extract the raw device-side pointer. Use with caution! On the host,
     /// this will not point to valid memory.
-    T* d_get() const
-    {
-        return m_ptr;
-    }
+    T* d_get() const { return m_ptr; }
 
     /// Evaluate as bool is a null pointer check.
-    operator bool() const noexcept
-    {
-        return m_ptr != nullptr;
-    }
+    operator bool() const noexcept { return m_ptr != nullptr; }
 
     /// Reset the pointer to `dptr`, which must be a device-side raw pointer,
     /// or null. Since this device_ptr is non-owning, any previous value is
     /// simply overwritten.
-    void reset(T* dptr = nullptr)
-    {
-        m_ptr = dptr;
-    }
+    void reset(T* dptr = nullptr) { m_ptr = dptr; }
 
 private:
     T* m_ptr = nullptr;  // underlying pointer, initializes to null

--- a/src/include/OSL/mask.h
+++ b/src/include/OSL/mask.h
@@ -171,22 +171,13 @@ public:
     }
 
 
-    OSL_FORCEINLINE ValueType value() const
-    {
-        return m_value;
-    }
+    OSL_FORCEINLINE ValueType value() const { return m_value; }
 
     // count number of active bits
-    OSL_FORCEINLINE int count() const
-    {
-        return OSL::popcount(m_value);
-    }
+    OSL_FORCEINLINE int count() const { return OSL::popcount(m_value); }
 
     // NOTE: undefined result if no bits are on
-    OSL_FORCEINLINE int first_on() const
-    {
-        return OSL::countr_zero(m_value);
-    }
+    OSL_FORCEINLINE int first_on() const { return OSL::countr_zero(m_value); }
 
     OSL_FORCEINLINE Mask invert() const
     {
@@ -239,10 +230,7 @@ public:
         return (m_value != static_cast<ValueType>(0));
     }
 
-    OSL_FORCEINLINE bool any_off() const
-    {
-        return (m_value < valid_bits);
-    }
+    OSL_FORCEINLINE bool any_off() const { return (m_value < valid_bits); }
 
     OSL_FORCEINLINE bool any_off(const Mask& mask) const
     {
@@ -257,39 +245,27 @@ public:
     // So really only set_on or set_off is required
     // Choose to not provide a generic set(int lane, bool flag)
 
-    OSL_FORCEINLINE void set_on(int lane)
-    {
-        m_value |= (1 << lane);
-    }
+    OSL_FORCEINLINE void set_on(int lane) { m_value |= (1 << lane); }
 
     OSL_FORCEINLINE void set_on_if(int lane, bool cond)
     {
         m_value |= (cond << lane);
     }
 
-    OSL_FORCEINLINE void set_all_on()
-    {
-        m_value = valid_bits;
-    }
+    OSL_FORCEINLINE void set_all_on() { m_value = valid_bits; }
     OSL_FORCEINLINE void set_count_on(int count)
     {
         m_value = valid_bits >> (width - count);
     }
 
-    OSL_FORCEINLINE void set_off(int lane)
-    {
-        m_value &= (~(1 << lane));
-    }
+    OSL_FORCEINLINE void set_off(int lane) { m_value &= (~(1 << lane)); }
 
     OSL_FORCEINLINE void set_off_if(int lane, bool cond)
     {
         m_value &= (~(cond << lane));
     }
 
-    OSL_FORCEINLINE void set_all_off()
-    {
-        m_value = static_cast<ValueType>(0);
-    }
+    OSL_FORCEINLINE void set_all_off() { m_value = static_cast<ValueType>(0); }
 
     OSL_FORCEINLINE bool operator==(const Mask& other) const
     {
@@ -323,10 +299,7 @@ public:
         return Mask(m_value | other.m_value);
     }
 
-    OSL_FORCEINLINE Mask operator~() const
-    {
-        return invert();
-    }
+    OSL_FORCEINLINE Mask operator~() const { return invert(); }
 
 
     template<int MinOccupancyT, int MaxOccupancyT = width, typename FunctorT>

--- a/src/include/OSL/oslclosure.h
+++ b/src/include/OSL/oslclosure.h
@@ -109,14 +109,8 @@ OSL_ALIGNAS(16) ClosureComponent : public ClosureColor
     Vec3 w;  ///< Weight of this component
 
     /// Handy method for getting the parameter memory as a void*.
-    OSL_HOSTDEVICE void* data()
-    {
-        return (char*)(this + 1);
-    }
-    OSL_HOSTDEVICE const void* data() const
-    {
-        return (const char*)(this + 1);
-    }
+    OSL_HOSTDEVICE void* data() { return (char*)(this + 1); }
+    OSL_HOSTDEVICE const void* data() const { return (const char*)(this + 1); }
 
     /// Handy methods for extracting the underlying parameters as a struct
     template<typename T> OSL_HOSTDEVICE const T* as() const

--- a/src/include/OSL/rendererservices.h
+++ b/src/include/OSL/rendererservices.h
@@ -19,8 +19,7 @@ struct ShaderGlobals;
 class ShaderGroup;
 
 // Tags for polymorphic dispatch
-template<int SimdWidthT> class WidthOf {
-};
+template<int SimdWidthT> class WidthOf {};
 
 
 /// Opaque pointer to whatever the renderer uses to represent a

--- a/src/include/OSL/wide.h
+++ b/src/include/OSL/wide.h
@@ -299,16 +299,13 @@ public:
 
 // Specializations
 template<int WidthT>
-struct Block<float, WidthT> : public BlockOfBuiltin<float, WidthT> {
-};
+struct Block<float, WidthT> : public BlockOfBuiltin<float, WidthT> {};
 
 template<int WidthT>
-struct Block<int, WidthT> : public BlockOfBuiltin<int, WidthT> {
-};
+struct Block<int, WidthT> : public BlockOfBuiltin<int, WidthT> {};
 
 template<typename DataT, int WidthT>
-struct Block<DataT*, WidthT> : public BlockOfBuiltin<DataT*, WidthT> {
-};
+struct Block<DataT*, WidthT> : public BlockOfBuiltin<DataT*, WidthT> {};
 
 
 // Vec4 isn't used by external interfaces, but some internal
@@ -2292,15 +2289,9 @@ template<typename DataT, int WidthT> struct MaskedLaneProxy {
     // visibility to end user whose IDE
     // might display these methods vs. free
     // functions
-    OSL_FORCEINLINE bool is_on() const
-    {
-        return m_mask.is_on(m_lane);
-    }
+    OSL_FORCEINLINE bool is_on() const { return m_mask.is_on(m_lane); }
 
-    OSL_FORCEINLINE bool is_off() const
-    {
-        return m_mask.is_off(m_lane);
-    }
+    OSL_FORCEINLINE bool is_off() const { return m_mask.is_off(m_lane); }
 
 private:
     Block<DataT, WidthT>& m_ref_wide_data;
@@ -2362,15 +2353,9 @@ struct MaskedArrayLaneProxy {
     // visibility to end user whose IDE
     // might display these methods vs. free
     // functions
-    OSL_FORCEINLINE bool is_on() const
-    {
-        return m_mask.is_on(m_lane);
-    }
+    OSL_FORCEINLINE bool is_on() const { return m_mask.is_on(m_lane); }
 
-    OSL_FORCEINLINE bool is_off() const
-    {
-        return m_mask.is_off(m_lane);
-    }
+    OSL_FORCEINLINE bool is_off() const { return m_mask.is_off(m_lane); }
 
     OSL_FORCEINLINE MaskedLaneProxy<DataT, WidthT>
     operator[](int array_index) const
@@ -2735,7 +2720,8 @@ struct MaskedDeriv : public Masked<DataT, WidthT> {
     template<typename FirstT, typename... ListT,
              std::enable_if_t<std::is_same<typename std::decay<FirstT>::type,
                                            MaskedDeriv>::value,
-                              bool> = true>
+                              bool>
+             = true>
     OSL_FORCEINLINE MaskedDeriv(FirstT&& first, ListT&&... argList)
         : Masked<DataT, WidthT>(std::forward<FirstT>(first),
                                 std::forward<ListT>(argList)...)
@@ -2746,7 +2732,8 @@ struct MaskedDeriv : public Masked<DataT, WidthT> {
     template<typename FirstT, typename... ListT,
              std::enable_if_t<!std::is_same<typename std::decay<FirstT>::type,
                                             MaskedDeriv>::value,
-                              bool> = true>
+                              bool>
+             = true>
     OSL_FORCEINLINE MaskedDeriv(FirstT&& first, ListT&&... argList)
         : Masked<DataT, WidthT>(std::forward<FirstT>(first),
                                 std::forward<ListT>(argList)...,
@@ -3197,7 +3184,8 @@ template<typename DataT, int DerivIndexT> struct RefDeriv : public Ref<DataT> {
     template<typename FirstT, typename... ListT,
              std::enable_if_t<!std::is_same<typename std::decay<FirstT>::type,
                                             RefDeriv>::value,
-                              bool> = true>
+                              bool>
+             = true>
     explicit OSL_FORCEINLINE RefDeriv(FirstT&& first, ListT&&... argList)
         : Ref<DataT>(std::forward<FirstT>(first),
                      std::forward<ListT>(argList)...,

--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -647,133 +647,55 @@ public:
     }
 
 
-    void dataoffset(int d)
-    {
-        m_dataoffset = d;
-    }
-    int dataoffset() const
-    {
-        return m_dataoffset;
-    }
+    void dataoffset(int d) { m_dataoffset = d; }
+    int dataoffset() const { return m_dataoffset; }
 
-    void wide_dataoffset(int d)
-    {
-        m_wide_dataoffset = d;
-    }
-    int wide_dataoffset() const
-    {
-        return m_wide_dataoffset;
-    }
+    void wide_dataoffset(int d) { m_wide_dataoffset = d; }
+    int wide_dataoffset() const { return m_wide_dataoffset; }
 
-    SymArena arena() const
-    {
-        return static_cast<SymArena>(m_arena);
-    }
+    SymArena arena() const { return static_cast<SymArena>(m_arena); }
 
-    void initializers(int d)
-    {
-        m_initializers = d;
-    }
-    int initializers() const
-    {
-        return m_initializers;
-    }
+    void initializers(int d) { m_initializers = d; }
+    int initializers() const { return m_initializers; }
 
-    bool has_derivs() const
-    {
-        return m_has_derivs;
-    }
-    void has_derivs(bool new_derivs)
-    {
-        m_has_derivs = new_derivs;
-    }
-    int size() const
-    {
-        return m_size;
-    }
-    void size(size_t newsize)
-    {
-        m_size = (int)newsize;
-    }
+    bool has_derivs() const { return m_has_derivs; }
+    void has_derivs(bool new_derivs) { m_has_derivs = new_derivs; }
+    int size() const { return m_size; }
+    void size(size_t newsize) { m_size = (int)newsize; }
 
     /// Return the size for each point, including derivs.
     ///
-    int derivsize() const
-    {
-        return m_has_derivs ? 3 * m_size : m_size;
-    }
+    int derivsize() const { return m_has_derivs ? 3 * m_size : m_size; }
 
-    bool connected() const
-    {
-        return valuesource() == ConnectedVal;
-    }
-    bool connected_down() const
-    {
-        return m_connected_down;
-    }
-    void connected_down(bool c)
-    {
-        m_connected_down = c;
-    }
+    bool connected() const { return valuesource() == ConnectedVal; }
+    bool connected_down() const { return m_connected_down; }
+    void connected_down(bool c) { m_connected_down = c; }
 
     /// Where did the symbol's value come from?
     ///
     enum ValueSource { DefaultVal, InstanceVal, GeomVal, ConnectedVal };
 
-    ValueSource valuesource() const
-    {
-        return (ValueSource)m_valuesource;
-    }
-    void valuesource(ValueSource v)
-    {
-        m_valuesource = v;
-    }
+    ValueSource valuesource() const { return (ValueSource)m_valuesource; }
+    void valuesource(ValueSource v) { m_valuesource = v; }
     const char* valuesourcename() const;
     static const char* valuesourcename(ValueSource v);
 
-    int fieldid() const
-    {
-        return m_fieldid;
-    }
-    void fieldid(int id)
-    {
-        m_fieldid = id;
-    }
+    int fieldid() const { return m_fieldid; }
+    void fieldid(int id) { m_fieldid = id; }
 
-    int layer() const
-    {
-        return m_layer;
-    }
-    void layer(int id)
-    {
-        m_layer = id;
-    }
+    int layer() const { return m_layer; }
+    void layer(int id) { m_layer = id; }
 
-    int initbegin() const
-    {
-        return m_initbegin;
-    }
-    void initbegin(int i)
-    {
-        m_initbegin = i;
-    }
-    int initend() const
-    {
-        return m_initend;
-    }
-    void initend(int i)
-    {
-        m_initend = i;
-    }
+    int initbegin() const { return m_initbegin; }
+    void initbegin(int i) { m_initbegin = i; }
+    int initend() const { return m_initend; }
+    void initend(int i) { m_initend = i; }
     void set_initrange(int b = 0, int e = 0)
     {
         m_initbegin = b;
         m_initend   = e;
     }
-    bool has_init_ops() const
-    {
-        return m_initbegin != m_initend;
-    }
+    bool has_init_ops() const { return m_initbegin != m_initend; }
 
     /// Clear read/write usage info.
     ///
@@ -817,42 +739,15 @@ public:
         }
     }
 
-    int firstread() const
-    {
-        return m_firstread;
-    }
-    int lastread() const
-    {
-        return m_lastread;
-    }
-    int firstwrite() const
-    {
-        return m_firstwrite;
-    }
-    int lastwrite() const
-    {
-        return m_lastwrite;
-    }
-    int firstuse() const
-    {
-        return std::min(firstread(), firstwrite());
-    }
-    int lastuse() const
-    {
-        return std::max(lastread(), lastwrite());
-    }
-    bool everread() const
-    {
-        return lastread() >= 0;
-    }
-    bool everwritten() const
-    {
-        return lastwrite() >= 0;
-    }
-    bool everused() const
-    {
-        return everread() || everwritten();
-    }
+    int firstread() const { return m_firstread; }
+    int lastread() const { return m_lastread; }
+    int firstwrite() const { return m_firstwrite; }
+    int lastwrite() const { return m_lastwrite; }
+    int firstuse() const { return std::min(firstread(), firstwrite()); }
+    int lastuse() const { return std::max(lastread(), lastwrite()); }
+    bool everread() const { return lastread() >= 0; }
+    bool everwritten() const { return lastwrite() >= 0; }
+    bool everused() const { return everread() || everwritten(); }
     // everused_in_group is an even more stringent test -- not only must
     // the symbol not be used within the shader but it also must not be
     // used elsewhere in the group, by being connected to something downstream
@@ -873,14 +768,8 @@ public:
         m_lastwrite  = last;
     }
 
-    bool initialized() const
-    {
-        return m_initialized;
-    }
-    void initialized(bool init)
-    {
-        m_initialized = init;
-    }
+    bool initialized() const { return m_initialized; }
+    void initialized(bool init) { m_initialized = init; }
 
     bool lockgeom() const
     {
@@ -889,76 +778,34 @@ public:
         return !m_interpolated && !m_interactive;
     }
 
-    bool interpolated() const
-    {
-        return m_interpolated;
-    }
-    void interpolated(bool val)
-    {
-        m_interpolated = val;
-    }
+    bool interpolated() const { return m_interpolated; }
+    void interpolated(bool val) { m_interpolated = val; }
 
-    bool interactive() const
-    {
-        return m_interactive;
-    }
-    void interactive(bool val)
-    {
-        m_interactive = val;
-    }
+    bool interactive() const { return m_interactive; }
+    void interactive(bool val) { m_interactive = val; }
 
-    bool noninteractive() const
-    {
-        return m_noninteractive;
-    }
-    void noninteractive(bool val)
-    {
-        m_noninteractive = val;
-    }
+    bool noninteractive() const { return m_noninteractive; }
+    void noninteractive(bool val) { m_noninteractive = val; }
 
-    bool allowconnect() const
-    {
-        return m_allowconnect;
-    }
-    void allowconnect(bool val)
-    {
-        m_allowconnect = val;
-    }
+    bool allowconnect() const { return m_allowconnect; }
+    void allowconnect(bool val) { m_allowconnect = val; }
 
-    int arraylen() const
-    {
-        return m_typespec.arraylength();
-    }
+    int arraylen() const { return m_typespec.arraylength(); }
     void arraylen(int len)
     {
         m_typespec.make_array(len);
         m_size = m_typespec.simpletype().size();
     }
 
-    bool renderer_output() const
-    {
-        return m_renderer_output;
-    }
-    void renderer_output(bool v)
-    {
-        m_renderer_output = v;
-    }
+    bool renderer_output() const { return m_renderer_output; }
+    void renderer_output(bool v) { m_renderer_output = v; }
 
     // When not uniform a symbol will have a varying value under batched
     // execution and must use a Wide data type to hold different values
     // for each data lane executing
-    bool is_uniform() const
-    {
-        return m_is_uniform;
-    }
-    bool is_varying() const
-    {
-        return (m_is_uniform == 0);
-    }
-    void make_varying()
-    {
-        m_is_uniform = false;
-    }
+    bool is_uniform() const { return m_is_uniform; }
+    bool is_varying() const { return (m_is_uniform == 0); }
+    void make_varying() { m_is_uniform = false; }
 
     // Results of a compare_op and other ops with logically boolean
     // results under certain conditions could be forced to be represented
@@ -972,32 +819,14 @@ public:
     // The value of forced_llvm_bool() is currently only respected during
     // batched execution.  Forced bools should not be coalesced with regular
     // ints, only other forced bools.
-    bool forced_llvm_bool() const
-    {
-        return m_forced_llvm_bool;
-    }
-    void forced_llvm_bool(bool v)
-    {
-        m_forced_llvm_bool = v;
-    }
+    bool forced_llvm_bool() const { return m_forced_llvm_bool; }
+    void forced_llvm_bool(bool v) { m_forced_llvm_bool = v; }
 
-    bool readonly() const
-    {
-        return m_readonly;
-    }
-    void readonly(bool v)
-    {
-        m_readonly = v;
-    }
+    bool readonly() const { return m_readonly; }
+    void readonly(bool v) { m_readonly = v; }
 
-    bool is_constant() const
-    {
-        return symtype() == SymTypeConst;
-    }
-    bool is_temp() const
-    {
-        return symtype() == SymTypeTemp;
-    }
+    bool is_constant() const { return symtype() == SymTypeConst; }
+    bool is_temp() const { return symtype() == SymTypeTemp; }
 
     // Retrieve the const float value (must be a const float!)
     float get_float(int index = 0) const
@@ -1332,7 +1161,6 @@ OSL_NAMESPACE_EXIT
 // Supply a fmtlib compatible custom formatter for TypeSpec.
 #if FMT_VERSION >= 100000
 FMT_BEGIN_NAMESPACE
-template<> struct formatter<OSL::pvt::TypeSpec> : ostream_formatter {
-};
+template<> struct formatter<OSL::pvt::TypeSpec> : ostream_formatter {};
 FMT_END_NAMESPACE
 #endif

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -1182,15 +1182,9 @@ public:
     }
 
 #ifdef OSL_DEV
-    OSL_FORCEINLINE int op_num() const
-    {
-        return m_op_num;
-    }
+    OSL_FORCEINLINE int op_num() const { return m_op_num; }
 
-    OSL_FORCEINLINE int loop_op_index() const
-    {
-        return m_loop_op_index;
-    }
+    OSL_FORCEINLINE int loop_op_index() const { return m_loop_op_index; }
 #endif
 };
 
@@ -2599,7 +2593,7 @@ struct Analyzer {
 #endif
                     const auto& early_out = *earlyOutIter;
                     auto begin_dep_iter   = m_conditional_symbol_stack.begin_at(
-                          early_out.dtt_pos);
+                        early_out.dtt_pos);
                     auto end_dep_iter = m_conditional_symbol_stack.end();
 
                     const Opcode& opcode = m_opcodes[op_index];

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -381,7 +381,7 @@ BatchedBackendLLVM::llvm_zero_derivs(const Symbol& sym, llvm::Value* count)
         llvm::Value* post_condition_mask = ll.op_and(condition_mask,
                                                      pre_condition_mask);
         llvm::Value* cond_val            = ll.test_if_mask_is_non_zero(
-                       post_condition_mask);
+            post_condition_mask);
 
         // Jump to either LoopBody or AfterLoop
         ll.op_branch(cond_val, body_block, after_block);

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -4282,7 +4282,7 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
     llvm::Value* wide_const_fone_value  = rop.ll.wide_constant(1.0f);
     llvm::Value* const_zero_value       = rop.ll.constant(0);
     llvm::Value* wrap_default_value     = rop.ll.constant(
-            static_cast<int>(Tex::Wrap::Default));
+        static_cast<int>(Tex::Wrap::Default));
 
     llvm::Value* sblur  = wide_const_fzero_value;
     llvm::Value* tblur  = wide_const_fzero_value;
@@ -4301,7 +4301,7 @@ llvm_batched_texture_options(BatchedBackendLLVM& rop, int opnum,
     llvm::Value* twrap        = wrap_default_value;
     llvm::Value* rwrap        = wrap_default_value;
     llvm::Value* mipmode      = rop.ll.constant(
-             static_cast<int>(Tex::MipMode::Default));
+        static_cast<int>(Tex::MipMode::Default));
     llvm::Value* interpmode = rop.ll.constant(
         static_cast<int>(Tex::InterpMode::SmartBicubic));
     llvm::Value* anisotropic         = rop.ll.constant(32);
@@ -7137,7 +7137,7 @@ LLVMGEN(llvm_gen_spline)
                                                                leadLane);
             args[splineNameArgumentIndex]  = scalar_splineName;
             lanesMatchingSplineName        = rop.ll.op_lanes_that_match_masked(
-                       scalar_splineName, splineNameVal, remainingMask);
+                scalar_splineName, splineNameVal, remainingMask);
 
             OSL_ASSERT(lanesMatchingSplineName);
             //rop.llvm_print_mask("lanesMatchingSplineName", lanesMatchingSplineName);
@@ -7383,7 +7383,7 @@ LLVMGEN(llvm_gen_closure)
 
             llvm::Value* dest_base = rop.ll.offset_ptr(mem_void_ptr, p.offset);
             llvm::Type* dest_type  = rop.ll.llvm_type(
-                 static_cast<const TypeSpec&>(p.type).simpletype());
+                static_cast<const TypeSpec&>(p.type).simpletype());
             dest_base = rop.ll.ptr_to_cast(dest_base, dest_type);
 
             if (num_elements > 1) {

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -359,10 +359,7 @@ public:
     {
         mm->registerEHFrames(Addr, LoadAddr, Size);
     }
-    void deregisterEHFrames() override
-    {
-        mm->deregisterEHFrames();
-    }
+    void deregisterEHFrames() override { mm->deregisterEHFrames(); }
 
     uint64_t getSymbolAddress(const std::string& Name) override
     {
@@ -778,17 +775,17 @@ LLVM_Util::debug_push_inlined_function(OIIO::ustring function_name,
         llvm::DINode::FlagPrototyped | llvm::DINode::FlagNoReturn);
     llvm::DISubprogram* function = nullptr;
     function                     = m_llvm_debug_builder->createFunction(
-                            mDebugCU,               // Scope
-                            function_name.c_str(),  // Name
-                            // We are inlined function so not sure supplying a linkage name
-                            // makes sense
-                            /*function_name.c_str()*/ llvm::StringRef(),  // Linkage Name
-                            file,                                   // File
-                            static_cast<unsigned int>(sourceline),  // Line Number
-                            mSubTypeForInlinedFunction,  // subroutine type
-                            method_scope_line,           // Scope Line,
-                            fnFlags,
-                            llvm::DISubprogram::toSPFlags(true /*isLocalToUnit*/,
+        mDebugCU,               // Scope
+        function_name.c_str(),  // Name
+        // We are inlined function so not sure supplying a linkage name
+        // makes sense
+        /*function_name.c_str()*/ llvm::StringRef(),  // Linkage Name
+        file,                                   // File
+        static_cast<unsigned int>(sourceline),  // Line Number
+        mSubTypeForInlinedFunction,  // subroutine type
+        method_scope_line,           // Scope Line,
+        fnFlags,
+        llvm::DISubprogram::toSPFlags(true /*isLocalToUnit*/,
                                                           true /*isDefinition*/,
                                                           true /*false*/ /*isOptimized*/));
 
@@ -4680,8 +4677,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
 
             llvm::Value* unmasked_value = wide_constant(0.0f);
             llvm::Value* args[]         = {
-                        unmasked_value, void_ptr(src_ptr), wide_index, int_mask,
-                        constant(4)  // not sure why the scale
+                unmasked_value, void_ptr(src_ptr), wide_index, int_mask,
+                constant(4)  // not sure why the scale
             };
             return builder().CreateCall(func_avx512_gather_ps,
                                         toArrayRef(args));
@@ -5616,9 +5613,9 @@ LLVM_Util::apply_return_to(llvm::Value* existing_mask)
     OSL_ASSERT(masked_function_context().return_count > 0);
 
     llvm::Value* loc_of_return_mask = masked_function_context().location_of_mask;
-    llvm::Value* rs_mask            = op_load_mask(loc_of_return_mask);
-    llvm::Value* result = builder().CreateSelect(rs_mask, existing_mask,
-                                                 rs_mask);
+    llvm::Value* rs_mask = op_load_mask(loc_of_return_mask);
+    llvm::Value* result  = builder().CreateSelect(rs_mask, existing_mask,
+                                                  rs_mask);
     return result;
 }
 

--- a/src/liboslexec/opcolor_impl.h
+++ b/src/liboslexec/opcolor_impl.h
@@ -538,7 +538,7 @@ ColorSystem::lookup_blackbody_rgb(float T /*Kelvin*/) const
     constexpr int stride = sizeof(Color3) / sizeof(float);
     int sti              = stride * ti;
     Color3 rgb           = OIIO::lerp(
-                  // Have all gathers use the same indices by having different base registers
+        // Have all gathers use the same indices by having different base registers
         // for each of the 6 components
         Color3((blackbody_components + 0)[sti], (blackbody_components + 1)[sti],
                          (blackbody_components + 2)[sti]),

--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -415,9 +415,9 @@ osl_get_textureinfo(void* sg_, ustringhash_pod name_, void* handle,
     ustringhash name     = ustringhash_from(name_);
     ustringhash dataname = ustringhash_from(dataname_);
     bool ok              = sg->renderer->get_texture_info(
-                     name, (RendererServices::TextureHandle*)handle,
-                     sg->context->texture_thread_info(), sg, 0 /*FIXME-ptex*/, dataname,
-                     typedesc, data, errormessage ? &em : nullptr);
+        name, (RendererServices::TextureHandle*)handle,
+        sg->context->texture_thread_info(), sg, 0 /*FIXME-ptex*/, dataname,
+        typedesc, data, errormessage ? &em : nullptr);
     if (errormessage)
         *errormessage = ok ? ustringhash {}.hash() : em.hash();
     return ok;
@@ -443,9 +443,9 @@ osl_get_textureinfo_st(void* sg_, ustringhash_pod name_, void* handle, float s,
     ustringhash name     = ustringhash_from(name_);
     ustringhash dataname = ustringhash_from(dataname_);
     bool ok              = sg->renderer->get_texture_info(
-                     name, (RendererServices::TextureHandle*)handle, s, t,
-                     sg->context->texture_thread_info(), sg, 0 /*FIXME-ptex*/, dataname,
-                     typedesc, data, errormessage ? &em : nullptr);
+        name, (RendererServices::TextureHandle*)handle, s, t,
+        sg->context->texture_thread_info(), sg, 0 /*FIXME-ptex*/, dataname,
+        typedesc, data, errormessage ? &em : nullptr);
     if (errormessage)
         *errormessage = ok ? ustringhash {}.hash() : em.hash();
     return ok;

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -791,10 +791,7 @@ public:
     }
 #endif
 
-    void clear_symlocs()
-    {
-        m_symlocs.clear();
-    }
+    void clear_symlocs() { m_symlocs.clear(); }
     void add_symlocs(cspan<SymLocationDesc> symlocs)
     {
         for (auto& s : symlocs)
@@ -1506,10 +1503,7 @@ public:
     typedef std::vector<SymOverrideInfo> SymOverrideInfoVec;
     static_assert(sizeof(SymOverrideInfo) == 8, "SymOverrideInfo size");
 
-    SymOverrideInfo* instoverride(int i)
-    {
-        return &m_instoverrides[i];
-    }
+    SymOverrideInfo* instoverride(int i) { return &m_instoverrides[i]; }
     const SymOverrideInfo* instoverride(int i) const
     {
         return &m_instoverrides[i];
@@ -1826,19 +1820,10 @@ public:
     }
 #endif
     // Is this shader group equivalent to ret void?
-    bool does_nothing() const
-    {
-        return m_does_nothing;
-    }
-    void does_nothing(bool new_val)
-    {
-        m_does_nothing = new_val;
-    }
+    bool does_nothing() const { return m_does_nothing; }
+    void does_nothing(bool new_val) { m_does_nothing = new_val; }
 
-    long long int executions() const
-    {
-        return m_executions;
-    }
+    long long int executions() const { return m_executions; }
 
     void start_running()
     {
@@ -1847,25 +1832,13 @@ public:
 #endif
     }
 
-    void name(ustring name)
-    {
-        m_name = name;
-    }
-    ustring name() const
-    {
-        return m_name;
-    }
+    void name(ustring name) { m_name = name; }
+    ustring name() const { return m_name; }
 
     std::string serialize() const;
 
-    void lock() const
-    {
-        m_mutex.lock();
-    }
-    void unlock() const
-    {
-        m_mutex.unlock();
-    }
+    void lock() const { m_mutex.lock(); }
+    void unlock() const { m_mutex.unlock(); }
 
     // Find which layer index corresponds to the layer name. Return -1 if
     // not found.
@@ -1877,10 +1850,7 @@ public:
 
     /// Return a unique ID of this group.
     ///
-    int id() const
-    {
-        return m_id;
-    }
+    int id() const { return m_id; }
 
     /// Mark all layers as not entry points and set m_num_entry_layers to 0.
     void clear_entry_layers();
@@ -1894,15 +1864,9 @@ public:
         mark_entry_layer(find_layer(layername));
     }
 
-    int num_entry_layers() const
-    {
-        return m_num_entry_layers;
-    }
+    int num_entry_layers() const { return m_num_entry_layers; }
 
-    bool is_last_layer(int layer) const
-    {
-        return layer == nlayers() - 1;
-    }
+    bool is_last_layer(int layer) const { return layer == nlayers() - 1; }
 
     /// Is the given layer an entry point? It is if explicitly tagged as
     /// such, or if no layers are so tagged then the last layer is the one
@@ -1913,10 +1877,7 @@ public:
                                   : is_last_layer(layer);
     }
 
-    int raytype_queries() const
-    {
-        return m_raytype_queries;
-    }
+    int raytype_queries() const { return m_raytype_queries; }
 
     /// Optionally set which ray types are known to be on or off (0 means
     /// not known at optimize time).
@@ -1925,19 +1886,10 @@ public:
         m_raytypes_on  = raytypes_on;
         m_raytypes_off = raytypes_off;
     }
-    int raytypes_on() const
-    {
-        return m_raytypes_on;
-    }
-    int raytypes_off() const
-    {
-        return m_raytypes_off;
-    }
+    int raytypes_on() const { return m_raytypes_on; }
+    int raytypes_off() const { return m_raytypes_off; }
 
-    void clear_symlocs()
-    {
-        m_symlocs.clear();
-    }
+    void clear_symlocs() { m_symlocs.clear(); }
     void add_symlocs(cspan<SymLocationDesc> symlocs)
     {
         for (auto& s : symlocs) {
@@ -1977,10 +1929,7 @@ public:
     // live with the group and copy the initial data.
     void setup_interactive_arena(cspan<uint8_t> paramblock);
 
-    uint8_t* interactive_arena_ptr()
-    {
-        return m_interactive_arena.get();
-    }
+    uint8_t* interactive_arena_ptr() { return m_interactive_arena.get(); }
 
     device_ptr<uint8_t>& device_interactive_arena()
     {
@@ -2319,25 +2268,13 @@ public:
 
     /// Return a pointer to the shading group for this context.
     ///
-    ShaderGroup* group()
-    {
-        return m_group;
-    }
-    const ShaderGroup* group() const
-    {
-        return m_group;
-    }
-    void group(ShaderGroup* grp)
-    {
-        m_group = grp;
-    }
+    ShaderGroup* group() { return m_group; }
+    const ShaderGroup* group() const { return m_group; }
+    void group(ShaderGroup* grp) { m_group = grp; }
 
     /// Return a reference to the MessageList containing messages.
     ///
-    MessageList& messages()
-    {
-        return m_messages;
-    }
+    MessageList& messages() { return m_messages; }
 #if OSL_USE_BATCHED
     BatchedMessageBuffer& batched_messages_buffer()
     {
@@ -2365,10 +2302,7 @@ public:
                            int array_lookup, int index, TypeDesc attr_type,
                            void* attr_dest);
 
-    PerThreadInfo* thread_info() const
-    {
-        return m_threadinfo;
-    }
+    PerThreadInfo* thread_info() const { return m_threadinfo; }
 
     TextureSystem::Perthread* texture_thread_info() const
     {
@@ -2388,20 +2322,11 @@ public:
         return thread_info()->llvm_thread_info;
     }
 
-    TextureOpt* texture_options_ptr()
-    {
-        return &m_textureopt;
-    }
+    TextureOpt* texture_options_ptr() { return &m_textureopt; }
 
-    RendererServices::NoiseOpt* noise_options_ptr()
-    {
-        return &m_noiseopt;
-    }
+    RendererServices::NoiseOpt* noise_options_ptr() { return &m_noiseopt; }
 
-    RendererServices::TraceOpt* trace_options_ptr()
-    {
-        return &m_traceopt;
-    }
+    RendererServices::TraceOpt* trace_options_ptr() { return &m_traceopt; }
 
     void* alloc_scratch(size_t size, size_t align = 1)
     {
@@ -2412,15 +2337,9 @@ public:
     bool ocio_transform(ustring fromspace, ustring tospace, const Color& C,
                         Color& Cout);
 
-    void incr_layers_executed()
-    {
-        ++m_stat_layers_executed;
-    }
+    void incr_layers_executed() { ++m_stat_layers_executed; }
 
-    void incr_get_userdata_calls()
-    {
-        ++m_stat_get_userdata_calls;
-    }
+    void incr_get_userdata_calls() { ++m_stat_get_userdata_calls; }
 
     // Clear the stats we record per-execution in this context (unlocked)
     void clear_runtime_stats()
@@ -2570,10 +2489,7 @@ private:
     // When interpreting symbol addresses we need to know if the
     // wide data offsets should be used
     int batch_size_executed;
-    bool execution_is_batched() const
-    {
-        return batch_size_executed != 0;
-    }
+    bool execution_is_batched() const { return batch_size_executed != 0; }
 };
 
 

--- a/src/liboslexec/wide/wide_opdictionary.cpp
+++ b/src/liboslexec/wide/wide_opdictionary.cpp
@@ -74,8 +74,8 @@ __OSL_MASKED_OP3(dict_find, Wi, Wi, Ws)(void* bsg_, void* wout, void* wnodeID,
         int nodeID    = wNID[lane];
         ustring query = wQ[lane];
         wOut[lane]    = bsg->uniform.context->dict_find(
-               nullptr /*causes errors be reported through ShadingContext*/,
-               nodeID, query);
+            nullptr /*causes errors be reported through ShadingContext*/,
+            nodeID, query);
     });
 }
 
@@ -109,8 +109,8 @@ __OSL_MASKED_OP3(dict_find, Wi, Ws, Ws)(void* bsg_, void* wout,
         ustring dictionary = wD[lane];
         ustring query      = wQ[lane];
         wOut[lane]         = bsg->uniform.context->dict_find(
-                    nullptr /*causes errors be reported through ShadingContext*/,
-                    dictionary, query);
+            nullptr /*causes errors be reported through ShadingContext*/,
+            dictionary, query);
     });
 }
 

--- a/src/liboslexec/wide/wide_opspline.cpp
+++ b/src/liboslexec/wide/wide_opspline.cpp
@@ -300,8 +300,8 @@ splineinverse_search(const MatrixT& M, R_T& result, X_T& xval, KArrayT knots,
         // We can NOT use the low and high knot values,
         // so will need to extract 2 more knot values
         // to detect if we are increasing
-        K_T k1 = knots[1];  // knots is proxy, must export to local
-        K_T k2 = knots[knot_count - 2];
+        K_T k1     = knots[1];  // knots is proxy, must export to local
+        K_T k2     = knots[knot_count - 2];
         increasing = k1 < k2;
     }
 

--- a/src/liboslexec/wide/wide_optexture.cpp
+++ b/src/liboslexec/wide/wide_optexture.cpp
@@ -112,8 +112,8 @@ default_texture(BatchedRendererServices* bsr, ustring filename,
         float dsdy = wdsdy[lane];
         float dtdy = wdtdy[lane];
         retVal     = bsr->texturesys()->texture(
-                texture_handle, texture_thread_info, opt, ws[lane], wt[lane], dsdx,
-                dtdx, dsdy, dtdy, 4, (float*)&result_simd,
+            texture_handle, texture_thread_info, opt, ws[lane], wt[lane], dsdx,
+            dtdx, dsdy, dtdy, 4, (float*)&result_simd,
             has_derivs ? (float*)&dresultds_simd : NULL,
             has_derivs ? (float*)&dresultdt_simd : NULL);
 

--- a/src/liboslnoise/sfm_gabornoise.h
+++ b/src/liboslnoise/sfm_gabornoise.h
@@ -563,16 +563,16 @@ scalar_gabor3(const Dual2<Vec3>& P, const sfm::GaborUniformParams& gup,
         // to better enable SROA (Scalar Replacement of Aggregates) optimizations
         if (seed == 0) {
             result.val().x = resultPart.val();
-            result.dx().x = resultPart.dx();
-            result.dy().x = resultPart.dy();
+            result.dx().x  = resultPart.dx();
+            result.dy().x  = resultPart.dy();
         } else if (seed == 1) {
             result.val().y = resultPart.val();
-            result.dx().y = resultPart.dx();
-            result.dy().y = resultPart.dy();
+            result.dx().y  = resultPart.dx();
+            result.dy().y  = resultPart.dy();
         } else {
             result.val().z = resultPart.val();
-            result.dx().z = resultPart.dx();
-            result.dy().z = resultPart.dy();
+            result.dx().z  = resultPart.dx();
+            result.dy().z  = resultPart.dy();
         }
     }
 #endif
@@ -646,16 +646,16 @@ scalar_pgabor3(const Dual2<Vec3>& P, const Vec3& Pperiod,
         // to better enable SROA (Scalar Replacement of Aggregates) optimizations
         if (seed == 0) {
             result.val().x = resultPart.val();
-            result.dx().x = resultPart.dx();
-            result.dy().x = resultPart.dy();
+            result.dx().x  = resultPart.dx();
+            result.dy().x  = resultPart.dy();
         } else if (seed == 1) {
             result.val().y = resultPart.val();
-            result.dx().y = resultPart.dx();
-            result.dy().y = resultPart.dy();
+            result.dx().y  = resultPart.dx();
+            result.dy().y  = resultPart.dy();
         } else {
             result.val().z = resultPart.val();
-            result.dx().z = resultPart.dx();
-            result.dy().z = resultPart.dy();
+            result.dx().z  = resultPart.dx();
+            result.dy().z  = resultPart.dy();
         }
     }
 #endif

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -449,7 +449,7 @@ OptixRaytracer::make_optix_materials()
     quad_hitgroup_desc.hitgroup.moduleCH = wrapper_module;
     quad_hitgroup_desc.hitgroup.entryFunctionNameCH
         = "__closesthit__closest_hit_osl";
-    quad_hitgroup_desc.hitgroup.moduleAH            = wrapper_module;
+    quad_hitgroup_desc.hitgroup.moduleAH = wrapper_module;
     quad_hitgroup_desc.hitgroup.entryFunctionNameAH = "__anyhit__any_hit_shadow";
     quad_hitgroup_desc.hitgroup.moduleIS            = quad_module;
     quad_hitgroup_desc.hitgroup.entryFunctionNameIS = "__intersection__quad";
@@ -498,7 +498,7 @@ OptixRaytracer::make_optix_materials()
     sphere_hitgroup_desc.hitgroup.moduleAH = wrapper_module;
     sphere_hitgroup_desc.hitgroup.entryFunctionNameAH
         = "__anyhit__any_hit_shadow";
-    sphere_hitgroup_desc.hitgroup.moduleIS            = sphere_module;
+    sphere_hitgroup_desc.hitgroup.moduleIS = sphere_module;
     sphere_hitgroup_desc.hitgroup.entryFunctionNameIS = "__intersection__sphere";
     OptixProgramGroup sphere_hitgroup;
     create_optix_pg(&sphere_hitgroup_desc, 1, &program_options,

--- a/src/testrender/shading.cpp
+++ b/src/testrender/shading.cpp
@@ -1646,7 +1646,7 @@ process_bsdf_closure(const OSL::ShaderGlobals& sg, ShadingResult& result,
             }
             case MX_CONDUCTOR_ID: {
                 const MxConductorParams& params = *comp->as<MxConductorParams>();
-                ok                              = result.bsdf.add_bsdf<
+                ok = result.bsdf.add_bsdf<
                     MxMicrofacet<MxConductorParams, GGXDist, false>>(cw, params,
                                                                      1.0f);
                 break;

--- a/src/testrender/shading.h
+++ b/src/testrender/shading.h
@@ -35,8 +35,8 @@ struct BSDF {
     BSDF() {}
     virtual Color3 get_albedo(const Vec3& /*wo*/) const { return Color3(1); }
     virtual Sample eval(const Vec3& wo, const Vec3& wi) const = 0;
-    virtual Sample sample(const Vec3& wo, float rx, float ry,
-                          float rz) const                     = 0;
+    virtual Sample sample(const Vec3& wo, float rx, float ry, float rz) const
+        = 0;
 };
 
 /// Represents a weighted sum of BSDFS

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -57,7 +57,7 @@ static std::string scenefile, imagefile;
 static std::string shaderpath;
 static bool shadingsys_options_set = false;
 static bool use_optix              = OIIO::Strutil::stoi(
-                 OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
+    OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
 static bool optix_no_inline             = false;
 static bool optix_no_inline_layer_funcs = false;
 static bool optix_no_merge_layer_funcs  = false;

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -87,7 +87,7 @@ static bool userdata_isconnected = false;
 static bool print_outputs        = false;
 static bool output_placement     = true;
 static bool use_optix            = OIIO::Strutil::stoi(
-               OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
+    OIIO::Sysutil::getenv("TESTSHADE_OPTIX"));
 static bool optix_no_inline             = false;
 static bool optix_no_inline_layer_funcs = false;
 static bool optix_no_merge_layer_funcs  = false;


### PR DESCRIPTION
style: Raise our formatting standard to clang-format 17
    
We had been using clang-format 14. Bump to 17 as our official
reference standard for formatting.
    
Moved the clang-format CI test from an aswf container to bare Ubuntu
to make it run faster -- it doesn't need to do a real build, so
there's no point wasting 2 minutes or so downloading a container holding
library dependencies it won't need.
    
Also fix a duplicate line in .clang-format that newer clang-format
complained about.
    
Signed-off-by: Larry Gritz <lg@larrygritz.com>
