### PR TITLE
Mute partio error prints

### DIFF
--- a/src/liboslexec/pointcloud.cpp
+++ b/src/liboslexec/pointcloud.cpp
@@ -3,6 +3,7 @@
 // https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 #include <cstdarg>
+#include <sstream>
 
 #include "pointcloud.h"
 
@@ -29,7 +30,13 @@ PointCloud::get(ustringhash filename, bool write)
     // Not found. Create a new one.
     Partio::ParticlesDataMutable* partio_cloud = nullptr;
     if (!write) {
-        partio_cloud = Partio::read(filename.c_str(), false);
+        // Mute Partio error prints: by default Partio::read sends errors directly
+        // to std::err, but in most cases we want errors to go via errorfmt so the
+        // renderer can recognize the message as an error, as we do in
+        // pointcloud_search and pointcloud_get.
+        std::stringstream m_errorStream;
+
+        partio_cloud = Partio::read(filename.c_str(), false, m_errorStream);
         if (!partio_cloud)
             return nullptr;
     } else {


### PR DESCRIPTION
## Description

This patch mutes the error printed to std::err from inside Partio when it fails to read a pointcloud.  OSL's pointcloud_search and pointcloud_find already reports errors "the proper way" via errorfmt, so a failed read will still thrown an error. Plain prints like this can sneak past log-limiting filtering  and result in very large log files.

Currently, running something like

shader partioerror(){
    float test[1];
    if(pointcloud_search("non-existing",P,1.0,1,"test",test))
        printf("Success");
}

in testshade, will print

Partio: No extension detected in filename
ERROR: pointcloud_search: could not open "non-existing"

with the patch, it will just print
ERROR: pointcloud_search: could not open "non-existing"

## Tests

I haven't added any tests yet

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
