### PR TITLE
docs: Clarify behavior of round()

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -3078,7 +3078,8 @@ Returns 1 if $x>0$, -1 if $x<0$, 0 if $x=0$.
 Various rounding methods: {\cf floor} returns the largest integer less
 than or equal to $x$; {\cf ceil} returns the smallest integer greater than
 or equal to $x$; {\cf round} returns the closest integer to $x$, in
-either direction; and {\cf trunc} returns the integral part of $x$
+either direction (rounding away from 0 in cases where $x$ is exactly
+half way between integers); and {\cf trunc} returns the integral part of $x$
 (equivalent to {\cf floor} if $x>0$ and {\cf ceil} if $x<0$).
 \apiend
 

--- a/src/doc/stdlib.md
+++ b/src/doc/stdlib.md
@@ -127,9 +127,10 @@ the computations are performed component-by-component (separately for `x`,
 
   : Various rounding methods: `floor` returns the largest integer less than or
     equal to $x$; `ceil` returns the smallest integer greater than or equal to
-    $x$; `round` returns the closest integer to $x$, in either direction; and
-    `trunc` returns the integral part of $x$ (equivalent to `floor` if $x>0$
-    and `ceil` if $x<0$).
+    $x$; `round` returns the closest integer to $x$, in either direction
+    (rounding away from 0 in cases where $x$ is exactly half way between
+    integers); and `trunc` returns the integral part of $x$ (equivalent to
+    `floor` if $x>0$ and `ceil` if $x<0$).
 
 
 *`type`* **`fmod`** (*`type`* `a`, *`type`* `b`) <br> *`type`* **`mod`** (*`type`* `a`, *`type`* `b`)


### PR DESCRIPTION
Pointed out in MaterialX discussions, our spec was not clear what round() should do in cases where the input value is exactly half way between two integers. Our design (and implementation) uses "round away from zero" policy for that case, matching C/C++ standard round(). But we were not clear about it in the docs.

