### PR TITLE
fix: Fix ifdef typo

### DIFF
--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -50,7 +50,7 @@
 #    ifdef OIIO_ERRORHANDLER_HIDE_PRINTF
 #        define OIIO_ERRORHANDLER_HIDE_PRINTF 1
 #    endif
-#    ifdef OIIO_HIDE_FORMAT
+#    ifndef OIIO_HIDE_FORMAT
 #        define OIIO_HIDE_FORMAT 1
 #    endif
 #endif


### PR DESCRIPTION
This is the only way that makes any sense -- define OIIO_HIDE_FORMAT if it ISN'T already defined.

