### PR TITLE
Print closure missing error message at compile time instead of run time. 

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3777,7 +3777,7 @@ LLVMGEN(llvm_gen_closure)
     const ClosureRegistry::ClosureEntry* clentry
         = rop.shadingsys().find_closure(closure_name);
     if (!clentry) {
-         rop.shadingcontext()->errorfmt(
+        rop.shadingcontext()->errorfmt(
             "Closure '{}' is not supported by the current renderer, called from {}:{} in shader \"{}\", layer {} \"{}\", group \"{}\"",
             closure_name, op.sourcefile(), op.sourceline(),
             rop.inst()->shadername(), rop.layer(), rop.inst()->layername(),

--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3777,11 +3777,11 @@ LLVMGEN(llvm_gen_closure)
     const ClosureRegistry::ClosureEntry* clentry
         = rop.shadingsys().find_closure(closure_name);
     if (!clentry) {
-        rop.llvm_gen_error(fmtformat(
+         rop.shadingcontext()->errorfmt(
             "Closure '{}' is not supported by the current renderer, called from {}:{} in shader \"{}\", layer {} \"{}\", group \"{}\"",
             closure_name, op.sourcefile(), op.sourceline(),
             rop.inst()->shadername(), rop.layer(), rop.inst()->layername(),
-            rop.group().name()));
+            rop.group().name());
         return false;
     }
 


### PR DESCRIPTION
## Description

Prevent complications on the GPU by printing error messages at compile time instead of generating code to print them at runtime when a closure doesn't exist.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
