### PR TITLE
fix(batched): Make sure to promote even zero-initialized closures to varying.

### DIFF
--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -1680,6 +1680,9 @@ struct Analyzer {
 
                 OSL_DEV_ONLY(std::cout << " discovery " << sym->unmangled()
                                        << std::endl);
+                if (sym->typespec().is_closure()) {
+                    recursively_mark_varying(sym);
+                }
             }
             OSL_DEV_ONLY(std::cout << std::endl);
 


### PR DESCRIPTION
## Description

Fixed a bug in the batched analysis of varying vs uniform that could miss promoting zero-initialized closures to varying.  Because the rest of the JIT code assumes closures are always varying, we simply mark all closures we see as varying in the analysis phase.

## Tests

I encountered this in a complex production case, but couldn't manage to duplicate it with small changes to the closure-zero tests in the test-suite.  So I know it resolves the issue, but would welcome input on how to craft a small test to trigger it. 

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
