### PR TITLE
PR/FixCompRefWithVaryingIndex

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -308,6 +308,7 @@ macro (osl_add_all_tests)
                 metadata-braces min-reg miscmath missing-shader
                 mix-reg
                 named-components
+                nestedloop-reg
                 noise noise-cell
                 noise-gabor noise-gabor2d-filter noise-gabor3d-filter
                 noise-gabor-reg

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -2141,7 +2141,7 @@ struct Analyzer {
                 }
             };
             OSL_DEV_ONLY(std::cout << ">>>> end make_varying symbol: "
-                                   << symbol_to_be_varying->unmangled().c_str() 
+                                   << symbol_to_be_varying->unmangled().c_str()
                                    << std::endl);
         }
     };

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -1064,7 +1064,8 @@ public:
 
     OSL_FORCEINLINE Position top_pos() const { return m_top_of_stack; }
 
-    OSL_FORCEINLINE int loop_depth_at_start_of_call() {
+    OSL_FORCEINLINE int loop_depth_at_start_of_call()
+    {
         if (m_loop_depth_stack.empty()) {
             return 0;
         } else {
@@ -1228,6 +1229,7 @@ class LoopStack {
     std::vector<LoopInfo> m_loop_info_by_depth;
 
     bool is_inside_loop() const { return depth() != 0; }
+
 public:
     int depth() const { return m_loop_info_by_depth.size(); }
 
@@ -2001,9 +2003,11 @@ struct Analyzer {
                     // as the current block, there was no conditionals involved
                     OSL_DEV_ONLY(std::cout << " FUNCTION CALL BLOCK BEGIN"
                                            << std::endl);
-                    m_execution_scope_stack.push_function_call(m_loop_stack.depth());
+                    m_execution_scope_stack.push_function_call(
+                        m_loop_stack.depth());
                     discover_symbols_between(op_index + 1, opcode.jump(0));
-                    m_execution_scope_stack.pop_function_call(m_loop_stack.depth());
+                    m_execution_scope_stack.pop_function_call(
+                        m_loop_stack.depth());
                     OSL_DEV_ONLY(std::cout << " FUNCTION CALL BLOCK END"
                                            << std::endl);
 
@@ -2037,13 +2041,14 @@ struct Analyzer {
 
                 // IF AND ONLY IF, the current loop control exists inside
                 // the current function, because the return should only early
-                // out of those loops, not any higher in the call stack.                
+                // out of those loops, not any higher in the call stack.
                 // The return will need to change the loop control flow which is dependent upon
                 // a conditional.  By making a circular dependency between the return operation
                 // and the conditionals value, any varying values in the conditional controlling
                 // the return should flow back to the loop control variable, which might need to
                 // be varying so allow lanes to terminate the loop independently
-                if (m_loop_stack.depth() > m_execution_scope_stack.loop_depth_at_start_of_call()) {
+                if (m_loop_stack.depth()
+                    > m_execution_scope_stack.loop_depth_at_start_of_call()) {
                     make_loops_control_flow_depend_on_early_out_conditions();
                 }
             }
@@ -2058,14 +2063,15 @@ struct Analyzer {
                 // IF AND ONLY IF, the current loop control exists inside
                 // the current function, because the return should only early
                 // out of those loops, not any higher in the call stack.
-                // A different mechanism will look for early outs when 
+                // A different mechanism will look for early outs when
                 // unwinding up the callstack.
                 // The exit will need to change the loop control flow which is dependent upon
                 // a conditional.  By making a circular dependency between the exit operation
                 // and the conditionals value, any varying values in the conditional controlling
                 // the exit should flow back to the loop control variable, which might need to
                 // be varying so allow lanes to terminate the loop independently
-                if (m_loop_stack.depth() > m_execution_scope_stack.loop_depth_at_start_of_call()) {
+                if (m_loop_stack.depth()
+                    > m_execution_scope_stack.loop_depth_at_start_of_call()) {
                     make_loops_control_flow_depend_on_early_out_conditions();
                 }
             }
@@ -2118,10 +2124,9 @@ struct Analyzer {
                        || symbol_to_be_varying->typespec().is_closure()
                        || symbol_to_be_varying->connected()
                        || symbol_to_be_varying->connected_down());
-            OSL_DEV_ONLY(std::cout
-                         << "<<<< make_varying symbol: "
-                         << symbol_to_be_varying->unmangled().c_str()
-                         << " force=" << force << std::endl);
+            OSL_DEV_ONLY(std::cout << "<<<< make_varying symbol: "
+                                   << symbol_to_be_varying->unmangled().c_str()
+                                   << " force=" << force << std::endl);
 
             symbol_to_be_varying->make_varying();
             auto range = m_symbols_dependent_upon.equal_range(
@@ -2135,10 +2140,9 @@ struct Analyzer {
                     recursively_mark_varying(dependent_symbol);
                 }
             };
-            OSL_DEV_ONLY(std::cout
-                         << ">>>> end make_varying symbol: "
-                         << symbol_to_be_varying->unmangled().c_str() << std::endl);
-
+            OSL_DEV_ONLY(std::cout << ">>>> end make_varying symbol: "
+                                   << symbol_to_be_varying->unmangled().c_str() 
+                                   << std::endl);
         }
     };
 
@@ -2671,7 +2675,8 @@ struct Analyzer {
 
     OSL_NOINLINE void push_varying_of_shader_globals()
     {
-        OSL_DEV_ONLY(std::cout << "push_varying_of_shader_globals begin" << std::endl);
+        OSL_DEV_ONLY(std::cout << "push_varying_of_shader_globals begin"
+                               << std::endl);
         for (auto&& s : inst()->symbols()) {
             if (s.symtype() == SymTypeGlobal) {
                 // TODO: now that symbol has is_uniform()
@@ -2692,12 +2697,14 @@ struct Analyzer {
             // so force their dependents to get marked
             recursively_mark_varying(sym_ptr, true /*force*/);
         }
-        OSL_DEV_ONLY(std::cout << "push_varying_of_shader_globals end" << std::endl);
+        OSL_DEV_ONLY(std::cout << "push_varying_of_shader_globals end"
+                               << std::endl);
     }
 
     OSL_NOINLINE void make_renderer_outputs_varying()
     {
-        OSL_DEV_ONLY(std::cout << "make_renderer_outputs_varying begin" << std::endl);
+        OSL_DEV_ONLY(std::cout << "make_renderer_outputs_varying begin"
+                               << std::endl);
         // Mark all output parameters as varying to catch
         // output parameters written to by uniform variables,
         // as nothing would have made them varying, however as
@@ -2714,12 +2721,14 @@ struct Analyzer {
                 }
             }
         }
-        OSL_DEV_ONLY(std::cout << "make_renderer_outputs_varying end" << std::endl);
+        OSL_DEV_ONLY(std::cout << "make_renderer_outputs_varying end"
+                               << std::endl);
     }
 
     OSL_NOINLINE void make_interpolated_parameters_varying()
     {
-        OSL_DEV_ONLY(std::cout << "make_interpolated_parameters_varying begin" << std::endl);
+        OSL_DEV_ONLY(std::cout << "make_interpolated_parameters_varying begin"
+                               << std::endl);
         // Mark all interpolated parameters as varying,
         // As we expect interpolated data,  get_userdata will
         // only provide varying values, so we must mark
@@ -2731,7 +2740,8 @@ struct Analyzer {
                 recursively_mark_varying(&s);
             }
         }
-        OSL_DEV_ONLY(std::cout << "make_interpolated_parameters_varying end" << std::endl);
+        OSL_DEV_ONLY(std::cout << "make_interpolated_parameters_varying end"
+                               << std::endl);
     }
 
     OSL_NOINLINE void make_closures_varying()

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -6800,7 +6800,7 @@ LLVMGEN(llvm_gen_getmessage)
         }
 
         llvm::Value* sourceVal
-            = has_source 
+            = has_source
                   ? rop.llvm_load_value(Source, /*deriv=*/0, /*component=*/0,
                                         TypeDesc::UNKNOWN, sourceVal_is_uniform)
                   : rop.ll.constant(ustring());

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -2298,7 +2298,8 @@ LLVMGEN(llvm_gen_compref)
 
     bool op_is_uniform = Result.is_uniform();
 
-    llvm::Value* c = rop.llvm_load_value(Index, /*deriv=*/ 0, /*component=*/0, TypeDesc::UNKNOWN, Index.is_uniform());
+    llvm::Value* c = rop.llvm_load_value(Index, /*deriv=*/ 0, /*component=*/0,
+                                         TypeDesc::UNKNOWN, Index.is_uniform());
 
     if (Index.is_uniform()) {
         if (rop.inst()->master()->range_checking()) {
@@ -6791,13 +6792,17 @@ LLVMGEN(llvm_gen_getmessage)
         rop.ll.call_function(rop.build_name(FuncSpec("getmessage").mask()),
                              args);
     } else {
-        llvm::Value* nameVal = rop.llvm_load_value(Name, /*deriv=*/ 0, /*component=*/0, TypeDesc::UNKNOWN, nameVal_is_uniform);
+        llvm::Value* nameVal = rop.llvm_load_value(Name, /*deriv=*/ 0, /*component=*/0,
+                                                   TypeDesc::UNKNOWN, nameVal_is_uniform);
         if (nameVal_is_uniform) {
             args[nameArgumentIndex] = nameVal;
         }
 
-        llvm::Value* sourceVal = has_source ? rop.llvm_load_value(Source, /*deriv=*/ 0, /*component=*/0, TypeDesc::UNKNOWN, sourceVal_is_uniform)
-                                            : rop.ll.constant(ustring());
+        llvm::Value* sourceVal
+           = has_source 
+                 ? rop.llvm_load_value(Source, /*deriv=*/ 0, /*component=*/0,
+                                       TypeDesc::UNKNOWN, sourceVal_is_uniform)
+                 : rop.ll.constant(ustring());
         if (sourceVal_is_uniform) {
             args[sourceArgumentIndex] = sourceVal;
         }
@@ -7104,7 +7109,8 @@ LLVMGEN(llvm_gen_spline)
     args.push_back(rop.llvm_void_ptr(Value));  // make things easy
     args.push_back(rop.llvm_void_ptr(Knots));
     if (has_knot_count)
-        args.push_back(rop.llvm_load_value(Knot_count)); // TODO: add support for varying Knot_count
+        args.push_back(rop.llvm_load_value(
+            Knot_count)); // TODO: add support for varying Knot_count
     else
         args.push_back(rop.ll.constant((int)Knots.typespec().arraylength()));
     args.push_back(rop.ll.constant((int)Knots.typespec().arraylength()));

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -2298,7 +2298,7 @@ LLVMGEN(llvm_gen_compref)
 
     bool op_is_uniform = Result.is_uniform();
 
-    llvm::Value* c = rop.llvm_load_value(Index, /*deriv=*/ 0, /*component=*/0,
+    llvm::Value* c = rop.llvm_load_value(Index, /*deriv=*/0, /*component=*/0,
                                          TypeDesc::UNKNOWN, Index.is_uniform());
 
     if (Index.is_uniform()) {
@@ -6792,17 +6792,18 @@ LLVMGEN(llvm_gen_getmessage)
         rop.ll.call_function(rop.build_name(FuncSpec("getmessage").mask()),
                              args);
     } else {
-        llvm::Value* nameVal = rop.llvm_load_value(Name, /*deriv=*/ 0, /*component=*/0,
-                                                   TypeDesc::UNKNOWN, nameVal_is_uniform);
+        llvm::Value* nameVal
+            = rop.llvm_load_value(Name, /*deriv=*/0, /*component=*/0,
+                                  TypeDesc::UNKNOWN, nameVal_is_uniform);
         if (nameVal_is_uniform) {
             args[nameArgumentIndex] = nameVal;
         }
 
         llvm::Value* sourceVal
-           = has_source 
-                 ? rop.llvm_load_value(Source, /*deriv=*/ 0, /*component=*/0,
-                                       TypeDesc::UNKNOWN, sourceVal_is_uniform)
-                 : rop.ll.constant(ustring());
+            = has_source 
+                  ? rop.llvm_load_value(Source, /*deriv=*/0, /*component=*/0,
+                                        TypeDesc::UNKNOWN, sourceVal_is_uniform)
+                  : rop.ll.constant(ustring());
         if (sourceVal_is_uniform) {
             args[sourceArgumentIndex] = sourceVal;
         }
@@ -7110,7 +7111,7 @@ LLVMGEN(llvm_gen_spline)
     args.push_back(rop.llvm_void_ptr(Knots));
     if (has_knot_count)
         args.push_back(rop.llvm_load_value(
-            Knot_count)); // TODO: add support for varying Knot_count
+            Knot_count));  // TODO: add support for varying Knot_count
     else
         args.push_back(rop.ll.constant((int)Knots.typespec().arraylength()));
     args.push_back(rop.ll.constant((int)Knots.typespec().arraylength()));

--- a/testsuite/nestedloop-reg/run.py
+++ b/testsuite/nestedloop-reg/run.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+
+###############################
+# 
+###############################
+command += testshade("-t 1 -g 32 32 -od uint8 test  -o cout out.tif ")
+outputs.append ("out.tif")
+
+# expect a few LSB failures
+failthresh = 0.008
+failpercent = 3
+

--- a/testsuite/nestedloop-reg/test.osl
+++ b/testsuite/nestedloop-reg/test.osl
@@ -1,3 +1,6 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 float limit_early_return(float channel) {
     if (channel > 1.0) {

--- a/testsuite/nestedloop-reg/test.osl
+++ b/testsuite/nestedloop-reg/test.osl
@@ -1,0 +1,36 @@
+
+float limit_early_return(float channel) {
+    if (channel > 1.0) {
+        //exit();
+        return 1.0;
+    }
+    return channel;
+}
+
+float limit_single_return(float channel) {
+    float result = channel;
+    if (channel > 1.0) {
+        result = 1.0;
+    }
+    return result;
+}
+
+color soft_clip(color in_color)
+{
+    color result;
+    for (int i=0; i < 3; ++i)
+    {
+#if 1
+        result[i] = limit_early_return(in_color[i]);
+#else
+        result[i] = limit_single_return(in_color[i]);
+#endif
+    }
+    return result;
+}
+
+shader test (output color cout = 0)
+{
+    color pixel = 2*P;
+    cout = soft_clip(pixel);
+}


### PR DESCRIPTION
## Description
Fix bug in batched codegen of compref when the index is varying.
The llvm_load_value was left to defaulted to uniform load, which we can't store into a varying/wide result. Fixed similar bug in getmessage, and added check for spline knotcount to be uniform (although varying support could be added).

This bug exposed a missed optimization in BatchedAnalysis where a early out (return) needs to change the loop conditional to be varying to support masking.  However no check was being done to see if the loop control existed higher in the callstack.  So now the execution scope tracks loop nesting depth to see if the current function is really in a loop or not.  This allows the loop control flow to remain uniform (avoiding masking and more complex control flow).

## Tests
Added nestloop-reg to testsuite to reproduce bug and verify its fixed.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
