### PR TITLE
ci: Increase timeout for slow MacOS-13 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,7 @@ jobs:
             openimageio_ver: master
             python_ver: "3.11"
             aclang: 14
-            setenvs: export DO_BREW_UPDATE=1
+            setenvs: export DO_BREW_UPDATE=1 CTEST_TEST_TIMEOUT=120
           - desc: MacOS-14-ARM llvm17
             runner: macos-14
             nametag: macos14-arm-p311


### PR DESCRIPTION
We didn't change anything on our end, but in the last few days, I believe the GHA MacOS-13 runners have slowed done somehow, and so now a few test are failing only because they don't complete within the ctest timeout period for "small tests". So this just bumps up the limit on this runner platform to allow the tests to pass.

