### PR TITLE
Fix NVPTX TargetMachine leak

### DIFF
--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -585,6 +585,9 @@ LLVM_Util::~LLVM_Util()
     delete m_new_pass_manager;
     delete m_builder;
     delete m_llvm_debug_builder;
+    if (m_nvptx_target_machine != nullptr) {
+        delete m_nvptx_target_machine;
+    }
     module(NULL);
     // DO NOT delete m_llvm_jitmm;  // just the dummy wrapper around the real MM
 }

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -428,6 +428,7 @@ LLVM_Util::LLVM_Util(const PerThreadInfo& per_thread_info, int debuglevel,
     , m_llvm_func_passes(NULL)
     , m_new_pass_manager(NULL)
     , m_llvm_exec(NULL)
+    , m_nvptx_target_machine(nullptr)
     , m_vector_width(vector_width)
     , m_llvm_type_native_mask(nullptr)
     , mVTuneNotifier(nullptr)

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -586,9 +586,7 @@ LLVM_Util::~LLVM_Util()
     delete m_new_pass_manager;
     delete m_builder;
     delete m_llvm_debug_builder;
-    if (m_nvptx_target_machine != nullptr) {
-        delete m_nvptx_target_machine;
-    }
+    delete m_nvptx_target_machine;
     module(NULL);
     // DO NOT delete m_llvm_jitmm;  // just the dummy wrapper around the real MM
 }


### PR DESCRIPTION
## Description

This PR includes fixes for three issues:

1. A leak of the `llvm::TargetMachine` used for NVPTX.
2. ~~A segfault that can occur in `testrender` when the renderer is destroyed before the  `ShadingSystem`.~~
3. A compilation failure when using CUDA Toolkit 12.0 or newer due to references to the long-deprecated (and now removed) `textureReference` API still being present in the LLVM headers.

These changes aren't related, but I've bundled them up for convenience. I can break these into individual PRs if that would be preferable.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

No new tests, but all previously passing tests still pass.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
