### PR TITLE
ci: Lock down to OIIO 2.5 for icc tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,14 @@ jobs:
             cxx_compiler: icpc
             cxx_std: 17
             fmt_ver: 7.1.3
-            openimageio_ver: master
+            openimageio_ver: release
+            # Changes to OIIO's simd.h starting in commit 68666db9 (from PR
+            # #4187) seem to trigger compiler bugs in icc and generate wrong
+            # SIMD code. It's probably not worth tracking down for just this
+            # obsolete compiler. Just lock down to OIIO 2.5 for icc builds to
+            # avoid the problem.
+            # openimageio_ver: e41ac03c0b21  # works
+            # openimageio_ver: 68666db994d5 # broken
             python_ver: 3.9
             pybind11_ver: v2.9.0
             # simd: avx2,f16c


### PR DESCRIPTION
Background: Intel's icc is essentially discontinued and we think all the renderers using OSL have moved on to the newer icx, but Alex Wells still likes to sometime use icc for its better facilities for some SIMD code generation sleuthing that he does. So we keep it in our CI matrix to esure we don't break it for OSL until it is truly unavoidable or he doesn't feel like he needs it anymore.

Some recent changes to OIIO's simd.h, from PR 4187 in that project, seem to tweak what appears to be a compiler bug in icc -- bugs were also noted in OIIO in the course of this PR and some workarounds were put there just for icc to make OIIO's own tests pass. Well, once that went in, OSL's CI tests for the icc case also started failing.  It's only texture derivatives that are broken, and in a weird wy that smells like a compiler icc bug with SIMD generation similar to what we discovered on the OIIO side.

Like I said, this is a discontinued compiler that no major renderers are still using, so it doesn't seem worth tracking it down any further to find a true fix. So let's just lock that one test case down to OIIO 2.5 (the current release) to avoid the changes that will eventually be in OIIO 2.6/3.0 and hope that we fully retire icc before OIIO 2.5 is no longer supported by OSL.
