### PR TITLE
Use new OIIO ustringhash decode methods when available

### DIFF
--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -42,7 +42,8 @@ osl_texture_set_firstchannel(void* opt, int x)
     ((TextureOpt*)opt)->firstchannel = x;
 }
 
-static TextureOpt::Wrap decode_wrapmode(ustringhash_pod name_)
+static TextureOpt::Wrap
+decode_wrapmode(ustringhash_pod name_)
 {
     ustringhash name_hash = ustringhash_from(name_);
 #ifdef OIIO_TEXTURESYSTEM_SUPPORTS_DECODE_BY_USTRINGHASH

--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -42,44 +42,45 @@ osl_texture_set_firstchannel(void* opt, int x)
     ((TextureOpt*)opt)->firstchannel = x;
 }
 
+static TextureOpt::Wrap decode_wrapmode(ustringhash_pod name_)
+{
+    ustringhash name_hash = ustringhash_from(name_);
+#ifdef OIIO_TEXTURESYSTEM_SUPPORTS_DECODE_BY_USTRINGHASH
+    return OIIO::TextureOpt::decode_wrapmode(name_hash);
+#else
+    ustring name = ustring_from(name_hash);
+    return OIIO::TextureOpt::decode_wrapmode(name);
+#endif
+}
+
 OSL_SHADEOP int
 osl_texture_decode_wrapmode(ustringhash_pod name_)
 {
-    ustringhash name_hash = ustringhash_from(name_);
-    ustring name          = ustring_from(name_hash);
-    return OIIO::TextureOpt::decode_wrapmode(name);
+    return decode_wrapmode(name_);
 }
 
 OSL_SHADEOP void
 osl_texture_set_swrap(void* opt, ustringhash_pod x_)
 {
-    ustringhash x_hash        = ustringhash_from(x_);
-    ustring x                 = ustring_from(x_hash);
-    ((TextureOpt*)opt)->swrap = TextureOpt::decode_wrapmode(x);
+    ((TextureOpt*)opt)->swrap = decode_wrapmode(x_);
 }
 
 OSL_SHADEOP void
 osl_texture_set_twrap(void* opt, ustringhash_pod x_)
 {
-    ustringhash x_hash        = ustringhash_from(x_);
-    ustring x                 = ustring_from(x_hash);
-    ((TextureOpt*)opt)->twrap = TextureOpt::decode_wrapmode(x);
+    ((TextureOpt*)opt)->twrap = decode_wrapmode(x_);
 }
 
 OSL_SHADEOP void
 osl_texture_set_rwrap(void* opt, ustringhash_pod x_)
 {
-    ustringhash x_hash        = ustringhash_from(x_);
-    ustring x                 = ustring_from(x_hash);
-    ((TextureOpt*)opt)->rwrap = TextureOpt::decode_wrapmode(x);
+    ((TextureOpt*)opt)->rwrap = decode_wrapmode(x_);
 }
 
 OSL_SHADEOP void
 osl_texture_set_stwrap(void* opt, ustringhash_pod x_)
 {
-    ustringhash x_hash        = ustringhash_from(x_);
-    ustring x                 = ustring_from(x_hash);
-    TextureOpt::Wrap code     = TextureOpt::decode_wrapmode(x);
+    TextureOpt::Wrap code     = decode_wrapmode(x_);
     ((TextureOpt*)opt)->swrap = code;
     ((TextureOpt*)opt)->twrap = code;
 }
@@ -175,8 +176,7 @@ OSL_SHADEOP int
 osl_texture_decode_interpmode(ustringhash_pod name_)
 {
     ustringhash name_hash = ustringhash_from(name_);
-    ustring name          = ustring_from(name_hash);
-    return tex_interp_to_code(name);
+    return tex_interp_to_code(name_hash);
 }
 
 OSL_SHADEOP void

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -2495,6 +2495,21 @@ private:
 
 #ifndef __CUDACC__
 inline int
+tex_interp_to_code(ustringhash modename)
+{
+    int mode = -1;
+    if (modename == Hashes::smartcubic)
+        mode = TextureOpt::InterpSmartBicubic;
+    else if (modename == Hashes::linear)
+        mode = TextureOpt::InterpBilinear;
+    else if (modename == Hashes::cubic)
+        mode = TextureOpt::InterpBicubic;
+    else if (modename == Hashes::closest)
+        mode = TextureOpt::InterpClosest;
+    return mode;
+}
+
+inline int
 tex_interp_to_code(ustring modename)
 {
     int mode = -1;


### PR DESCRIPTION
## Description

We noticed a few ustring-related performance regressions while converting Arnold to the new ustringhash pipeline.

These changes update relevant shadeops to avoid a ustringhash -> ustring conversion. The decode_wrapmode call into OIIO requires the latest master: https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4207/commits/6759d4d85dc6f41f16c56379d18daf4833663913

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
