### PR TITLE
Fix GPU interpolated param initialization

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -394,7 +394,7 @@ macro (osl_add_all_tests)
                 transform transform-reg transformc transformc-reg trig trig-reg
                 typecast
                 unknown-instruction
-                userdata userdata-partial userdata-custom userdata-passthrough
+                userdata userdata-defaults userdata-partial userdata-custom userdata-passthrough
                 vararray-connect vararray-default
                 vararray-deserialize vararray-param
                 vecctr vector vector-reg

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -792,22 +792,6 @@ BackendLLVM::llvm_assign_initial_value(const Symbol& sym, bool force)
         if (sym.has_init_ops() && sym.valuesource() == Symbol::DefaultVal) {
             // Handle init ops.
             build_llvm_code(sym.initbegin(), sym.initend());
-        } else if (sym.interpolated() && !sym.typespec().is_closure()) {
-            // geometrically-varying param; memcpy its default value
-            TypeDesc t = sym.typespec().simpletype();
-            if (sym.typespec().is_string()) {
-                //llvm_create_constant(sym);
-                auto default_str = ll.constant64(
-                    uint64_t(sym.get_string().hash()));
-
-                OSL_ASSERT(llvm_store_value(default_str, sym, 0, nullptr, 0));
-            } else {
-                ll.op_memcpy(llvm_void_ptr(sym), ll.constant_ptr(sym.data()),
-                             t.size(), t.basesize() /*align*/);
-            }
-
-            if (sym.has_derivs())
-                llvm_zero_derivs(sym);
         } else {
             // Use default value
             int num_components = sym.typespec().simpletype().aggregate;

--- a/testsuite/userdata-defaults/ref/out.txt
+++ b/testsuite/userdata-defaults/ref/out.txt
@@ -1,0 +1,3 @@
+Compiled test.osl -> test.oso
+Val_Default = 1.000000 0.200000 0.700000
+

--- a/testsuite/userdata-defaults/run.py
+++ b/testsuite/userdata-defaults/run.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command += testshade("-g 1 1 test")
+outputs = [ "out.txt" ]

--- a/testsuite/userdata-defaults/test.osl
+++ b/testsuite/userdata-defaults/test.osl
@@ -1,0 +1,10 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader test(color Val_Default = color(1., 0.2, 0.7) [[ int lockgeom=0 ]],
+                   output color Cout = color(0))
+{
+    printf("Val_Default = %f %f %f\n", Val_Default.r, Val_Default.g, Val_Default.b);
+    Cout = color(Val_Default);
+}


### PR DESCRIPTION
## Description

Currently, the GPU will crash when initializing non-string interpolated parameters with default values.

It looks like this is a regression from the ustringhash conversion in 12530f115dfc759b00ee4de6dc27bf5fa3f32fe0. I believe that before the phase 3 commit, we had global variables on GPU that we memcpy'd the defaults values from. Now after their removal, we're memcpy'ing from an illegal address.

As a proposed fix I removed the entire memcpy branch of the code and let interpolated parameters fall back to the default code path that stores the values directly. I'm open to instead guarding the removed block with "&& !gpu" making the patch have no effect on cpu, but leaned towards having unified code paths. Still, it's not an area of the code I'm very familiar with, any feedback would be appreciated.

## Tests

Added userdata-defaults that tests against the regression.
<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
