### PR TITLE
fix(build): Remove unused static ustring

### DIFF
--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -3261,9 +3261,8 @@ LLVMGEN(llvm_gen_construct_triple)
 
     // Do the transformation in-place, if called for
     if (using_space) {
-        ustring from, to;  // N.B. initialize to empty strings
         if (Space.is_constant()) {
-            from = Space.get_string();
+            ustring from = Space.get_string();
             if (from == Strings::common
                 || from == rop.shadingsys().commonspace_synonym())
                 return true;  // no transformation necessary

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -59,7 +59,6 @@ static ustring op_xor("xor");
 
 static ustring u_distance("distance");
 static ustring u_index("index");
-static ustring u__empty;  // empty/default ustring
 
 
 


### PR DESCRIPTION
A recent change in OIIO master made some of the ustring methods "trivial", and somehow that makes this variable warn about being unused, which it did not do before.

