### PR TITLE
Change release notice icon to use the icon vs the normal logo so it shows up better

### DIFF
--- a/.github/workflows/release-notice.yml
+++ b/.github/workflows/release-notice.yml
@@ -22,5 +22,5 @@ jobs:
         project_name: "Open Shading Language"
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
         slack_channel: "#release-announcements"
-        project_logo: "https://artwork.aswf.io/projects/openshadinglanguage/AcronymStack/Shaded/openshadinglanguage-AcronymStack-Shaded.png"
+        project_logo: "https://artwork.aswf.io/projects/openshadinglanguage/Icon/Color/openshadinglanguage-Icon-Color.png"
       uses: jmertic/slack-release-notifier@main


### PR DESCRIPTION
## Description

This fixed the icon used by the release notice to make it show up better.

## Tests

N/A

## Checklist:

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
