### PR TITLE
build: print commit hash of locally built dependencies

### DIFF
--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -43,6 +43,8 @@ cd ${OPENCOLORIO_SOURCE_DIR}
 
 echo "git checkout ${OPENCOLORIO_VERSION} --force"
 git checkout ${OPENCOLORIO_VERSION} --force
+echo "Building OpenColorIO from commit" `git rev-parse --short HEAD`
+
 time cmake -S . -B ${OPENCOLORIO_BUILD_DIR} \
            -DCMAKE_BUILD_TYPE=${OPENCOLORIO_BUILD_TYPE} \
            -DCMAKE_INSTALL_PREFIX=${OPENCOLORIO_INSTALL_DIR} \

--- a/src/build-scripts/build_openexr.bash
+++ b/src/build-scripts/build_openexr.bash
@@ -40,6 +40,7 @@ mkdir -p ${OPENEXR_INSTALL_DIR} && true
 
 pushd ${OPENEXR_SOURCE_DIR}
 git checkout ${OPENEXR_VERSION} --force
+echo "Building OpenEXR from commit" `git rev-parse --short HEAD`
 
 cmake   -S . -B ${OPENEXR_BUILD_DIR} \
         -DCMAKE_BUILD_TYPE=${OPENEXR_BUILD_TYPE} \

--- a/src/build-scripts/build_openimageio.bash
+++ b/src/build-scripts/build_openimageio.bash
@@ -32,6 +32,7 @@ mkdir -p ${OPENIMAGEIO_BUILD_DIR} && true
 pushd $OPENIMAGEIO_SRCDIR
 git fetch --all -p
 git checkout $OPENIMAGEIO_VERSION --force
+echo "Building OpenImageIO from commit" `git rev-parse --short HEAD`
 
 if [[ "$USE_SIMD" != "" ]] ; then
     OPENIMAGEIO_CMAKE_FLAGS="$OPENIMAGEIO_CMAKE_FLAGS -DUSE_SIMD=$USE_SIMD"

--- a/src/build-scripts/build_pugixml.bash
+++ b/src/build-scripts/build_pugixml.bash
@@ -37,6 +37,7 @@ cd ${PUGIXML_SRC_DIR}
 
 echo "git checkout ${PUGIXML_VERSION} --force"
 git checkout ${PUGIXML_VERSION} --force
+echo "Building pugixml from commit" `git rev-parse --short HEAD`
 
 if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -S . -B ${PUGIXML_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release \

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -41,6 +41,7 @@ cd ${PYBIND11_SRC_DIR}
 
 echo "git checkout ${PYBIND11_VERSION} --force"
 git checkout ${PYBIND11_VERSION} --force
+echo "Building pybind11 from commit" `git rev-parse --short HEAD`
 
 if [[ -z $DEP_DOWNLOAD_ONLY ]]; then
     time cmake -S . -B ${PYBIND11_BUILD_DIR} -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Especially for our "bleeding edge" test that builds from the current master of several dependencies, sometimes our tests fail not because of anything we've done, but because of a change in one of the dependencies.  To help track down exactly which change broke the dependency, make sure our CI build logs print the specific commit hash of those packages that we built.

