### PR TITLE
Remove the only use of boost::thread_specific_ptr

### DIFF
--- a/src/liboslexec/context.cpp
+++ b/src/liboslexec/context.cpp
@@ -46,13 +46,13 @@ ShadingContext::ShadingContext(ShadingSystemImpl& shadingsys,
                                PerThreadInfo* threadinfo)
     : m_shadingsys(shadingsys)
     , m_renderer(m_shadingsys.renderer())
+    , m_threadinfo(threadinfo)
     , m_group(NULL)
     , m_max_warnings(shadingsys.max_warnings_per_thread())
     , m_dictionary(NULL)
     , batch_size_executed(0)
 {
     m_shadingsys.m_stat_contexts += 1;
-    m_threadinfo = threadinfo ? threadinfo : shadingsys.get_perthread_info();
     m_texture_thread_info = NULL;
 }
 

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -9,8 +9,6 @@
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/thread.h>
 
-#include <boost/thread/tss.hpp> /* for thread_specific_ptr */
-
 #include <OSL/llvm_util.h>
 #include <OSL/oslconfig.h>
 #include <OSL/wide.h>

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -14,8 +14,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <boost/thread/tss.hpp> /* for thread_specific_ptr */
-
 // Pull in the modified Imath headers and the OSL_HOSTDEVICE macro
 #ifdef __CUDACC__
 #    include <OSL/oslconfig.h>
@@ -836,20 +834,6 @@ private:
                                           string_view layername,
                                           ShaderInstance* inst);
 
-    /// Get the per-thread info, create it if necessary.
-    // N.B. This will be DEPRECATED (as will the m_perthread_info itself)
-    // in OSL 2.1 when we fully require the app to allocate the per-thread
-    // info data.
-    PerThreadInfo* get_perthread_info() const
-    {
-        PerThreadInfo* p = m_perthread_info.get();
-        if (!p) {
-            p = new PerThreadInfo;
-            m_perthread_info.reset(p);
-        }
-        return p;
-    }
-
     /// Set up LLVM -- make sure we have a Context, Module, ExecutionEngine,
     /// retained JITMemoryManager, etc.
     void SetupLLVM();
@@ -984,7 +968,6 @@ private:
 
     // Thread safety
     mutable mutex m_mutex;
-    mutable boost::thread_specific_ptr<PerThreadInfo> m_perthread_info;
 
     // Stats
     atomic_int m_stat_shaders_loaded;      ///< Stat: shaders loaded

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3432,13 +3432,8 @@ ShadingSystemImpl::get_context(PerThreadInfo* threadinfo,
                                TextureSystem::Perthread* texture_threadinfo)
 {
     if (!threadinfo) {
-#if OSL_VERSION < 20200
-        threadinfo = get_perthread_info();
-        warning("ShadingSystem::get_context called without a PerThreadInfo");
-#else
         error("ShadingSystem::get_context called without a PerThreadInfo");
         return nullptr;
-#endif
     }
     ShadingContext* ctx = threadinfo->context_pool.empty()
                               ? new ShadingContext(*this, threadinfo)


### PR DESCRIPTION
## Description

This had already been marked as deprecated, and there is concensus that the overhead does not outweight the slight inconvenience of creating one object per thread

## Tests

Testsuite passes on my machine.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
