### PR TITLE
build: Propagate cpp version

### DIFF
--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -51,7 +51,9 @@ function ( NVCC_COMPILE cuda_src extra_headers ptx_generated extra_nvcc_args )
             ${LLVM_COMPILE_FLAGS}
             -DOSL_USE_FAST_MATH=1
             -m64 -arch ${CUDA_TARGET_ARCH} -ptx
-            --std=c++14 -dc --use_fast_math ${CUDA_OPT_FLAG_NVCC} ${NVCC_FTZ_FLAG} --expt-relaxed-constexpr
+            --std=c++${CMAKE_CXX_STANDARD}
+            -dc --use_fast_math ${CUDA_OPT_FLAG_NVCC} ${NVCC_FTZ_FLAG}
+            --expt-relaxed-constexpr
             ${extra_nvcc_args}
             ${OSL_EXTRA_NVCC_ARGS}
             ${cuda_src} -o ${cuda_ptx}

--- a/testsuite/example-cuda/CMakeLists.txt
+++ b/testsuite/example-cuda/CMakeLists.txt
@@ -38,9 +38,13 @@ find_library(CUDA_cuda_LIBRARY cuda HINTS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES
 # TODO: move to sm_60?
 set(CUDA_TARGET_ARCH sm_35)
 
+set (CMAKE_CXX_STANDARD 14 CACHE STRING
+     "C++ standard to build with (14, 17, 20, etc.)")
+
 # Compile our "renderer" to PTX
 cuda_compile_ptx(CUDA_PTX_FILES cuda_grid_renderer.cu
-    OPTIONS --gpu-architecture=${CUDA_TARGET_ARCH} --use_fast_math -dc --std=c++14
+    OPTIONS --gpu-architecture=${CUDA_TARGET_ARCH} --use_fast_math -dc
+            --std=c++${CMAKE_CXX_STANDARD}
             --expt-relaxed-constexpr
             -I${OSL_INCLUDES}
             -I${IMATH_INCLUDES}
@@ -58,7 +62,8 @@ add_custom_target(cuda_grid_renderer_ptx ALL
 
 # Compile the rend_lib shadeops to PTX
 cuda_compile_ptx(CUDA_PTX_FILES rend_lib.cu
-    OPTIONS --gpu-architecture=${CUDA_TARGET_ARCH} --use_fast_math -dc --std=c++14
+    OPTIONS --gpu-architecture=${CUDA_TARGET_ARCH} --use_fast_math -dc
+            --std=c++${CMAKE_CXX_STANDARD}
             --expt-relaxed-constexpr
             -I${OSL_INCLUDES}
             -I${IMATH_INCLUDES}

--- a/testsuite/example-cuda/example-cuda.cpp
+++ b/testsuite/example-cuda/example-cuda.cpp
@@ -337,7 +337,7 @@ register_closures(ShadingSystem& ss)
 
 const char* cuda_compile_options[] = { "--gpu-architecture=compute_35",
                                        "--use_fast_math", "-dc",
-                                       "--std=c++11" };
+                                       "--std=c++" #OSL_CPLUSPLUS_VERSION };
 
 std::string
 build_trampoline_ptx(OSL::ShaderGroup& group, std::string init_name,


### PR DESCRIPTION
OIIO recently pushed its master to be C++17 minimum. When using a C++17-minimum OIIO, you need to build OSL with C++17 as well. This broke a couple CI cases for OSL.

There were a few spots where we were hard-coded to C++14 on the OSL side rather than even using the C++ version specified for the OSL build, so these are some fixes here to address this.



