### PR TITLE
oslquery: Simplify include and link needs

### DIFF
--- a/src/include/OSL/oslquery.h
+++ b/src/include/OSL/oslquery.h
@@ -19,9 +19,38 @@ Sony Pictures Imageworks terms, above.
 #include <string>
 #include <vector>
 
-#include <OSL/oslconfig.h>
+#include <OSL/export.h>
+#include <OSL/oslversion.h>
+#include <OSL/platform.h>
+
+#include <OpenImageIO/span.h>
+#include <OpenImageIO/string_view.h>
+#include <OpenImageIO/typedesc.h>
+#include <OpenImageIO/ustring.h>
+
+// #include <OSL/oslconfig.h>
 
 OSL_NAMESPACE_ENTER
+
+using OIIO::cspan;
+using OIIO::span;
+using OIIO::string_view;
+using OIIO::ustring;
+
+using OIIO::TypeColor;
+using OIIO::TypeDesc;
+using OIIO::TypeFloat;
+using OIIO::TypeFloat2;
+using OIIO::TypeFloat4;
+using OIIO::TypeInt;
+using OIIO::TypeMatrix;
+using OIIO::TypeNormal;
+using OIIO::TypePoint;
+using OIIO::TypeString;
+using OIIO::TypeUnknown;
+using OIIO::TypeVector;
+using OIIO::TypeVector2;
+using OIIO::TypeVector4;
 
 class ShaderGroup;  // opaque class for now
 

--- a/src/liboslquery/CMakeLists.txt
+++ b/src/liboslquery/CMakeLists.txt
@@ -12,15 +12,11 @@ add_library (${local_lib} ${lib_src})
 target_include_directories (${local_lib}
     PUBLIC
         ${CMAKE_INSTALL_FULL_INCLUDEDIR}
-        ${IMATH_INCLUDES}
     PRIVATE
         ../liboslexec)
 target_link_libraries (${local_lib}
     PUBLIC
-        OpenImageIO::OpenImageIO
-    PRIVATE
-        # ${IMATH_LIBRARIES}
-        ${Boost_LIBRARIES}
+        OpenImageIO::OpenImageIO_Util
     )
 
 target_compile_features (${local_lib}

--- a/src/liboslquery/py_osl.h
+++ b/src/liboslquery/py_osl.h
@@ -25,6 +25,8 @@
 
 #include <OSL/oslquery.h>
 
+#include <OSL/oslconfig.h>
+
 #if OSL_USING_IMATH >= 3
 #    include <Imath/half.h>
 #else

--- a/src/oslinfo/CMakeLists.txt
+++ b/src/oslinfo/CMakeLists.txt
@@ -5,6 +5,5 @@
 set ( oslinfo_srcs oslinfo.cpp )
 add_executable ( oslinfo ${oslinfo_srcs} )
 target_link_libraries (oslinfo
-                       PRIVATE oslquery
-                               ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+                       PRIVATE oslquery)
 install_targets (oslinfo)


### PR DESCRIPTION
The (should be) tiny oslquery library was over-including and over-linking beyond its actual needs.

* Remove`#include <OSL/oslconfig.h>`, which is a lot of setup, type definitions, and many transitive header includes.  Instead, just include the very small number of headers and types actually needed by the OSLQuery class definition.
* In particular, this removes includes of OpenEXR/Imath headers and references to Imath types, the OIIO TextureSystem (!), and other big things, from what oslquery.h needs to see.
* liboslquery can link against libOpenImageIO_Util (which it uses primarily for ustring and TypeDesc), it doesn't need the full libOpenImageIO, since it doesn't read or write image files.
* Remove some link references to Boost which isn't actually needed for this library.
* This also lightens the load for the Python module for oslquery.
