### PR TITLE
Make isconnected() work with downstream renderer "connections."

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -2499,7 +2499,8 @@ RuntimeOptimizer::resolve_isconnected()
             bool upconnected = s->connected();
             if (s->interpolated() && shadingsys().userdata_isconnected())
                 upconnected = true;
-            int val = (upconnected ? 1 : 0) + (s->connected_down() ? 2 : 0);
+            bool downconnected = s->connected_down() || s->renderer_output();
+            int val = (upconnected ? 1 : 0) + (downconnected ? 2 : 0);
             turn_into_assign(op, add_constant(TypeDesc::TypeInt, &val),
                              "resolve isconnected()");
         }

--- a/testsuite/isconnected/ref/out.txt
+++ b/testsuite/isconnected/ref/out.txt
@@ -2,6 +2,8 @@ Compiled test.osl -> test.oso
 Compiled upstream.osl -> upstream.oso
 Connect upstream.out to downstream.a
 Connect upstream.struct1 to downstream.mystruct1
+
+Output Fout to out.tif
 Upstream:
 out connected: 2  (value=0.5)
 notout connected: 0  (value=10)
@@ -22,7 +24,7 @@ mystruct1.y connected: 1  (value=4)
 mystruct2 connected: 0  (value={0, 0})
 mystruct2.x connected: 0  (value=0)
 mystruct2.y connected: 0  (value=0)
-
+Fout connected: 2  (value=0.42)
 Connect upstream.out to downstream.a
 Connect upstream.struct1 to downstream.mystruct1
 Upstream:
@@ -45,4 +47,5 @@ mystruct1.y connected: 1  (value=4)
 mystruct2 connected: 0  (value={0, 0})
 mystruct2.x connected: 0  (value=0)
 mystruct2.y connected: 0  (value=0)
+Fout connected: 0  (value=0)
 

--- a/testsuite/isconnected/run.py
+++ b/testsuite/isconnected/run.py
@@ -4,9 +4,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
-command  = testshade("--layer upstream upstream --layer downstream test " +
+command  = testshade("-g 1 1 -od uint8 -o Fout out.tif " +
+                     "--layer upstream upstream --layer downstream test " +
                      "--connect upstream out downstream a " +
-                     "--connect upstream struct1 downstream mystruct1")
+                     "--connect upstream struct1 downstream mystruct1" 
+                     )
 
 # Run again, this time considering userdata (lockgeom=0) parameters to be
 # isconnected(). This time, parameter c should look like a connection.

--- a/testsuite/isconnected/test.osl
+++ b/testsuite/isconnected/test.osl
@@ -7,7 +7,8 @@
 shader test (float a = 0, float b = 0,
              float c = 0 [[ int lockgeom=0 ]],
              MyStruct mystruct1 = {0,0},
-             MyStruct mystruct2 = {0,0})
+             MyStruct mystruct2 = {0,0},
+             output float Fout = 1)
 {
     printf ("a=%g\n", a);   // force retrieval/execution of upstream layer
     printf ("Downstream:\n");
@@ -16,4 +17,14 @@ shader test (float a = 0, float b = 0,
     status (c, "c");
     status (mystruct1, "mystruct1");
     status (mystruct2, "mystruct2");
+    
+    if (isconnected(Fout) == 2)
+    {
+      Fout = .42;
+    }
+    else
+    {
+      Fout = 0;
+    }
+    status (Fout, "Fout");
 }


### PR DESCRIPTION




## Description

The isconnected() returns 2 when used on an output that is connected to another downstream shader node -- this can be used to limit computation to only the outputs used.  However, that misses the important case of where the renderer has declared a shader node output as a renderer output, which happens often when using OSL purely for pattern generation purposes.  This change makes that case also return 2.


## Tests

The isconnected test has been updated to include testing this functionality.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
