### PR TITLE
Calculatenormal needs fliphandedness

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -42,6 +42,8 @@ static ustring u_setmessage("setmessage");
 static ustring u_getmessage("getmessage");
 static ustring u_getattribute("getattribute");
 static ustring u_backfacing("backfacing");
+static ustring u_calculatenormal ("calculatenormal");
+static ustring u_flipHandedness ("flipHandedness");
 static ustring u_N("N");
 static ustring u_I("I");
 
@@ -3352,6 +3354,8 @@ RuntimeOptimizer::run()
             } else if (op.opname() == u_backfacing) {
                 m_globals_needed.insert(u_N);
                 m_globals_needed.insert(u_I);
+            } else if (op.opname() == u_calculatenormal) {
+                m_globals_needed.insert(u_flipHandedness);
             } else if (op.opname() == u_getattribute) {
                 Symbol* sym1 = opargsym(op, 1);
                 OSL_DASSERT(sym1 && sym1->typespec().is_string());

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -42,8 +42,8 @@ static ustring u_setmessage("setmessage");
 static ustring u_getmessage("getmessage");
 static ustring u_getattribute("getattribute");
 static ustring u_backfacing("backfacing");
-static ustring u_calculatenormal ("calculatenormal");
-static ustring u_flipHandedness ("flipHandedness");
+static ustring u_calculatenormal("calculatenormal");
+static ustring u_flipHandedness("flipHandedness");
 static ustring u_N("N");
 static ustring u_I("I");
 

--- a/testsuite/globals-needed/printcalculatenormal.osl
+++ b/testsuite/globals-needed/printcalculatenormal.osl
@@ -1,0 +1,9 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader printcalculatenormal ()
+{
+    normal n2 = calculatenormal(P+1);
+    printf ("calculatenormal = %f", n2);
+}

--- a/testsuite/globals-needed/ref/out.txt
+++ b/testsuite/globals-needed/ref/out.txt
@@ -1,1 +1,2 @@
 Need 2 globals:  I N
+Need 2 globals:  P flipHandedness

--- a/testsuite/globals-needed/run.py
+++ b/testsuite/globals-needed/run.py
@@ -5,6 +5,7 @@
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 command += testshade("-g 2 2 -debug printbackfacing")
+command += testshade("-g 2 2 -debug printcalculatenormal")
 
 # debug output is very verbose, use regexp to filter down to
 # only the line we're interested in testing


### PR DESCRIPTION
## Description

The calculatenormal() shadeop references flipHandedness in order to know which order to cross the derivatives.  This change makes it so flipHandedness shows up in the list of "globals_needed" that can be queried by renderers to lazily fill in.

## Tests

The globals-needed test was extended to test caclulatenormal() as well


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
