### PR TITLE
Remove remaining traces of boost

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: sonar gcc9/C++14 llvm13 py3.9 boost1.76 exr3.1 oiio2.3 avx2
+          - desc: sonar gcc9/C++14 llvm13 py3.9 exr3.1 oiio2.3 avx2
             nametag: static-analysis-sonar
             os: ubuntu-latest
             vfxyear: 2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: gcc6/C++14 llvm9 py2.7 boost1.66 exr2.4 oiio2.3 sse2
+          - desc: gcc6/C++14 llvm9 py2.7 exr2.4 oiio2.3 sse2
             nametag: linux-vfx2020
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2019-clang9
@@ -49,7 +49,7 @@ jobs:
             python_ver: 2.7
             pybind11_ver: v2.4.2
             setenvs: export CMAKE_VERSION=3.15.5
-          - desc: clang9/C++14 llvm9 oiio-release boost1.66 avx2 exr2.4 py2.7
+          - desc: clang9/C++14 llvm9 oiio-release avx2 exr2.4 py2.7
             nametag: linux-clang9-llvm9
             runner: ubuntu-20.04
             container: aswftesting/ci-osl:2019-clang9
@@ -63,7 +63,7 @@ jobs:
             # pybind11_ver: v2.9.0
             simd: avx
             setenvs: export CMAKE_VERSION=3.15.5
-          - desc: gcc6/C++14 llvm10 py3.7 boost1.70 exr2.4 oiio2.2 sse4
+          - desc: gcc6/C++14 llvm10 py3.7 exr2.4 oiio2.2 sse4
             nametag: linux-vfx2020
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2020
@@ -74,7 +74,7 @@ jobs:
             pybind11_ver: v2.5.0
             simd: sse4.2
             setenvs: export CONAN_LLVM_VERSION=10.0.1
-          - desc: gcc9/C++17 llvm11 py3.7 boost1.73 exr2.5 oiio2.3 avx2 batch-b8avx2
+          - desc: gcc9/C++17 llvm11 py3.7 exr2.5 oiio2.3 avx2 batch-b8avx2
             nametag: linux-vfx2021
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2021-clang11
@@ -85,7 +85,7 @@ jobs:
             pybind11_ver: v2.7.0
             simd: avx2,f16c
             batched: b8_AVX2_noFMA
-          - desc: gcc9/C++17 llvm13 py3.9 boost1.76 exr3.1 oiio-rel avx2
+          - desc: gcc9/C++17 llvm13 py3.9 exr3.1 oiio-rel avx2
             nametag: linux-vfx2022
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2022-clang13
@@ -96,7 +96,7 @@ jobs:
             pybind11_ver: v2.9.0
             simd: avx2,f16c
             batched: b8_AVX2
-          - desc: clang12/C++17 llvm12 oiio-master boost1.73 exr3.1 py3.9 avx2 batch-avx512
+          - desc: clang12/C++17 llvm12 oiio-master exr3.1 py3.9 avx2 batch-avx512
             nametag: linux-clang12-llvm12-batch
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2022-clang12
@@ -108,7 +108,7 @@ jobs:
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
             setenvs: USE_OPENVDB=0
-          - desc: icc/C++17 llvm14 py3.9 boost1.76 exr3.1 oiio-master avx2
+          - desc: icc/C++17 llvm14 py3.9 exr3.1 oiio-master avx2
             nametag: linux-icc
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2022-clang14
@@ -132,7 +132,7 @@ jobs:
             setenvs: export OSL_CMAKE_FLAGS="-DSTOP_ON_WARNING=OFF -DEXTRA_CPP_ARGS=-fp-model=consistent"
                             OPENIMAGEIO_CMAKE_FLAGS=-DBUILD_FMT_VERSION=7.1.3
                             USE_OPENVDB=0
-          - desc: icx/C++17 llvm14 py3.9 boost1.76 exr3.1 oiio2.3 avx2
+          - desc: icx/C++17 llvm14 py3.9 exr3.1 oiio2.3 avx2
             nametag: linux-icx
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2022-clang14
@@ -147,7 +147,7 @@ jobs:
             simd: avx2,f16c
             batched: b8_AVX2_noFMA
             setenvs: export OSL_CMAKE_FLAGS="-DSTOP_ON_WARNING=OFF" USE_OPENVDB=0
-          - desc: gcc11/C++17 llvm15 py3.10 boost1.80 exr3.1 oiio-rel avx2
+          - desc: gcc11/C++17 llvm15 py3.10 exr3.1 oiio-rel avx2
             nametag: linux-vfx2023
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2023-clang15
@@ -158,7 +158,7 @@ jobs:
             pybind11_ver: v2.9.0
             simd: avx2,f16c
             batched: b8_AVX2
-          - desc: GPU Cuda11 gcc11/C++17 llvm15 py3.10 boost1.80 exr3.1 OIIO-master avx2
+          - desc: GPU Cuda11 gcc11/C++17 llvm15 py3.10 exr3.1 OIIO-master avx2
             nametag: linux-optix7-2023
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2023-clang15
@@ -171,7 +171,7 @@ jobs:
             skip_tests: 1
             setenvs: export OSL_CMAKE_FLAGS="-DOSL_USE_OPTIX=1" OPTIX_VERSION=7.0
                             OPENIMAGEIO_CMAKE_FLAGS=-DBUILD_FMT_VERSION=9.1.0
-          - desc: oldest everything gcc6/C++14 llvm9 py2.7 boost1.66 oiio2.3 no-simd exr2.4
+          - desc: oldest everything gcc6/C++14 llvm9 py2.7 oiio2.3 no-simd exr2.4
             nametag: linux-oldest
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2019-clang9
@@ -342,7 +342,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: Debug gcc7/C++14 llvm9 py2.7 oiio2.3 exr2.4 sse4 boost1.65 exr2.4
+          - desc: Debug gcc7/C++14 llvm9 py2.7 oiio2.3 exr2.4 sse4 exr2.4
             nametag: linux-debug-gcc7-llvm9
             runner: ubuntu-20.04
             cxx_compiler: g++-7
@@ -356,7 +356,7 @@ jobs:
                             LLVM_VERSION=9.0.0
                             PUGIXML_VERSION=v1.9
                             CTEST_TEST_TIMEOUT=240
-          - desc: gcc10/C++17 llvm10 oiio-release boost1.65 exr2.5 avx2
+          - desc: gcc10/C++17 llvm10 oiio-release exr2.5 avx2
             nametag: linux-2021ish-gcc10-llvm10
             runner: ubuntu-20.04
             cxx_compiler: g++-10
@@ -370,7 +370,7 @@ jobs:
             setenvs: export LLVM_VERSION=10.0.0
                             OPENIMAGEIO_CMAKE_FLAGS="-DBUILD_FMT_VERSION=7.0.1"
                             PUGIXML_VERSION=v1.10
-          - desc: latest releases gcc11/C++17 llvm16 boost1.71 exr3.2 py3.9 avx2 batch-b16avx512
+          - desc: latest releases gcc11/C++17 llvm16 exr3.2 py3.9 avx2 batch-b16avx512
             nametag: linux-latest-releases
             runner: ubuntu-22.04
             cxx_compiler: g++-11
@@ -386,7 +386,7 @@ jobs:
                             LLVM_DISTRO_NAME=ubuntu-22.04
                             OPENCOLORIO_VERSION=v2.2.0
                             PUGIXML_VERSION=v1.13
-          - desc: bleeding edge gcc12/C++17 llvm17 oiio/ocio/exr/pybind-master boost1.71 py3.10 avx2 batch-b16avx512
+          - desc: bleeding edge gcc12/C++17 llvm17 oiio/ocio/exr/pybind-master py3.10 avx2 batch-b16avx512
             nametag: linux-bleeding-edge
             runner: ubuntu-22.04
             cxx_compiler: g++-12
@@ -402,7 +402,7 @@ jobs:
                             LLVM_DISTRO_NAME=ubuntu-22.04
                             OPENCOLORIO_VERSION=main
                             PUGIXML_VERSION=master
-          - desc: clang14/C++17 llvm14 boost1.71 exr3.1 py3.8 avx2 batch-b16avx512
+          - desc: clang14/C++17 llvm14 exr3.1 py3.8 avx2 batch-b16avx512
             nametag: linux-latest-releases-clang
             runner: ubuntu-20.04
             cxx_compiler: clang++

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,7 @@ Prefer C++11 `std` rather than Boost or other third party libraries, where
 both can do the same task.
 
 If you see a third party library already used as a dependency (such as OIIO,
-Boost, Imath, or LLVM), feel free to any of its public features in OSL
+Imath, or LLVM), feel free to any of its public features in OSL
 internals (provided those features are present in the minimum version of
 that library that we support).
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,6 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     * [Cuda](https://developer.nvidia.com/cuda-downloads) 9.0 or higher. It is
       recommended that you use 11.0 or higher.
 
-* [Boost](https://www.boost.org) 1.55 or newer (tested through boost 1.83)
 * [Ilmbase or Imath](https://github.com/AcademySoftwareFoundation/Imath) 2.4
    or newer (recommended: 3.1 or higher; tested through 3.2)
    NOTE: It is likely that 1.13 is the last release that will support
@@ -100,7 +99,7 @@ Here are the steps to check out, build, and test the OSL distribution:
 
    Note: OSL uses 'CMake' for its cross-platform build system.  But for
    simplicity, we have made a "make wrapper" around it, so that by just
-   typing 'make' everything will build.  Type 'make help' for other 
+   typing 'make' everything will build.  Type 'make help' for other
    options, and note that 'make nuke' will blow everything away for the
    freshest possible compile.
 
@@ -130,7 +129,7 @@ Here are the steps to check out, build, and test the OSL distribution:
    test suite with:
 
         make test
-        
+
 Troubleshooting
 ----------------
 

--- a/Makefile
+++ b/Makefile
@@ -369,7 +369,6 @@ help:
 	@echo "      if found. And you can hint where to find it with Foo_ROOT=path"
 	@echo "      Note that it is case sensitive!"
 	@echo "  Finding and Using Dependencies:"
-	@echo "      BOOST_ROOT=path          Custom Boost installation"
 	@echo "      USE_QT=0                 Skip anything that needs Qt"
 	@echo "  LLVM-related options:"
 	@echo "      LLVM_VERSION=12.0        Specify which LLVM version to use"

--- a/README.md
+++ b/README.md
@@ -567,7 +567,6 @@ The OSL implementation depends upon several other open source packages,
 all with compatible licenses:
 
 * [OpenImageIO](http://www.openimageio.org)
-* [Boost](http://www.boost.org)
 * [IlmBase](http://www.openexr.com)
 * [LLVM Compiler Infrastructure](http://llvm.org)
 

--- a/doc/build_install/windows/Readme.md
+++ b/doc/build_install/windows/Readme.md
@@ -64,8 +64,6 @@ My System and Setup Configuration:
 
 **OpenShadingLanguage:** cloned from latest master branch
 
-**Boost:** 1.70
-
 **LLVM:** 11.0.0 C++ is set on C++14
 
 **CLANG:** 11.0.0 C++ is set on C++14
@@ -152,9 +150,9 @@ Open `doc/build_install/windows/osl_env_vars_setup.bat` in your editor and edit 
 
 The main build launcher is here `doc/build_install/windows/build_osl.bat`
 
-For now we can not assign pre-installed llvm or boost so we have to build all together at once and put all of them in one directory.
+For now we can not assign pre-installed llvm so we have to build all together at once and put all of them in one directory.
 
-I am working on it to see how we can use external llvm and boost installation without error.
+I am working on it to see how we can use external llvm installation without error.
 
 **Table of flags we can assign to the command**
 
@@ -163,7 +161,6 @@ I am working on it to see how we can use external llvm and boost installation wi
 | --osl         | Implemented     | Yes     |
 | --python      | Implemented     | Yes     |
 | --zlib        | Implemented     | Yes     |
-| --boost       | Implemented     | Yes     |
 | --llvm        | Implemented     | Yes     |
 | --clang       | Implemented     | Yes     |
 | --pugixml     | Implemented     | Yes     |

--- a/doc/build_install/windows/build_osl.bat
+++ b/doc/build_install/windows/build_osl.bat
@@ -14,17 +14,17 @@ cls
 
 set OSL_INPUT_CONFIG=%1
 
-if "%OSL_INPUT_CONFIG%" equ "debug" ( 
+if "%OSL_INPUT_CONFIG%" equ "debug" (
   set OSL_LOCATION_DIR=osl_debug
   set OSL_BUILD_CONFIG=--debug
   goto RUN
 )
-if "%OSL_INPUT_CONFIG%" equ "release" ( 
+if "%OSL_INPUT_CONFIG%" equ "release" (
   set OSL_LOCATION_DIR=osl_release
   set OSL_BUILD_CONFIG=
   goto RUN
 )
-if "%OSL_INPUT_CONFIG%" equ "" ( 
+if "%OSL_INPUT_CONFIG%" equ "" (
   echo --= Enter debug or release as argument
   exit
 )
@@ -44,5 +44,5 @@ call %VCVARS_LOCATION%/vcvarsall.bat x64
 
 cls
 
-python build_osl.py --generator "Visual Studio 16 2019" --osl --python %OSL_BUILD_CONFIG% --zlib --boost --llvm --clang --pugixml --openexr --tiff --jpeg --png --flex --bison --opencolorio --openimageio --libraw --pybind11 %BASE_LOCATION%/%OSL_LOCATION_DIR%
+python build_osl.py --generator "Visual Studio 16 2019" --osl --python %OSL_BUILD_CONFIG% --zlib --llvm --clang --pugixml --openexr --tiff --jpeg --png --flex --bison --opencolorio --openimageio --libraw --pybind11 %BASE_LOCATION%/%OSL_LOCATION_DIR%
 

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -67,6 +67,7 @@ else
 
     time sudo apt-get -q install -y \
         git cmake ninja-build ccache g++ \
+        libboost-dev libboost-thread-dev libboost-filesystem-dev \
         libilmbase-dev libopenexr-dev \
         libtiff-dev libgif-dev libpng-dev \
         flex bison libbison-dev \

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -67,7 +67,6 @@ else
 
     time sudo apt-get -q install -y \
         git cmake ninja-build ccache g++ \
-        libboost-dev libboost-thread-dev libboost-filesystem-dev \
         libilmbase-dev libopenexr-dev \
         libtiff-dev libgif-dev libpng-dev \
         flex bison libbison-dev \

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -12,12 +12,7 @@ VCPKG_INSTALLATION_ROOT=/c/vcpkg
 
 export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:=.}
 export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$DEP_DIR"
-export BOOST_ROOT=${BOOST_ROOT_1_72_0}
 
-BOOST_UNIX_PATH=$(echo "/$BOOST_ROOT" | sed -e 's/\\/\//g' -e 's/://')
-echo "BOOST_UNIX_PATH=$BOOST_UNIX_PATH"
-
-export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$BOOST_ROOT"
 export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH;$VCPKG_INSTALLATION_ROOT/installed/x64-windows"
 export PATH="$PATH:$DEP_DIR/bin:$DEP_DIR/lib:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin:/bin"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$DEP_DIR/bin:$VCPKG_INSTALLATION_ROOT/installed/x64-windows/bin"
@@ -49,7 +44,7 @@ echo "All pre-installed VCPkg installs:"
 vcpkg list
 echo "---------------"
 # vcpkg update
-# 
+#
 # # vcpkg install zlib:x64-windows
 vcpkg install tiff:x64-windows
 vcpkg install libpng:x64-windows

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -28,7 +28,7 @@ echo ""
 echo "Before my brew installs:"
 brew list --versions
 
-brew install --display-times -q gcc ccache cmake ninja boost || true
+brew install --display-times -q gcc ccache cmake ninja || true
 brew link --overwrite gcc
 brew install --display-times -q python@${PYTHON_VERSION} || true
 # brew unlink python@3.8 || true

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -120,9 +120,6 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
     endif ()
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        # fix compilation error when using MSVC
-        set (CLANG_MSVC_FIX "-DBOOST_CONFIG_REQUIRES_THREADS_HPP")
-
         # these are warnings triggered by the dllimport/export attributes not being supported when
         # compiling for Cuda. When all 3rd parties have their export macro fixed these warnings
         # can be restored.

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -46,7 +46,6 @@ function ( NVCC_COMPILE cuda_src extra_headers ptx_generated extra_nvcc_args )
             ${ALL_OpenImageIO_INCLUDES}
             ${ALL_IMATH_INCLUDES}
             ${ALL_OPENEXR_INCLUDES}
-            "-I${Boost_INCLUDE_DIRS}"
             "-DFMT_DEPRECATED=\"\""
             ${LLVM_COMPILE_FLAGS}
             -DOSL_USE_FAST_MATH=1
@@ -169,7 +168,6 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
             ${ALL_OpenImageIO_INCLUDES}
             ${ALL_IMATH_INCLUDES}
             ${ALL_OPENEXR_INCLUDES}
-            "-I${Boost_INCLUDE_DIRS}"
             ${LLVM_COMPILE_FLAGS} ${CUDA_LIB_FLAGS} ${CLANG_MSVC_FIX} ${CUDA_TEXREF_FIX}
             -D__CUDACC__ -DOSL_COMPILING_TO_BITCODE=1 -DNDEBUG -DOIIO_NO_SSE -D__CUDADEVRT_INTERNAL__
             --language=cuda --cuda-device-only --cuda-gpu-arch=${CUDA_TARGET_ARCH}

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -30,13 +30,19 @@ message (STATUS "CMAKE_PREFIX_PATH = ${CMAKE_PREFIX_PATH}")
 
 
 include (ExternalProject)
+include(FetchContent)
 
 option (BUILD_MISSING_DEPS "Try to download and build any missing dependencies" OFF)
 
+FetchContent_Declare(
+  tsl-robin-map
+  GIT_REPOSITORY https://github.com/Tessil/robin-map.git
+  GIT_TAG        v1.3.0
+  FIND_PACKAGE_ARGS NAMES tsl-robin-map
+)
+FetchContent_MakeAvailable(tsl-robin-map)
 
 checked_find_package (ZLIB REQUIRED)  # Needed by several packages
-
-checked_find_package(tsl-robin-map REQUIRED)
 
 # IlmBase & OpenEXR
 checked_find_package (OpenEXR REQUIRED

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -34,50 +34,6 @@ include (ExternalProject)
 option (BUILD_MISSING_DEPS "Try to download and build any missing dependencies" OFF)
 
 
-###########################################################################
-# Boost setup
-if (LINKSTATIC)
-    set (Boost_USE_STATIC_LIBS ON)
-else ()
-    if (MSVC)
-        add_definitions (-DBOOST_ALL_DYN_LINK=1)
-    endif ()
-endif ()
-if (BOOST_CUSTOM)
-    set (Boost_FOUND true)
-    # N.B. For a custom version, the caller had better set up the variables
-    # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
-else ()
-    set (Boost_COMPONENTS filesystem system thread)
-    # The FindBoost.cmake interface is broken if it uses boost's installed
-    # cmake output (e.g. boost 1.70.0, cmake <= 3.14). Specifically it fails
-    # to set the expected variables printed below. So until that's fixed
-    # force FindBoost.cmake to use the original brute force path.
-    if (NOT DEFINED Boost_NO_BOOST_CMAKE)
-        set (Boost_NO_BOOST_CMAKE ON)
-    endif ()
-    checked_find_package (Boost REQUIRED
-                       VERSION_MIN 1.55
-                       COMPONENTS ${Boost_COMPONENTS}
-                       RECOMMEND_MIN 1.66
-                       RECOMMEND_MIN_REASON "Boost 1.66 is the oldest version our CI tests against"
-                       PRINT Boost_INCLUDE_DIRS Boost_LIBRARIES
-                      )
-endif ()
-
-# On Linux, Boost 1.55 and higher seems to need to link against -lrt
-if (CMAKE_SYSTEM_NAME MATCHES "Linux"
-      AND ${Boost_VERSION} VERSION_GREATER_EQUAL 105500)
-    list (APPEND Boost_LIBRARIES "rt")
-endif ()
-
-include_directories (SYSTEM "${Boost_INCLUDE_DIRS}")
-link_directories ("${Boost_LIBRARY_DIRS}")
-
-# end Boost setup
-###########################################################################
-
-
 checked_find_package (ZLIB REQUIRED)  # Needed by several packages
 
 checked_find_package(tsl-robin-map REQUIRED)

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -80,6 +80,8 @@ link_directories ("${Boost_LIBRARY_DIRS}")
 
 checked_find_package (ZLIB REQUIRED)  # Needed by several packages
 
+checked_find_package(tsl-robin-map REQUIRED)
+
 # IlmBase & OpenEXR
 checked_find_package (OpenEXR REQUIRED
                       VERSION_MIN 2.4

--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -65,25 +65,6 @@ execute_process (COMMAND ${LLVM_CONFIG} --targets-built
        OUTPUT_VARIABLE LLVM_TARGETS
        OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-############ HACK ##############
-# On OSX, the Homebrew (and maybe any build) of LLVM 10.0 seems to have a
-# link conflict with its dependency on the llvm libc++ and the system
-# libc++, both can end up dynamically linked and lead to very subtle and
-# frustrating behavior failures (in particular, osl's use of libclang will
-# botch include file parsing any time LD_LIBRARY_PATH doesn't have the llvm
-# libc++ first).
-#
-# It seems that this is not a problem when linking against the llvm and
-# libclang libraries statically. So on apple and when LLVM 10+ are involved,
-# just force that choice. Other than larger executables, it seems harmless,
-# and in any case a better choice than this beastly bug.
-#
-# We can periodically revisit this with new version of LLVM, maybe they will
-# fix things and we won't require this preemptive static linking.
-if (APPLE AND LLVM_VERSION VERSION_GREATER_EQUAL 10.0)
-    set (LLVM_STATIC ON)
-endif ()
-
 if (LLVM_STATIC)
     execute_process (COMMAND ${LLVM_CONFIG} --system-libs --link-static
                      OUTPUT_VARIABLE LLVM_SYSTEM_LIBRARIES

--- a/src/cmake/modules/FindRobinmap.cmake
+++ b/src/cmake/modules/FindRobinmap.cmake
@@ -1,0 +1,25 @@
+# Find Robinmap
+#
+# Copyright Contributors to the OpenImageIO project.
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/AcademySoftwareFoundation/OpenImageIO
+#
+# Sets the usual variables expected for find_package scripts:
+#
+# ROBINMAP_INCLUDES - header location
+# ROBINMAP_FOUND - true if robin-map was found.
+
+find_path (ROBINMAP_INCLUDE_DIR tsl/robin_map.h
+           HINTS "${PROJECT_SOURCE_DIR}/ext/robin-map"
+           )
+
+# Support the REQUIRED and QUIET arguments, and set ROBINMAP_FOUND if found.
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (Robinmap
+                                   REQUIRED_VARS ROBINMAP_INCLUDE_DIR)
+
+if (ROBINMAP_FOUND)
+    set (ROBINMAP_INCLUDES ${ROBINMAP_INCLUDE_DIR})
+endif ()
+
+mark_as_advanced (ROBINMAP_INCLUDE_DIR)

--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -120,7 +120,7 @@ find are different in OSL compared to other languages:
 
   OSL shaders are evaluated in SIMD fashion, executing shaders on many
   points at once, but there is no need to burden shader writers with
-  declaring which variables need to be uniform or varying.  
+  declaring which variables need to be uniform or varying.
 
   In the open source OSL implementation, this is done both automatically
   and dynamically, meaning that a variable can switch back and forth
@@ -133,7 +133,7 @@ find are different in OSL compared to other languages:
   and use arbitrary quantities as texture coordinates and expect correct
   filtering.  This does not require that shaded points be arranged in a
   rectangular grid, or have any particular connectivity, or that any
-  "extra points" be shaded.  
+  "extra points" be shaded.
 
   In the open source OSL implementation, this is possible because
   derivatives are not computed by finite differences with neighboring
@@ -182,7 +182,6 @@ other open source packages:
   http://openimageio.org
 - **Imath** Copyright Contributors to Imath.
   http://www.openexr.com
-- **Boost** Copyright various authors.  http://www.boost.org
 - **LLVM** Copyright 2003-2010 University of Illinois at
   Urbana-Champaign. http://llvm.org
 

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -384,7 +384,6 @@ other open source packages:
 \url{http://openimageio.org}
 \item Imath \copyright\ Contributors to Imath.
 \url{http://www.openexr.com}
-\item Boost \copyright\ various authors.  \url{http://www.boost.org}
 \item LLVM \copyright\ 2003-2010 University of Illinois at
   Urbana-Champaign. \url{http://llvm.org}
 \end{itemize}

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -182,7 +182,7 @@ Unported License. \\
 \smallskip
 \spc \includegraphics[width=0.85in]{Figures/CC-BY.png}
 \spc http://creativecommons.org/licenses/by/4.0/
- \bigskip 
+ \bigskip
 
 
 
@@ -318,7 +318,7 @@ find are different in OSL compared to other languages:
 
   OSL shaders are evaluated in SIMD fashion, executing shaders on many
   points at once, but there is no need to burden shader writers with
-  declaring which variables need to be uniform or varying.  
+  declaring which variables need to be uniform or varying.
 
   In the open source OSL implementation, this is done both automatically
   and dynamically, meaning that a variable can switch back and forth
@@ -331,7 +331,7 @@ find are different in OSL compared to other languages:
   and use arbitrary quantities as texture coordinates and expect correct
   filtering.  This does not require that shaded points be arranged in a
   rectangular grid, or have any particular connectivity, or that any
-  "extra points" be shaded.  
+  "extra points" be shaded.
 
   In the open source OSL implementation, this is possible because
   derivatives are not computed by finite differences with neighboring
@@ -384,7 +384,6 @@ other open source packages:
 \url{http://openimageio.org}
 \item Imath \copyright\ Contributors to Imath.
 \url{http://www.openexr.com}
-\item Boost \copyright\ various authors.  \url{http://www.boost.org}
 \item LLVM \copyright\ 2003-2010 University of Illinois at
   Urbana-Champaign. \url{http://llvm.org}
 \end{itemize}
@@ -402,7 +401,7 @@ to be used by and distributed with \product.
 % readers of early drafts, sometimes questions, sometimes guideposts
 % to uncertain areas, sometimes explanations of what is to come but that
 % has not yet been fully fleshed out.
-% 
+%
 % \begin{comment}
 % Short annotations will sometimes spring up anywhere, but there's also a
 % full chapter of discussion of design choices
@@ -418,7 +417,7 @@ to be used by and distributed with \product.
 \label{chap:bigpicture}
 
 This chapter attempts to lay out the major concepts of \langname,
-define key nomenclature, and sketch out how individual shaders fit 
+define key nomenclature, and sketch out how individual shaders fit
 together in the context of a renderer as a whole.
 
 % \begin{annotate}
@@ -445,9 +444,9 @@ in its output {\cf Cout}:
 
 \medskip
 
-The shader's inputs and outputs are called \emph{shader parameters}.  
+The shader's inputs and outputs are called \emph{shader parameters}.
 Parameters have default values, specified in the shader code, but may
-also be given new values by the renderer at runtime.  
+also be given new values by the renderer at runtime.
 
 \subsection*{Shader instances}
 
@@ -744,7 +743,7 @@ are equivalent to a single whitespace character. \index{whitespace}
 
 Source code may be split into multiple lines, separated by end-of-line
 markers (carriage return and/or linefeed).  Lines may be of any length
-and end-of-line markers carry no significant difference from other 
+and end-of-line markers carry no significant difference from other
 whitespace, except that they terminate {\cf //} comments and delimit
 preprocessor directives.
 
@@ -824,11 +823,11 @@ languages: \index{reserved words}
 
 \begin{quote} {\cf
 
-bool case catch char class const delete default double 
+bool case catch char class const delete default double
 enum extern false friend
-goto inline long new operator private protected 
-short signed sizeof static 
-switch template this throw true try typedef 
+goto inline long new operator private protected
+short signed sizeof static
+switch template this throw true try typedef
 uniform union unsigned varying virtual volatile
 
 }
@@ -850,7 +849,7 @@ uniform union unsigned varying virtual volatile
 \indexapi{\#pragma}
 
 Shader source code is passed through a standard C preprocessor as a
-first step in parsing.  
+first step in parsing.
 
 Preprocessor directives are designated by a hash mark ({\cf \#}) as the
 first character on a line, followed by a preprocessor directive name.
@@ -992,13 +991,13 @@ parameters.  Formally, the grammar for a simple parameter
 declaration looks like this:
 
 \medskip
-\spc \emph{type parametername = default-expression} 
+\spc \emph{type parametername = default-expression}
 \medskip
 
 \noindent where \emph{type} is one of the data types described
 in Chapter~\ref{chap:types}, \emph{parametername} is the name of the
 parameter, and \emph{default-expression} is a valid expression
-(see Section~\ref{sec:expressions}).  Multiple parameters are 
+(see Section~\ref{sec:expressions}).  Multiple parameters are
 simply separated by commas:
 
 \medskip
@@ -1079,7 +1078,7 @@ renderer's API).
 Here is an example of a shader declaration, with several parameters:
 
 \begin{code}
-    surface wood ( 
+    surface wood (
                /* Simple params with constant initializers */
                    float Kd = 0.5,
                    color woodcolor = color (.7, .5, .3),
@@ -1163,9 +1162,9 @@ Below is an example shader declaration showing the use of shader and
 parameter metadata:
 
 \begin{code}
-    surface wood 
+    surface wood
                 [[ string help = "Realistic wood shader" ]]
-        ( 
+        (
            float Kd = 0.5
                [[ string help = "Diffuse reflectivity",
                   float min = 0, float max = 1 ]] ,
@@ -1190,7 +1189,7 @@ not affect the actual execution of the shader.  Most metadata exist only
 to be embedded in the compiled shader and able to be queried by other
 applications, such as to construct user interfaces for shader assignment
 that allow usage tips, appropriate kinds of widgets for setting each
-parameter, etc.  
+parameter, etc.
 
 The choice of metadata and their meaning is completely up to the shader
 writer and/or modeling system.  However, we propose some conventions
@@ -1593,17 +1592,17 @@ lists the built-in color spaces.
 {\cf "rgb"} & The coordinate system that all colors start out in, and
 in which the renderer expects to find colors that are set by
 your shader.   \\
-\hline 
+\hline
 {\cf "hsv"} & hue, saturation, and value. \\
-\hline 
+\hline
 {\cf "hsl"} & hue, saturation, and lightness. \\
-\hline 
+\hline
 {\cf "YIQ"} & the color space used for the NTSC television standard. \\
-\hline 
+\hline
 {\cf "XYZ"} & CIE \emph{XYZ} coordinates. \\
-\hline 
+\hline
 {\cf "xyY"} & CIE \emph{xyY} coordinates. \\
-\hline 
+\hline
 \end{tabular}
 \end{table}
 
@@ -1693,7 +1692,7 @@ describe below.
 
 All of these point-like types are internally represented by three
 floating-point numbers that uniquely describe a position or
-direction relative to the three axes of some coordinate system.  
+direction relative to the three axes of some coordinate system.
 
 All points, vectors, and normals are described relative to some
 coordinate system.  All data provided to a shader (surface information,
@@ -1739,7 +1738,7 @@ Some computations may be easier in a coordinate system other than
 ``solid texture'' to a moving object in its \objectspace than in
 \commonspace.  For these reasons, OSL provides a built-in
 {\cf transform} function that
-allows you to transform points, vectors, and normals 
+allows you to transform points, vectors, and normals
 among different coordinate systems (see Section~\ref{sec:stdlib:geom}).  Note,
 however, that \langname does not keep track of which point variables are
 in which coordinate systems.  It is the responsibility of the shader
@@ -1759,31 +1758,31 @@ to designate transformations.
 {\cf "common"} & The coordinate system that all spatial values start out in and
 the one in which all lighting calculations are carried out.  Note that
 the choice of {\cf "common"} space may be different on each renderer. \\
-\hline 
+\hline
 {\cf "object"} & The local coordinate system of the graphics primitive (sphere,
 patch, etc.) that we are shading. \\
-\hline 
+\hline
 {\cf "shader"} & The local coordinate system active at the time that the shader
 was instanced. \\
-\hline 
+\hline
 {\cf "world"} & The world coordinate system designated in the scene. \\
-\hline 
+\hline
 {\cf "camera"} & The coordinate system with its origin at the center of
 the camera lens, $x$-axis pointing right, $y$-axis pointing up, and
 $z$-axis pointing into the screen. \\
-\hline 
+\hline
 {\cf "screen"} & The coordinate system of the camera's image plane
 (after perspective transformation, if any).  Coordinate (0,0) of {\cf
 "screen"} space is looking along the $z$-axis of \cameraspace. \\
-\hline 
+\hline
 {\cf "raster"} & 2D pixel coordinates, with (0,0) as the upper-left
 corner of the image and (xres, yres) as the lower-right corner. \\
-\hline 
+\hline
 {\cf "NDC"} & 2D Normalized Device Coordinates --- like raster space, but
 normalized so that $x$ and $y$ both run from 0 to 1 across the whole
 image, with (0,0) being at the upper left of the image, and (1,1) being
 at the lower right. \\
-\hline 
+\hline
 \end{tabular}
 \end{table}
 
@@ -1867,7 +1866,7 @@ example:
     matrix ident = 1;  // makes the identity matrix
 
     // Construct a matrix from 16 floats
-    matrix m = matrix (m00, m01, m02, m03, m10, m11, m12, m13, 
+    matrix m = matrix (m00, m01, m02, m03, m10, m11, m12, m13,
                        m20, m21, m22, m23, m30, m31, m32, m33);
 \end{code}
 
@@ -1875,7 +1874,7 @@ example:
 in a matrix with diagonal components all being $x$ and other
 components being zero (i.e., $x$ times the identity matrix).
 Constructing a matrix with 16 floats will create the matrix whose
-components are those floats, in row-major order.  
+components are those floats, in row-major order.
 
 Similar to point-like types, a {\cf matrix} may be constructed in
 reference to a named space:
@@ -1883,7 +1882,7 @@ reference to a named space:
 \begin{code}
     // Construct matrices relative to something other than "common"
     matrix q = matrix ("shader", 1);
-    matrix m = matrix ("world", m00, m01, m02, m03, m10, m11, m12, m13, 
+    matrix m = matrix ("world", m00, m01, m02, m03, m10, m11, m12, m13,
                                m20, m21, m22, m23, m30, m31, m32, m33);
 \end{code}
 
@@ -2218,7 +2217,7 @@ to its use.  For example
 The syntax for declaring a variable in \langname is:
 
 \vspace{12pt}
-\spc \emph{type} \emph{name} 
+\spc \emph{type} \emph{name}
 
 \spc \emph{type} \emph{name} = \emph{value}
 \vspace{12pt}
@@ -2283,7 +2282,7 @@ types into a single object that can be referred to by name.  The syntax
 for declaring a structure type is:
 
 \vspace{12pt}
-\spc {\cf struct} \emph{structname} {\cf \{} 
+\spc {\cf struct} \emph{structname} {\cf \{}
 
 \spc\spc \emph{type1} \emph{fieldname1} {\cf ;}
 
@@ -2309,7 +2308,7 @@ initialized with the initializer in the corresponding position, which
 is expected to be of the appropriate type.
 
 Structure elements are accessed in the same way as other C-like
-languages, using the `dot' operator: 
+languages, using the `dot' operator:
 
 \vspace{12pt}
 \spc \emph{variablename}{\cf .} \emph{fieldname}
@@ -2364,7 +2363,7 @@ assembled bit by bit at runtime.
 \item An individual element of an array (using {\cf [ ] })
 
 \item An individual component of a \color,
-\point, \vector, \normal (using {\cf [ ]}), 
+\point, \vector, \normal (using {\cf [ ]}),
 or of a \matrix (using {\cf [][]})
 
 \item prefix and postfix increment and decrement operators:
@@ -2409,7 +2408,7 @@ multiplication and matrix multiplication by the inverse of another
 matrix.
 
 The integer and bit-wise operators {\cf \%}, {\cf <<}, {\cf >>},
-{\cf \&}, {\cf |}, {\cf \textasciicircum}, and {\cf \textasciitilde} may only be 
+{\cf \&}, {\cf |}, {\cf \textasciicircum}, and {\cf \textasciitilde} may only be
 used with expressions of type \inttype.
 
 For details on which operators are allowed, please consult the operator
@@ -2461,7 +2460,7 @@ the empty string (\qkw{}).
 \item another expression enclosed in parentheses: {\cf ( )}.
   Parentheses may be used to guarantee associativity of operations.
 
-\item Type casts, specified either by having the type name in 
+\item Type casts, specified either by having the type name in
 parentheses in front of the value to cast (C-style typecasts)
 or the type name called as a constructor (C++-style type constructors):
 \begin{code}
@@ -2510,7 +2509,7 @@ allowed only if {\cf var = var OP expr} is allowed, and means exactly
 the same thing.  Please consult the operator tables for each individual
 type in Chapter~\ref{chap:types}.
 
-\item ternary operator, just like C: 
+\item ternary operator, just like C:
 
 \hspace{0.5in}  \emph{condition} {\cf ?} \emph{expr1} {\cf :} \emph{expr2}
 
@@ -2534,7 +2533,7 @@ Conditionals in \langname just like in C or C++:
 \begin{tabbing}
 \hspace{0.5in} \= \hspace{0.3in} \= \kill
 \> {\cf if (} \emph{condition} {\cf )} \\
-\> \> \emph{truestatement}  
+\> \> \emph{truestatement}
 \end{tabbing}
 
 \noindent and
@@ -2544,7 +2543,7 @@ Conditionals in \langname just like in C or C++:
 \> {\cf if (} \emph{condition} {\cf )} \\
 \> \> \emph{truestatement}  \\
 \> {\cf else} \\
-\> \> \emph{falsestatement}  
+\> \> \emph{falsestatement}
 \end{tabbing}
 
 \noindent The statements can also be entire blocks, surrounded by curly
@@ -2586,7 +2585,7 @@ possible with a {\cf while} statement:
 \begin{tabbing}
 \hspace{0.5in} \= \hspace{0.3in} \= \kill
 \> {\cf while (} \emph{condition} {\cf )} \\
-\> \> \emph{statement}  
+\> \> \emph{statement}
 \end{tabbing}
 
 Or the test may happen after the body of the loop, with a {\cf do/while}
@@ -2605,7 +2604,7 @@ loop:
 \begin{tabbing}
 \hspace{0.5in} \= \hspace{0.3in} \= \kill
 \> {\cf for (} \emph{initialization-statement} {\cf ;} \emph{condition} {\cf ;} \emph{iteration-statement} {\cf )} \\
-\> \> \emph{body}  
+\> \> \emph{body}
 \end{tabbing}
 
 \indexapi{for}
@@ -2620,7 +2619,7 @@ loop itself.  For example,
 \end{code}
 
 As with {\cf if} statements, loop conditions may be relations or
-numerical quantities (which are considered ``true'' if nonzero, 
+numerical quantities (which are considered ``true'' if nonzero,
 ``false'' if zero), or strings (considered ``true'' if nonempty,
 ``false'' if the empty string \qkw{}).
 
@@ -2698,8 +2697,8 @@ will not be noticeably different from C-style ``pass by value''
 semantics, except if you pass the same variable as two separate
 arguments to a function that modifies an argument's value.
 
-Certain functions allow optional arguments to be passed.  
-Optional arguments are key-value pairs with the key passed as an 
+Certain functions allow optional arguments to be passed.
+Optional arguments are key-value pairs with the key passed as an
 argument and the associated value passed as the subsequent argument:
 
 \begin{tabbing}
@@ -2782,7 +2781,7 @@ simply available by default in your shader.  Global variables available
 in shaders are listed in Table~\ref{tab:globalvars}.
 
 \begin{table}[H]
-\begin{tabular}{|p{1.5in}p{4in}|} 
+\begin{tabular}{|p{1.5in}p{4in}|}
 \hline
 {\bf Variable} & {\bf Description} \\
 \hline
@@ -2801,7 +2800,7 @@ displacement shader, changing this variable displaces the surface. \\
   true surface geometric normal
   of the surface at \P. \\
 \hline
-\float\ {\ce u}, {\ce v} & The 2D parametric coordinates of \P (on the 
+\float\ {\ce u}, {\ce v} & The 2D parametric coordinates of \P (on the
 		  particular geometric primitive you are shading). \\
 \hline
 \vector\ {\ce dPdu}, {\ce dPdv} & Partial derivatives $\partial
@@ -2812,13 +2811,13 @@ P/\partial u$ and $\partial P/\partial v$ tangent to the surface at \P.  \\
 %\hline
 %\color\ {\ce Cl} & Incoming light color at P. \\
 \hline
-\point\ {\ce Ps} & Position at which the light is being queried 
+\point\ {\ce Ps} & Position at which the light is being queried
     (currently only used for light attenuation shaders) \\
 %\\
 %\hline
 %\normal\ {\ce Ns} & Axis about which the light is being queried
 % (i.e., the axis passed to \illuminance), or the surface's \N if no
-% axis was passed to \illuminance). 
+% axis was passed to \illuminance).
 %\\
 %\hline
 %\point\ {\ce Pl} & Position of the light source. \\
@@ -2868,7 +2867,7 @@ P/\partial u$ and $\partial P/\partial v$ tangent to the surface at \P.  \\
 %{\cf Nl}      &       &    & R$^2$ & R \\
 {\cf Pl}      &       &    &  & R \\
 {\cf Nl}      &       &    &  & R \\
-\hline 
+\hline
 \end{tabular}
 \end{table}
 \end{comment}
@@ -2890,7 +2889,7 @@ P/\partial u$ and $\partial P/\partial v$ tangent to the surface at \P.  \\
 {\cf dtime}   & R     & R  & R       \\
 {\cf dPdtime} & R     & R  & R       \\
 \Ci           & RW    &    & RW     \\
-\hline 
+\hline
 \end{tabular}
 
 %$^1$Certain surface variables (including \N, \Ng, \I, etc.) are readable
@@ -3017,7 +3016,7 @@ operations, such as {\cf pow(-1,0.5)}.
 \emph{type} {\ce exp2} (\emph{type} x) \\
 \emph{type} {\ce expm1} (\emph{type} x)}
 \indexapi{exp()} \indexapi{exp2()} \indexapi{expm1()}
-Computes $e^x$, $2^x$, and $e^x-1$, respectively.  Note that 
+Computes $e^x$, $2^x$, and $e^x-1$, respectively.  Note that
 {\cf expm1(x)} is accurate even for very small values of $x$.
 \apiend
 
@@ -3053,7 +3052,7 @@ Computes $\sqrt{x^2+y^2}$ and $\sqrt{x^2+y^2+z^z}$, respectively.
 \apiend
 
 \apiitem{\emph{type} {\ce abs} (\emph{type} x) \\
-\emph{type} {\ce fabs} (\emph{type} x)} 
+\emph{type} {\ce fabs} (\emph{type} x)}
 \indexapi{abs()} \indexapi{fabs()}
 Absolute value of $x$.  (The two functions are synonyms.)
 \apiend
@@ -3095,7 +3094,7 @@ in OSL, {\cf fmod(a,0)} returns {\cf 0}, rather than {\cf NaN}.  Note
 that if $a < 0$, the return value will be negative.
 
 The {\cf mod()} function returns $a - b*\mbox{floor}(a/b)$, which will
-always be a positive number or zero.  
+always be a positive number or zero.
 As an example, {\cf fmod(-0.25,1.0) = -0.25}, but {\cf mod(-0.25,1.0) =
   0.75}.  For positive {\cf a} they return the same value.
 
@@ -3148,7 +3147,7 @@ NaN), 0 otherwise.  \apiend
 \apiitem{float {\ce erf} (float x) \\
 float {\ce erfc} (float x)}
 \indexapi{erf()} \indexapi{erfc()}
-The {\cf erf()} function returns the error function 
+The {\cf erf()} function returns the error function
 ${\mathrm{erf}(x) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2}} dt$.
 The {\cf erfc} returns the complementary error function {\cf 1-erf(x)}
 (useful in maintaining precision for large values of $x$).
@@ -3189,13 +3188,13 @@ to the named coordinate system.  In other words,
 
 \apiitem{float {\ce dot} (vector A, vector B)}
 \indexapi{dot()}
-Returns the inner product of the two vectors (or normals), i.e., 
+Returns the inner product of the two vectors (or normals), i.e.,
 $A \cdot B = A_x B_x + A_y B_y + A_z C_z$.
 \apiend
 
 \apiitem{vector {\ce cross} (vector A, vector B)}
 \indexapi{cross()}
-Returns the cross product of two vectors (or normals), i.e., 
+Returns the cross product of two vectors (or normals), i.e.,
 $A \times B$.
 \apiend
 
@@ -3257,12 +3256,12 @@ normalized (unit length) for this formula to work properly.
 
 \apiitem{vector {\ce refract} (vector I, vector N, float eta)}
 \indexapi{refract()}
-For incident vector {\cf I} and surface orientation {\cf N}, 
-returns the refraction direction using Snell's law. The {\cf eta} 
+For incident vector {\cf I} and surface orientation {\cf N},
+returns the refraction direction using Snell's law. The {\cf eta}
 parameter is the ratio of the index of refraction of the volume containing
 {\cf I} divided by the index of refraction of the volume being entered.
-The result is not necessarily normalized and a zero-length vector is 
-returned in the case of total internal reflection.  
+The result is not necessarily normalized and a zero-length vector is
+returned in the case of total internal reflection.
 For reference, here is the equivalent \langname of the implementation:
 
 \begin{code}
@@ -3303,7 +3302,7 @@ or about the {\cf axis} vector centered on the origin.
 
 Transform a \point, \vector, or \normal (depending on the type of the
 \emph{ptype p} argument) from the coordinate system named by
-\emph{fromspace} to the one named by \emph{tospace}.  If 
+\emph{fromspace} to the one named by \emph{tospace}.  If
 \emph{fromspace} is not supplied, $p$ is assumed to be in \commonspace
 coordinates, so the transformation will be from \commonspace to
 \emph{tospace}.  A $4 \times 4$ matrix may be passed directly rather
@@ -3421,7 +3420,7 @@ it is assumed to be transforming from \rgbspace.
 \bigspc\spc float m30, float m31, float m32, float m33)}
 \indexapi{matrix()}
 Constructs a \matrix from 16 individual \float values, in row-major
-order.  
+order.
 \apiend
 
 \apiitem{matrix {\ce matrix} (float f)}
@@ -3438,7 +3437,7 @@ Constructs a \matrix relative to the named space, multiplying it by the
 {\cf space}-to-{\cf common} transformation matrix.  If the coordinate
 system name is unknown, it will be assumed to be the identity matrix.
 
-Note that {\cf matrix (space, 1)} returns the 
+Note that {\cf matrix (space, 1)} returns the
 \emph{space}-to-{\cf common} transformation matrix. If the coordinate
 system name is unknown, it will be assumed to be the identity matrix.
 \apiend
@@ -3546,7 +3545,7 @@ or 4 (\point and \float), with a return value of either 1D (\float) or 3D
 (\color, \point, \vector, or \normal).
 
 The {\cf noisename} specifies which of a variety of possible noise
-functions will be used.  
+functions will be used.
 
 \apiitem{"perlin", "snoise"}
 \vspace{12pt}
@@ -3612,7 +3611,7 @@ derivatives.  Gabor noise allows several optional parameters to the
 \vspace{12pt}
 If {\cf anisotropic} is 0 (the default), Gabor noise
 will be isotropic.  If {\cf anisotropic} is 1, the Gabor noise will
-be anisotropic with the 3D frequency given by the {\cf direction} 
+be anisotropic with the 3D frequency given by the {\cf direction}
 vector (which defaults to {\cf (1,0,0)}).  If {\cf anisotropic} is
 2, a hybrid mode will be used which is anisotropic along the
 {\cf direction} vector, but radially isotropic perpendicular to that
@@ -3701,7 +3700,7 @@ is equivalent to {\cf noise("perlin",...coords...)}.
 \apiitem{\emph{type} {\ce pnoise} (float u, float uperiod) \\
 \emph{type} {\ce pnoise} (float u, float v, float uperiod, float vperiod) \\
 \emph{type} {\ce pnoise} (point p, point pperiod) \\
-\emph{type} {\ce pnoise} (point p, float t, point pperiod, float tperiod) 
+\emph{type} {\ce pnoise} (point p, float t, point pperiod, float tperiod)
 \smallskip \\
 \emph{type} {\ce psnoise} (float u, float uperiod) \\
 \emph{type} {\ce psnoise} (float u, float v, float uperiod, float vperiod) \\
@@ -3765,7 +3764,7 @@ each component will be interpolated separately.
 
 The type of interpolation is specified by the \emph{basis} name,
 \emph{basis} parameter, which may be any of: \qkw{catmull-rom},
-\qkw{bezier}, \qkw{bspline}, \qkw{hermite}, \qkw{linear}, or 
+\qkw{bezier}, \qkw{bspline}, \qkw{hermite}, \qkw{linear}, or
 \qkw{constant}. Some basis
 types require particular numbers of knot values -- Bezier splines
 require $3n+1$ values, Hermite splines require $2n+2$ values, and all of
@@ -3785,7 +3784,7 @@ float {\ce splineinverse} (string basis, float v, int nknots, float y[])}
 
 Computes the \emph{inverse} of the {\cf spline()} function, i.e., returns
 the value $x$ for which \\
-   \spc {\cf spline (basis, x, y...)}\\ 
+   \spc {\cf spline (basis, x, y...)}\\
 would return value
 $v$.  Results are undefined if the knots do not specify a monotonic
 (only increasing or only decreasing) set of values.
@@ -3835,7 +3834,7 @@ in $x$ between adjacent shading samples.
 \apiitem{float {\ce area} (point p)}
 \indexapi{area()}
 Returns the differential area of position $p$ corresponding to this
-shading sample.  If $p$ is the actual surface position \P, then 
+shading sample.  If $p$ is the actual surface position \P, then
 {\ce area(P)} will return the surface area of the section of the
 surface that is ``covered'' by this shading sample.
 \apiend
@@ -3854,7 +3853,7 @@ float {\ce aastep} (float edge, float s, float dedge, float ds)}
 Computes an antialiased step function, similar to {\cf step(edge,s)} but
 filtering the edge to take into account how rapidly {\cf s} and {\cf edge}
 are changing over the surface.  If the differentials {\cf ds} and/or
-{\cf dedge} are not passed explicitly, they will be automatically 
+{\cf dedge} are not passed explicitly, they will be automatically
 computed (using {\cf filterwidth()}).
 \apiend
 
@@ -3911,7 +3910,7 @@ the C language. The {\cf \%d}, {\cf \%i}, {\cf \%o}, and {\cf \%x}
 arguments expect an {\cf int} argument.  The {\cf \%f}, {\cf \%g}, and
 {\cf \%e} expect a \float, \color, point-like, or \matrix argument (for
 multi-component types such as \color, the format will be applied to each
-of the components).  The {\cf \%s} expects a {\cf string} or 
+of the components).  The {\cf \%s} expects a {\cf string} or
 {\cf closure} argument.
 
 All of the substitution commands follow the usual C/C++ formatting rules,
@@ -3966,7 +3965,7 @@ otherwise return 0.
 
 \apiitem{int {\ce stoi} (string str)}
 \indexapi{stoi()}
-Convert/decode the initial part of {\cf str} to an {\cf int} 
+Convert/decode the initial part of {\cf str} to an {\cf int}
 representation.  Base 10 is assumed.
 The return value will be {\cf 0} if the string doesn't appear to hold
 valid representation of the destination type.
@@ -4017,11 +4016,11 @@ Returns a deterministic, repeatable \emph{hash} of the string.
 \apiitem{int {\ce regex_search} (string subject, string regex) \\
 int {\ce regex_search} (string subject, int results[], string regex)}
 \indexapi{regex_search()}
-Returns 1 if any substring of \emph{subject} matches a standard POSIX 
+Returns 1 if any substring of \emph{subject} matches a standard POSIX
 regular expression \emph{regex}, 0 if it does not.
 
 In the form that also supplies a {\cf results} array, when a match is
-found, the array will be filled in as follows: 
+found, the array will be filled in as follows:
 
 \begin{tabular}{p{1.5in} p{3.5in}}
 {\cf\small results[0]} & the character index of the start of the
@@ -4185,7 +4184,7 @@ errors. The error message stored will be \qkw{} if no error occurred.
 
 \apiitem{"interp", <string>}
 \vspace{12pt}
-Overrides the texture interpolation method: \qkw{smartcubic} (the 
+Overrides the texture interpolation method: \qkw{smartcubic} (the
 default), \qkw{cubic}, \qkw{linear}, or \qkw{closest}.
 \apiend
 \vspace{-16pt}
@@ -4359,7 +4358,7 @@ The first channel to look up from the texture map (default: 0).
 
 \apiitem{"fill", <float>}
 \vspace{12pt}
-The value to return for any channels that are requested, but 
+The value to return for any channels that are requested, but
 not present in the texture file (default: 0).
 \apiend
 \vspace{-16pt}
@@ -4565,7 +4564,7 @@ maxpoints} of the data type in the file).
 
 Given a point cloud and a list of points {\cf indices[0..count-1]},
 store the attribute named by {\cf attr} for each point, respectively, in
-{\cf data[0..count-1]}.  Return 1 if successful, 0 for failure, which 
+{\cf data[0..count-1]}.  Return 1 if successful, 0 for failure, which
 could include the attribute not matching the type of {\cf data}, invalid
 indices, or an unknown point cloud file.
 
@@ -4654,19 +4653,19 @@ model.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{albedo}
   \vspace{12pt}
   Surface albedo.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness}
   \vspace{12pt}
   Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
   \apiend
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4682,7 +4681,7 @@ SIGGRAPH 1994, pp.239-246 (July, 1994).
 \apiitem{\colorclosure\ {\ce burley_diffuse_bsdf} (normal N, color albedo, float roughness)}
 \indexapi{burley_diffuse_bsdf()}
 
-Constructs a diffuse reflection BSDF based on the corresponding component of 
+Constructs a diffuse reflection BSDF based on the corresponding component of
 the Disney Principled shading model.
 
 \noindent Parameters include:
@@ -4692,19 +4691,19 @@ the Disney Principled shading model.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{albedo}
   \vspace{12pt}
   Surface albedo.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness}
   \vspace{12pt}
   Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
   \apiend
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4738,64 +4737,64 @@ interior to handle absorption and scattering inside the medium.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{U}
   \vspace{12pt}
   Tangent vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{reflection_tint}
   \vspace{12pt}
   Weight per color channel for the reflection lobe. Should be (1,1,1) for a physically-correct dielectric surface, but can be tweaked for artistic control. Set to (0,0,0) to disable reflection.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{transmission_tint}
   \vspace{12pt}
   Weight per color channel for the transmission lobe. Should be (1,1,1) for a physically-correct dielectric surface, but can be tweaked for artistic control. Set to (0,0,0) to disable transmission.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness_x}
   \vspace{12pt}
   Surface roughness in the U direction with a perceptually linear response over its range.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness_y}
   \vspace{12pt}
   Surface roughness in the V direction with a perceptually linear response
   over its range.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{ior}
   \vspace{12pt}
   Refraction index.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{distribution}
   \vspace{12pt}
   Microfacet distribution. An implementation is expected to support the
   following distributions: \qkw{ggx}
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{thinfilm_thickness}
   \vspace{12pt}
   Optional float parameter for thickness of an iridescent thin film layer on
   top of this BSDF. Given in nanometers.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{thinfilm_ior}
   \vspace{12pt}
   Optional float parameter for refraction index of the thin film layer.
   \apiend
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4820,57 +4819,57 @@ function can be used to convert from artistic to physical parameters.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{U}
   \vspace{12pt}
   Tangent vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness_x}
   \vspace{12pt}
   Surface roughness in the U direction with a perceptually linear response over its range.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness_y}
   \vspace{12pt}
   Surface roughness in the V direction with a perceptually linear response over its range.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{ior}
   \vspace{12pt}
   Refraction index.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{extinction}
   \vspace{12pt}
   Extinction coefficient.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{distribution}
   \vspace{12pt}
   Microfacet distribution. An implementation is expected to support the
   following distributions: \qkw{ggx}
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{thinfilm_thickness}
   \vspace{12pt}
   Optional float parameter for thickness of an iridescent thin film layer on
   top of this BSDF. Given in nanometers.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{thinfilm_ior}
   \vspace{12pt}
   Optional float parameter for refraction index of the thin film layer.
   \apiend
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4903,80 +4902,80 @@ handle absorption and scattering inside the medium.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{U}
   \vspace{12pt}
   Tangent vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{reflection_tint}
   \vspace{12pt}
   Weight per color channel for the reflection lobe. Set to (0,0,0) to disable
   reflection.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{transmission_tint}
   \vspace{12pt}
   Weight per color channel for the transmission lobe. Set to (0,0,0) to
   disable transmission.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness_x}
   \vspace{12pt}
   Surface roughness in the U direction with a perceptually linear response
   over its range.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness_y}
   \vspace{12pt}
   Surface roughness in the V direction with a perceptually linear response
   over its range.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{f0}
   \vspace{12pt}
   Reflectivity per color channel at facing angles.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{f90}
   \vspace{12pt}
   Reflectivity per color channel at grazing angles.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{exponent}
   \vspace{12pt}
   Variable exponent for the Schlick Fresnel curve, the default value should be
   5.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{distribution}
   \vspace{12pt}
   Microfacet distribution. An implementation is expected to support the
   following distributions: \qkw{ggx}
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{thinfilm_thickness}
   \vspace{12pt}
   Optional float parameter for thickness of an iridescent thin film layer on
   top of this BSDF. Given in nanometers.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{thinfilm_ior}
   \vspace{12pt}
   Optional float parameter for refraction index of the thin film layer.
   \apiend
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4999,19 +4998,19 @@ reflectance model.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{albedo}
   \vspace{12pt}
   Surface albedo.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness}
   \vspace{12pt}
   Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
   \apiend
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5040,13 +5039,13 @@ Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{albedo}
   \vspace{12pt}
   Single-scattering albedo of the medium.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{transmission_depth}
   \vspace{12pt}
   Distance travelled inside the medium by white light before its color becomes
@@ -5055,7 +5054,7 @@ Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
   extinction coefficient of the medium.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{transmission_color}
   \vspace{12pt}
   Desired color resulting from white light transmitted a distance of
@@ -5063,15 +5062,15 @@ Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
   this determines the extinction coefficient of the medium.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{anisotropy}
   \vspace{12pt}
   Scattering anisotropy [-1,1]. Negative values give backwards scattering,
   positive values give forward scattering, and 0.0 gives uniform scattering.
   \apiend
-  
+
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5093,19 +5092,19 @@ energy that is not reflected will be transmitted to the base closure.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{albedo}
   \vspace{12pt}
   Surface albedo.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{roughness}
   \vspace{12pt}
   Surface roughness [0,1].
   \apiend
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5131,20 +5130,20 @@ is supported and controlled by the anisotropy input.
   Single-scattering albedo of the medium.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{extinction}
   \vspace{12pt}
   Volume extinction coefficient.
   \apiend
-  
+
   \apiitem{anisotropy}
   \vspace{12pt}
   Scattering anisotropy [-1,1]. Negative values give backwards scattering,
   positive values give forward scattering, and 0.0 gives uniform scattering.
   \apiend
-  
+
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5169,7 +5168,7 @@ overlapping media.
   Single-scattering albedo of the medium.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{transmission_depth}
   \vspace{12pt}
   Distance travelled inside the medium by white light before its color becomes
@@ -5178,7 +5177,7 @@ overlapping media.
   extinction coefficient of the medium.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{transmission_color}
   \vspace{12pt}
   Desired color resulting from white light transmitted a distance of
@@ -5186,27 +5185,27 @@ overlapping media.
   this determines the extinction coefficient of the medium.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{anisotropy}
   \vspace{12pt}
   Scattering anisotropy [-1,1]. Negative values give backwards scattering,
   positive values give forward scattering, and 0.0 gives uniform scattering.
   \apiend
-  
+
   \apiitem{ior}
   \vspace{12pt}
   Refraction index of the medium.
   \apiend
   \vspace{-16pt}
-  
+
   \apiitem{priority}
   \vspace{12pt}
   Priority of this medium (for nested dielectrics).
   \apiend
   \vspace{-16pt}
-  
+
 %   \vspace{-16pt}
-  
+
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5253,7 +5252,7 @@ reflectance() calculates the directional albedo of a given top BSDF.
 \apiitem{\colorclosure\ {\ce holdout} ( )}
 \indexapi{holdout()}
 Returns a \colorclosure that does not represent any additional light
-reflection from the surface, but does signal to the renderer that 
+reflection from the surface, but does signal to the renderer that
 the surface is a \emph{holdout object} (appears transparent in
 the final output yet hides objects behind it).  ``Partial holdouts''
 may be designated by weighting the {\cf holdout()} closure by a
@@ -5298,7 +5297,7 @@ NOTE: This is not equal to 'f90' in a Schlick Fresnel parameterization.
 Output refraction index.
 \apiend
 \vspace{-16pt}
-  
+
 \apiitem{extinction}
 \vspace{12pt}
 Output extinction coefficient.
@@ -5377,7 +5376,7 @@ implemented as follows:
         float theta_i = acos (cos_theta_i);
         float alpha = max (theta_i, theta_r);
         float beta = min (theta_i, theta_r);
-        C += Cl * cos_theta_i * 
+        C += Cl * cos_theta_i *
                 (A + B * max(0,cos_phi_diff) * sin(alpha) * tan(beta));
     }
     return C;
@@ -5386,7 +5385,7 @@ implemented as follows:
 
 \apiend
 
-\apiitem{\colorclosure\ {\ce ward} (normal N, vector T, 
+\apiitem{\colorclosure\ {\ce ward} (normal N, vector T,
   float xrough, float yrough)}
 \indexapi{ward()}
 
@@ -5470,7 +5469,7 @@ objects ``behind'' the surface.  The \emph{eta} parameter is the ratio
 of the index of refraction of the medium on the ``inside'' of the
 surface divided by the index of refration of the medium on the
 ``outside'' of the surface.  The ``outside'' direction is the one
-specified by \N.  
+specified by \N.
 The refraction direction will be automatically computed based on the
 incident angle and \emph{eta}, and the radiance returned will be
 automatically scaled by the Fresnel factor for dielectrics.
@@ -5621,7 +5620,7 @@ assignment in OSL source code: {\cf int} to {\cf float}, {\cf float} to
 {\cf int} (truncation), {\cf float} (or {\cf int}) to \emph{triple}
 (replicating the value), any \emph{triple} to any other \emph{triple}.
 Additionally, the following conversions which are not allowed by
-assignment in OSL source code will also be performed by this call: 
+assignment in OSL source code will also be performed by this call:
 {\cf float} (or {\cf int}) to {\cf float[2]} (replication into both
 array elements), {\cf float[2]} to \emph{triple} (setting the third
 component to 0).
@@ -5775,9 +5774,9 @@ by the shader (via {\cf setmessage()}).
 \apiitem{float {\ce surfacearea} ()}
 \indexapi{surfacearea()}
 Returns the surface area of the area light geometry being shaded.  This
-is meant to be used in conjunction with {\cf emission()} in order to 
+is meant to be used in conjunction with {\cf emission()} in order to
 produce the correct emissive radiance given a user preference for a
-total wattage for the area light source.  The value of this function 
+total wattage for the area light source.  The value of this function
 is not expected to be meaningful for non-light shaders.
 \apiend
 
@@ -5812,7 +5811,7 @@ from the ``front'' or the ``outside'' of a closed object.
 \apiitem{int {\ce isconnected} (\emph{type} parameter)}
 \indexapi{isconnected()}
 Returns {\cf 1} if the argument is a shader parameter and is connected
-to an earlier layer in the shader group, 
+to an earlier layer in the shader group,
 {\cf 2} if the argument is a shader output parameter connected
 to a later layer in the shader group, {\cf 3} if connected to both
 earlier and later layers, otherwise returns {\cf 0}.
@@ -5910,16 +5909,16 @@ view-dependence into shaders.
 The return value is 0 if the ray missed all geometry, 1 if it hit
 anything within the distance range.
 
-The following optional key-value arguments 
+The following optional key-value arguments
 (see Section~\ref{sec:syntax:functioncalls}) can be passed:
 
 \apiitem{"mindist", <float>}
 \vspace{12pt}
 The minimum hit distance (default: 0).
 
-The units of the {\cf "mindist"} and {\cf "maxdist"} are determined by the renderer 
-and are sometimes defined by the dir vector, which can lead to unexpected 
-behavior.  So, generally, clearly written and portable shaders should pass 
+The units of the {\cf "mindist"} and {\cf "maxdist"} are determined by the renderer
+and are sometimes defined by the dir vector, which can lead to unexpected
+behavior.  So, generally, clearly written and portable shaders should pass
 a unit length (see Section~\ref{sec:stdlib:geom}) dir vector.
 \apiend
 \vspace{-16pt}
@@ -5932,7 +5931,7 @@ The maximum hit distance (default: infinite).
 
 \apiitem{"shade", <int>}
 \vspace{12pt}
-Defines whether objects hit will be shaded (default: 0).  
+Defines whether objects hit will be shaded (default: 0).
 \apiend
 \vspace{-16pt}
 
@@ -6019,7 +6018,7 @@ nothing (empty, no token).
 <number> ::= <integer>
 \alt <floating-point>
 
-<char-sequence> ::= \{ <any-char> \} 
+<char-sequence> ::= \{ <any-char> \}
 
 <stringliteral> ::= `"' <char-sequence> `"'
 
@@ -6032,12 +6031,12 @@ nothing (empty, no token).
 \begin{grammar}
 <shader-file> ::= \{ <global-declaration> \}
 
-<global-declaration> ::= <function-declaration> 
+<global-declaration> ::= <function-declaration>
 \alt <struct-declaration>
 \alt <shader-declaration>
 
-<shader-declaration> ::= \spc \\ 
-    <shadertype> <identifier> <metadata-block-opt> 
+<shader-declaration> ::= \spc \\
+    <shadertype> <identifier> <metadata-block-opt>
     "(" <shader-formal-params-opt> ")" "{" <statement-list> "}"
 
 <shadertype> ::= "displacement" |  "shader" | "surface" | "volume"
@@ -6059,7 +6058,7 @@ nothing (empty, no token).
 \section*{Declarations}
 \begin{grammar}
 
-<function-declaration> ::= \spc \\ <typespec> <identifier> 
+<function-declaration> ::= \spc \\ <typespec> <identifier>
       "(" <function-formal-params-opt> ")" "{" <statement-list> "}"
 
 <function-formal-params> ::= <function-formal-param> \{ "," <function-formal-param> \}
@@ -6101,11 +6100,11 @@ nothing (empty, no token).
 
 <init-expression> ::= <expression> | <compound-initializer>
 
-<typespec> ::= <simple-typename> 
+<typespec> ::= <simple-typename>
 \alt "closure" <simple-typename>
 \alt <identifier-structname>
 
-<simple-typename> ::= 
+<simple-typename> ::=
 "color"
 | "float"
 | "matrix"
@@ -6123,7 +6122,7 @@ nothing (empty, no token).
 
 <statement-list> ::= <statement> \{ <statement> \}
 
-<statement> ::= 
+<statement> ::=
 <compound-expression-opt> ";"
 \alt <scoped-statements>
 \alt <local-declaration>
@@ -6140,7 +6139,7 @@ nothing (empty, no token).
 
 <loop-statement> ::= \spc \\ "while" "(" <compound-expression> ")" <statement>
 \alt "do" <statement> "while" "(" <compound-expression> ")" ";"
-\alt "for" "(" <for-init-statement-opt>  <compound-expression-opt> ";" 
+\alt "for" "(" <for-init-statement-opt>  <compound-expression-opt> ";"
                 <compound-expression-opt> ")" <statement>
 
 <for-init-statement> ::= \spc \\ <expression-opt> ";"
@@ -6183,7 +6182,7 @@ nothing (empty, no token).
 \alt <variable_lvalue> "[" <expression> "]"
 \alt <variable_lvalue> "." <identifier>
 
-<variable-ref> ::= <identifier> <array-deref-opt> 
+<variable-ref> ::= <identifier> <array-deref-opt>
 
 <array-deref> ::= "[" <expression> "]"
 
@@ -6193,10 +6192,10 @@ nothing (empty, no token).
 <component-field> ::= "x" | "y" | "z" | "r" | "g" | "b"
 
 <binary-op> ::= "*" | "/" | "\%"
-\alt "+" | "-" 
+\alt "+" | "-"
 \alt "<<" | ">>"
-\alt "<" | "<=" | ">" | ">=" 
-\alt "==" | "!=" 
+\alt "<" | "<=" | ">" | ">="
+\alt "==" | "!="
 \alt "&"
 \alt "^"
 \alt "|"
@@ -6351,7 +6350,7 @@ unnecessary things or a bad idea.
 Right now, this is just a hodge-podge of topics.  Some day I will give
 it a more coherent form.
 
-\medskip 
+\medskip
 
 {\bf Meta-discussion: the editing of this chapter has NOT kept pace with
   development and solidification of the rest of the spec.  It's largely
@@ -6504,7 +6503,7 @@ anybody want to argue for any of the following to be included?
 \item Array assignment: {\cf A = B}, legal as long as {\cf A} and {\cf
   B} are the same type and have the same number of elements length?
 \item Casting to built-in types: Ability to assign an array of length 3
-  to a \color, \point, \vector, or \normal, and vice versa?  
+  to a \color, \point, \vector, or \normal, and vice versa?
 \item Array arithmetic: {\cf A + B}, and so on, defined as
   element-by-element addition, subtraction, etc., legal as long as the
   two arrays are the same type and have the same number of elements?
@@ -6612,13 +6611,13 @@ In this document, I'm tentatively using the RenderMan-inspired {\cf Ci}
 and for output radiance.  (The ``i'' is for
 \emph{incident}.)  In Gelato, we used {\cf C}, which I
 think was slightly less obtuse (though loses the advantage of being
-familiar to RenderMan experts).  
+familiar to RenderMan experts).
 
 
 \subsection{Global variables and view-dependence}
 
 Should we allow access to \I (incident viewing ray) from anyplace except
-inside the integrator?  
+inside the integrator?
 
 On one hand, it's just an invitation to inadvertently build
 view-dependence into material descriptions.
@@ -6651,7 +6650,7 @@ consistent for each ``side?''
 \subsection{Light loops -- to be, or not to be?}
 
 With closures, can we remove all facilities for an explicit loop over
-lights (i.e., what RenderMan calls {\cf illuminance})?  At least, 
+lights (i.e., what RenderMan calls {\cf illuminance})?  At least,
 unless/until we allow people to code integrators in the language itself?
 
 Or does it makes sense to allow explicit light loops, in case somebody
@@ -6674,7 +6673,7 @@ It's very tempting to extend the language itself to be able to express a
 primitive closure function or an integrator.  But I fear that (1) this
 will be more expensive than we want; and (2) we don't know the best way
 to do it yet; (3) it will require a variety of syntaxes, functions, and
-complications in the language that would not otherwise be needed.  
+complications in the language that would not otherwise be needed.
 
 So I'm currently leaning toward leaving this out of the language for
 now, and considering it for a future revision.  Comments?
@@ -6689,7 +6688,7 @@ back side of a surface; (2) Proper coherent refraction of objects
 primitive, usually employing a ``compositing'' method; (4) making an
 object ``disappear'' to form a ``stencil'' effect under shader control.
 
-It is clear that \#1 and \#2 are properly handled with our usual 
+It is clear that \#1 and \#2 are properly handled with our usual
 material closures ({\cf translucent} and {\cf refraction()},
 respectively).
 
@@ -6751,7 +6750,7 @@ But I want to throw a few additional options out here for debate:
   \end{code}
   Or even, {\cf refraction()} could serve the same purpose, and the
   renderer could just know that if the index of refraction is 1, it
-  should use the compositing trick.  
+  should use the compositing trick.
 
   Holdout mattes don't fall into this scheme especially well, so there's
   an orthogonal problem of whether to have a {\cf holdout} variable to
@@ -6922,7 +6921,7 @@ full control in the shader.
 % Canonical figure
 %\begin{figure}[ht]
 %\noindent
-%\includegraphics[width=5in]{Figures/foo} 
+%\includegraphics[width=5in]{Figures/foo}
 %\caption{Caption
 %\label{fig:foo}}
 %\end{figure}

--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -182,7 +182,7 @@ Unported License. \\
 \smallskip
 \spc \includegraphics[width=0.85in]{Figures/CC-BY.png}
 \spc http://creativecommons.org/licenses/by/4.0/
- \bigskip
+ \bigskip 
 
 
 
@@ -318,7 +318,7 @@ find are different in OSL compared to other languages:
 
   OSL shaders are evaluated in SIMD fashion, executing shaders on many
   points at once, but there is no need to burden shader writers with
-  declaring which variables need to be uniform or varying.
+  declaring which variables need to be uniform or varying.  
 
   In the open source OSL implementation, this is done both automatically
   and dynamically, meaning that a variable can switch back and forth
@@ -331,7 +331,7 @@ find are different in OSL compared to other languages:
   and use arbitrary quantities as texture coordinates and expect correct
   filtering.  This does not require that shaded points be arranged in a
   rectangular grid, or have any particular connectivity, or that any
-  "extra points" be shaded.
+  "extra points" be shaded.  
 
   In the open source OSL implementation, this is possible because
   derivatives are not computed by finite differences with neighboring
@@ -384,6 +384,7 @@ other open source packages:
 \url{http://openimageio.org}
 \item Imath \copyright\ Contributors to Imath.
 \url{http://www.openexr.com}
+\item Boost \copyright\ various authors.  \url{http://www.boost.org}
 \item LLVM \copyright\ 2003-2010 University of Illinois at
   Urbana-Champaign. \url{http://llvm.org}
 \end{itemize}
@@ -401,7 +402,7 @@ to be used by and distributed with \product.
 % readers of early drafts, sometimes questions, sometimes guideposts
 % to uncertain areas, sometimes explanations of what is to come but that
 % has not yet been fully fleshed out.
-%
+% 
 % \begin{comment}
 % Short annotations will sometimes spring up anywhere, but there's also a
 % full chapter of discussion of design choices
@@ -417,7 +418,7 @@ to be used by and distributed with \product.
 \label{chap:bigpicture}
 
 This chapter attempts to lay out the major concepts of \langname,
-define key nomenclature, and sketch out how individual shaders fit
+define key nomenclature, and sketch out how individual shaders fit 
 together in the context of a renderer as a whole.
 
 % \begin{annotate}
@@ -444,9 +445,9 @@ in its output {\cf Cout}:
 
 \medskip
 
-The shader's inputs and outputs are called \emph{shader parameters}.
+The shader's inputs and outputs are called \emph{shader parameters}.  
 Parameters have default values, specified in the shader code, but may
-also be given new values by the renderer at runtime.
+also be given new values by the renderer at runtime.  
 
 \subsection*{Shader instances}
 
@@ -743,7 +744,7 @@ are equivalent to a single whitespace character. \index{whitespace}
 
 Source code may be split into multiple lines, separated by end-of-line
 markers (carriage return and/or linefeed).  Lines may be of any length
-and end-of-line markers carry no significant difference from other
+and end-of-line markers carry no significant difference from other 
 whitespace, except that they terminate {\cf //} comments and delimit
 preprocessor directives.
 
@@ -823,11 +824,11 @@ languages: \index{reserved words}
 
 \begin{quote} {\cf
 
-bool case catch char class const delete default double
+bool case catch char class const delete default double 
 enum extern false friend
-goto inline long new operator private protected
-short signed sizeof static
-switch template this throw true try typedef
+goto inline long new operator private protected 
+short signed sizeof static 
+switch template this throw true try typedef 
 uniform union unsigned varying virtual volatile
 
 }
@@ -849,7 +850,7 @@ uniform union unsigned varying virtual volatile
 \indexapi{\#pragma}
 
 Shader source code is passed through a standard C preprocessor as a
-first step in parsing.
+first step in parsing.  
 
 Preprocessor directives are designated by a hash mark ({\cf \#}) as the
 first character on a line, followed by a preprocessor directive name.
@@ -991,13 +992,13 @@ parameters.  Formally, the grammar for a simple parameter
 declaration looks like this:
 
 \medskip
-\spc \emph{type parametername = default-expression}
+\spc \emph{type parametername = default-expression} 
 \medskip
 
 \noindent where \emph{type} is one of the data types described
 in Chapter~\ref{chap:types}, \emph{parametername} is the name of the
 parameter, and \emph{default-expression} is a valid expression
-(see Section~\ref{sec:expressions}).  Multiple parameters are
+(see Section~\ref{sec:expressions}).  Multiple parameters are 
 simply separated by commas:
 
 \medskip
@@ -1078,7 +1079,7 @@ renderer's API).
 Here is an example of a shader declaration, with several parameters:
 
 \begin{code}
-    surface wood (
+    surface wood ( 
                /* Simple params with constant initializers */
                    float Kd = 0.5,
                    color woodcolor = color (.7, .5, .3),
@@ -1162,9 +1163,9 @@ Below is an example shader declaration showing the use of shader and
 parameter metadata:
 
 \begin{code}
-    surface wood
+    surface wood 
                 [[ string help = "Realistic wood shader" ]]
-        (
+        ( 
            float Kd = 0.5
                [[ string help = "Diffuse reflectivity",
                   float min = 0, float max = 1 ]] ,
@@ -1189,7 +1190,7 @@ not affect the actual execution of the shader.  Most metadata exist only
 to be embedded in the compiled shader and able to be queried by other
 applications, such as to construct user interfaces for shader assignment
 that allow usage tips, appropriate kinds of widgets for setting each
-parameter, etc.
+parameter, etc.  
 
 The choice of metadata and their meaning is completely up to the shader
 writer and/or modeling system.  However, we propose some conventions
@@ -1592,17 +1593,17 @@ lists the built-in color spaces.
 {\cf "rgb"} & The coordinate system that all colors start out in, and
 in which the renderer expects to find colors that are set by
 your shader.   \\
-\hline
+\hline 
 {\cf "hsv"} & hue, saturation, and value. \\
-\hline
+\hline 
 {\cf "hsl"} & hue, saturation, and lightness. \\
-\hline
+\hline 
 {\cf "YIQ"} & the color space used for the NTSC television standard. \\
-\hline
+\hline 
 {\cf "XYZ"} & CIE \emph{XYZ} coordinates. \\
-\hline
+\hline 
 {\cf "xyY"} & CIE \emph{xyY} coordinates. \\
-\hline
+\hline 
 \end{tabular}
 \end{table}
 
@@ -1692,7 +1693,7 @@ describe below.
 
 All of these point-like types are internally represented by three
 floating-point numbers that uniquely describe a position or
-direction relative to the three axes of some coordinate system.
+direction relative to the three axes of some coordinate system.  
 
 All points, vectors, and normals are described relative to some
 coordinate system.  All data provided to a shader (surface information,
@@ -1738,7 +1739,7 @@ Some computations may be easier in a coordinate system other than
 ``solid texture'' to a moving object in its \objectspace than in
 \commonspace.  For these reasons, OSL provides a built-in
 {\cf transform} function that
-allows you to transform points, vectors, and normals
+allows you to transform points, vectors, and normals 
 among different coordinate systems (see Section~\ref{sec:stdlib:geom}).  Note,
 however, that \langname does not keep track of which point variables are
 in which coordinate systems.  It is the responsibility of the shader
@@ -1758,31 +1759,31 @@ to designate transformations.
 {\cf "common"} & The coordinate system that all spatial values start out in and
 the one in which all lighting calculations are carried out.  Note that
 the choice of {\cf "common"} space may be different on each renderer. \\
-\hline
+\hline 
 {\cf "object"} & The local coordinate system of the graphics primitive (sphere,
 patch, etc.) that we are shading. \\
-\hline
+\hline 
 {\cf "shader"} & The local coordinate system active at the time that the shader
 was instanced. \\
-\hline
+\hline 
 {\cf "world"} & The world coordinate system designated in the scene. \\
-\hline
+\hline 
 {\cf "camera"} & The coordinate system with its origin at the center of
 the camera lens, $x$-axis pointing right, $y$-axis pointing up, and
 $z$-axis pointing into the screen. \\
-\hline
+\hline 
 {\cf "screen"} & The coordinate system of the camera's image plane
 (after perspective transformation, if any).  Coordinate (0,0) of {\cf
 "screen"} space is looking along the $z$-axis of \cameraspace. \\
-\hline
+\hline 
 {\cf "raster"} & 2D pixel coordinates, with (0,0) as the upper-left
 corner of the image and (xres, yres) as the lower-right corner. \\
-\hline
+\hline 
 {\cf "NDC"} & 2D Normalized Device Coordinates --- like raster space, but
 normalized so that $x$ and $y$ both run from 0 to 1 across the whole
 image, with (0,0) being at the upper left of the image, and (1,1) being
 at the lower right. \\
-\hline
+\hline 
 \end{tabular}
 \end{table}
 
@@ -1866,7 +1867,7 @@ example:
     matrix ident = 1;  // makes the identity matrix
 
     // Construct a matrix from 16 floats
-    matrix m = matrix (m00, m01, m02, m03, m10, m11, m12, m13,
+    matrix m = matrix (m00, m01, m02, m03, m10, m11, m12, m13, 
                        m20, m21, m22, m23, m30, m31, m32, m33);
 \end{code}
 
@@ -1874,7 +1875,7 @@ example:
 in a matrix with diagonal components all being $x$ and other
 components being zero (i.e., $x$ times the identity matrix).
 Constructing a matrix with 16 floats will create the matrix whose
-components are those floats, in row-major order.
+components are those floats, in row-major order.  
 
 Similar to point-like types, a {\cf matrix} may be constructed in
 reference to a named space:
@@ -1882,7 +1883,7 @@ reference to a named space:
 \begin{code}
     // Construct matrices relative to something other than "common"
     matrix q = matrix ("shader", 1);
-    matrix m = matrix ("world", m00, m01, m02, m03, m10, m11, m12, m13,
+    matrix m = matrix ("world", m00, m01, m02, m03, m10, m11, m12, m13, 
                                m20, m21, m22, m23, m30, m31, m32, m33);
 \end{code}
 
@@ -2217,7 +2218,7 @@ to its use.  For example
 The syntax for declaring a variable in \langname is:
 
 \vspace{12pt}
-\spc \emph{type} \emph{name}
+\spc \emph{type} \emph{name} 
 
 \spc \emph{type} \emph{name} = \emph{value}
 \vspace{12pt}
@@ -2282,7 +2283,7 @@ types into a single object that can be referred to by name.  The syntax
 for declaring a structure type is:
 
 \vspace{12pt}
-\spc {\cf struct} \emph{structname} {\cf \{}
+\spc {\cf struct} \emph{structname} {\cf \{} 
 
 \spc\spc \emph{type1} \emph{fieldname1} {\cf ;}
 
@@ -2308,7 +2309,7 @@ initialized with the initializer in the corresponding position, which
 is expected to be of the appropriate type.
 
 Structure elements are accessed in the same way as other C-like
-languages, using the `dot' operator:
+languages, using the `dot' operator: 
 
 \vspace{12pt}
 \spc \emph{variablename}{\cf .} \emph{fieldname}
@@ -2363,7 +2364,7 @@ assembled bit by bit at runtime.
 \item An individual element of an array (using {\cf [ ] })
 
 \item An individual component of a \color,
-\point, \vector, \normal (using {\cf [ ]}),
+\point, \vector, \normal (using {\cf [ ]}), 
 or of a \matrix (using {\cf [][]})
 
 \item prefix and postfix increment and decrement operators:
@@ -2408,7 +2409,7 @@ multiplication and matrix multiplication by the inverse of another
 matrix.
 
 The integer and bit-wise operators {\cf \%}, {\cf <<}, {\cf >>},
-{\cf \&}, {\cf |}, {\cf \textasciicircum}, and {\cf \textasciitilde} may only be
+{\cf \&}, {\cf |}, {\cf \textasciicircum}, and {\cf \textasciitilde} may only be 
 used with expressions of type \inttype.
 
 For details on which operators are allowed, please consult the operator
@@ -2460,7 +2461,7 @@ the empty string (\qkw{}).
 \item another expression enclosed in parentheses: {\cf ( )}.
   Parentheses may be used to guarantee associativity of operations.
 
-\item Type casts, specified either by having the type name in
+\item Type casts, specified either by having the type name in 
 parentheses in front of the value to cast (C-style typecasts)
 or the type name called as a constructor (C++-style type constructors):
 \begin{code}
@@ -2509,7 +2510,7 @@ allowed only if {\cf var = var OP expr} is allowed, and means exactly
 the same thing.  Please consult the operator tables for each individual
 type in Chapter~\ref{chap:types}.
 
-\item ternary operator, just like C:
+\item ternary operator, just like C: 
 
 \hspace{0.5in}  \emph{condition} {\cf ?} \emph{expr1} {\cf :} \emph{expr2}
 
@@ -2533,7 +2534,7 @@ Conditionals in \langname just like in C or C++:
 \begin{tabbing}
 \hspace{0.5in} \= \hspace{0.3in} \= \kill
 \> {\cf if (} \emph{condition} {\cf )} \\
-\> \> \emph{truestatement}
+\> \> \emph{truestatement}  
 \end{tabbing}
 
 \noindent and
@@ -2543,7 +2544,7 @@ Conditionals in \langname just like in C or C++:
 \> {\cf if (} \emph{condition} {\cf )} \\
 \> \> \emph{truestatement}  \\
 \> {\cf else} \\
-\> \> \emph{falsestatement}
+\> \> \emph{falsestatement}  
 \end{tabbing}
 
 \noindent The statements can also be entire blocks, surrounded by curly
@@ -2585,7 +2586,7 @@ possible with a {\cf while} statement:
 \begin{tabbing}
 \hspace{0.5in} \= \hspace{0.3in} \= \kill
 \> {\cf while (} \emph{condition} {\cf )} \\
-\> \> \emph{statement}
+\> \> \emph{statement}  
 \end{tabbing}
 
 Or the test may happen after the body of the loop, with a {\cf do/while}
@@ -2604,7 +2605,7 @@ loop:
 \begin{tabbing}
 \hspace{0.5in} \= \hspace{0.3in} \= \kill
 \> {\cf for (} \emph{initialization-statement} {\cf ;} \emph{condition} {\cf ;} \emph{iteration-statement} {\cf )} \\
-\> \> \emph{body}
+\> \> \emph{body}  
 \end{tabbing}
 
 \indexapi{for}
@@ -2619,7 +2620,7 @@ loop itself.  For example,
 \end{code}
 
 As with {\cf if} statements, loop conditions may be relations or
-numerical quantities (which are considered ``true'' if nonzero,
+numerical quantities (which are considered ``true'' if nonzero, 
 ``false'' if zero), or strings (considered ``true'' if nonempty,
 ``false'' if the empty string \qkw{}).
 
@@ -2697,8 +2698,8 @@ will not be noticeably different from C-style ``pass by value''
 semantics, except if you pass the same variable as two separate
 arguments to a function that modifies an argument's value.
 
-Certain functions allow optional arguments to be passed.
-Optional arguments are key-value pairs with the key passed as an
+Certain functions allow optional arguments to be passed.  
+Optional arguments are key-value pairs with the key passed as an 
 argument and the associated value passed as the subsequent argument:
 
 \begin{tabbing}
@@ -2781,7 +2782,7 @@ simply available by default in your shader.  Global variables available
 in shaders are listed in Table~\ref{tab:globalvars}.
 
 \begin{table}[H]
-\begin{tabular}{|p{1.5in}p{4in}|}
+\begin{tabular}{|p{1.5in}p{4in}|} 
 \hline
 {\bf Variable} & {\bf Description} \\
 \hline
@@ -2800,7 +2801,7 @@ displacement shader, changing this variable displaces the surface. \\
   true surface geometric normal
   of the surface at \P. \\
 \hline
-\float\ {\ce u}, {\ce v} & The 2D parametric coordinates of \P (on the
+\float\ {\ce u}, {\ce v} & The 2D parametric coordinates of \P (on the 
 		  particular geometric primitive you are shading). \\
 \hline
 \vector\ {\ce dPdu}, {\ce dPdv} & Partial derivatives $\partial
@@ -2811,13 +2812,13 @@ P/\partial u$ and $\partial P/\partial v$ tangent to the surface at \P.  \\
 %\hline
 %\color\ {\ce Cl} & Incoming light color at P. \\
 \hline
-\point\ {\ce Ps} & Position at which the light is being queried
+\point\ {\ce Ps} & Position at which the light is being queried 
     (currently only used for light attenuation shaders) \\
 %\\
 %\hline
 %\normal\ {\ce Ns} & Axis about which the light is being queried
 % (i.e., the axis passed to \illuminance), or the surface's \N if no
-% axis was passed to \illuminance).
+% axis was passed to \illuminance). 
 %\\
 %\hline
 %\point\ {\ce Pl} & Position of the light source. \\
@@ -2867,7 +2868,7 @@ P/\partial u$ and $\partial P/\partial v$ tangent to the surface at \P.  \\
 %{\cf Nl}      &       &    & R$^2$ & R \\
 {\cf Pl}      &       &    &  & R \\
 {\cf Nl}      &       &    &  & R \\
-\hline
+\hline 
 \end{tabular}
 \end{table}
 \end{comment}
@@ -2889,7 +2890,7 @@ P/\partial u$ and $\partial P/\partial v$ tangent to the surface at \P.  \\
 {\cf dtime}   & R     & R  & R       \\
 {\cf dPdtime} & R     & R  & R       \\
 \Ci           & RW    &    & RW     \\
-\hline
+\hline 
 \end{tabular}
 
 %$^1$Certain surface variables (including \N, \Ng, \I, etc.) are readable
@@ -3016,7 +3017,7 @@ operations, such as {\cf pow(-1,0.5)}.
 \emph{type} {\ce exp2} (\emph{type} x) \\
 \emph{type} {\ce expm1} (\emph{type} x)}
 \indexapi{exp()} \indexapi{exp2()} \indexapi{expm1()}
-Computes $e^x$, $2^x$, and $e^x-1$, respectively.  Note that
+Computes $e^x$, $2^x$, and $e^x-1$, respectively.  Note that 
 {\cf expm1(x)} is accurate even for very small values of $x$.
 \apiend
 
@@ -3052,7 +3053,7 @@ Computes $\sqrt{x^2+y^2}$ and $\sqrt{x^2+y^2+z^z}$, respectively.
 \apiend
 
 \apiitem{\emph{type} {\ce abs} (\emph{type} x) \\
-\emph{type} {\ce fabs} (\emph{type} x)}
+\emph{type} {\ce fabs} (\emph{type} x)} 
 \indexapi{abs()} \indexapi{fabs()}
 Absolute value of $x$.  (The two functions are synonyms.)
 \apiend
@@ -3094,7 +3095,7 @@ in OSL, {\cf fmod(a,0)} returns {\cf 0}, rather than {\cf NaN}.  Note
 that if $a < 0$, the return value will be negative.
 
 The {\cf mod()} function returns $a - b*\mbox{floor}(a/b)$, which will
-always be a positive number or zero.
+always be a positive number or zero.  
 As an example, {\cf fmod(-0.25,1.0) = -0.25}, but {\cf mod(-0.25,1.0) =
   0.75}.  For positive {\cf a} they return the same value.
 
@@ -3147,7 +3148,7 @@ NaN), 0 otherwise.  \apiend
 \apiitem{float {\ce erf} (float x) \\
 float {\ce erfc} (float x)}
 \indexapi{erf()} \indexapi{erfc()}
-The {\cf erf()} function returns the error function
+The {\cf erf()} function returns the error function 
 ${\mathrm{erf}(x) = \frac{2}{\sqrt{\pi}} \int_0^x e^{-t^2}} dt$.
 The {\cf erfc} returns the complementary error function {\cf 1-erf(x)}
 (useful in maintaining precision for large values of $x$).
@@ -3188,13 +3189,13 @@ to the named coordinate system.  In other words,
 
 \apiitem{float {\ce dot} (vector A, vector B)}
 \indexapi{dot()}
-Returns the inner product of the two vectors (or normals), i.e.,
+Returns the inner product of the two vectors (or normals), i.e., 
 $A \cdot B = A_x B_x + A_y B_y + A_z C_z$.
 \apiend
 
 \apiitem{vector {\ce cross} (vector A, vector B)}
 \indexapi{cross()}
-Returns the cross product of two vectors (or normals), i.e.,
+Returns the cross product of two vectors (or normals), i.e., 
 $A \times B$.
 \apiend
 
@@ -3256,12 +3257,12 @@ normalized (unit length) for this formula to work properly.
 
 \apiitem{vector {\ce refract} (vector I, vector N, float eta)}
 \indexapi{refract()}
-For incident vector {\cf I} and surface orientation {\cf N},
-returns the refraction direction using Snell's law. The {\cf eta}
+For incident vector {\cf I} and surface orientation {\cf N}, 
+returns the refraction direction using Snell's law. The {\cf eta} 
 parameter is the ratio of the index of refraction of the volume containing
 {\cf I} divided by the index of refraction of the volume being entered.
-The result is not necessarily normalized and a zero-length vector is
-returned in the case of total internal reflection.
+The result is not necessarily normalized and a zero-length vector is 
+returned in the case of total internal reflection.  
 For reference, here is the equivalent \langname of the implementation:
 
 \begin{code}
@@ -3302,7 +3303,7 @@ or about the {\cf axis} vector centered on the origin.
 
 Transform a \point, \vector, or \normal (depending on the type of the
 \emph{ptype p} argument) from the coordinate system named by
-\emph{fromspace} to the one named by \emph{tospace}.  If
+\emph{fromspace} to the one named by \emph{tospace}.  If 
 \emph{fromspace} is not supplied, $p$ is assumed to be in \commonspace
 coordinates, so the transformation will be from \commonspace to
 \emph{tospace}.  A $4 \times 4$ matrix may be passed directly rather
@@ -3420,7 +3421,7 @@ it is assumed to be transforming from \rgbspace.
 \bigspc\spc float m30, float m31, float m32, float m33)}
 \indexapi{matrix()}
 Constructs a \matrix from 16 individual \float values, in row-major
-order.
+order.  
 \apiend
 
 \apiitem{matrix {\ce matrix} (float f)}
@@ -3437,7 +3438,7 @@ Constructs a \matrix relative to the named space, multiplying it by the
 {\cf space}-to-{\cf common} transformation matrix.  If the coordinate
 system name is unknown, it will be assumed to be the identity matrix.
 
-Note that {\cf matrix (space, 1)} returns the
+Note that {\cf matrix (space, 1)} returns the 
 \emph{space}-to-{\cf common} transformation matrix. If the coordinate
 system name is unknown, it will be assumed to be the identity matrix.
 \apiend
@@ -3545,7 +3546,7 @@ or 4 (\point and \float), with a return value of either 1D (\float) or 3D
 (\color, \point, \vector, or \normal).
 
 The {\cf noisename} specifies which of a variety of possible noise
-functions will be used.
+functions will be used.  
 
 \apiitem{"perlin", "snoise"}
 \vspace{12pt}
@@ -3611,7 +3612,7 @@ derivatives.  Gabor noise allows several optional parameters to the
 \vspace{12pt}
 If {\cf anisotropic} is 0 (the default), Gabor noise
 will be isotropic.  If {\cf anisotropic} is 1, the Gabor noise will
-be anisotropic with the 3D frequency given by the {\cf direction}
+be anisotropic with the 3D frequency given by the {\cf direction} 
 vector (which defaults to {\cf (1,0,0)}).  If {\cf anisotropic} is
 2, a hybrid mode will be used which is anisotropic along the
 {\cf direction} vector, but radially isotropic perpendicular to that
@@ -3700,7 +3701,7 @@ is equivalent to {\cf noise("perlin",...coords...)}.
 \apiitem{\emph{type} {\ce pnoise} (float u, float uperiod) \\
 \emph{type} {\ce pnoise} (float u, float v, float uperiod, float vperiod) \\
 \emph{type} {\ce pnoise} (point p, point pperiod) \\
-\emph{type} {\ce pnoise} (point p, float t, point pperiod, float tperiod)
+\emph{type} {\ce pnoise} (point p, float t, point pperiod, float tperiod) 
 \smallskip \\
 \emph{type} {\ce psnoise} (float u, float uperiod) \\
 \emph{type} {\ce psnoise} (float u, float v, float uperiod, float vperiod) \\
@@ -3764,7 +3765,7 @@ each component will be interpolated separately.
 
 The type of interpolation is specified by the \emph{basis} name,
 \emph{basis} parameter, which may be any of: \qkw{catmull-rom},
-\qkw{bezier}, \qkw{bspline}, \qkw{hermite}, \qkw{linear}, or
+\qkw{bezier}, \qkw{bspline}, \qkw{hermite}, \qkw{linear}, or 
 \qkw{constant}. Some basis
 types require particular numbers of knot values -- Bezier splines
 require $3n+1$ values, Hermite splines require $2n+2$ values, and all of
@@ -3784,7 +3785,7 @@ float {\ce splineinverse} (string basis, float v, int nknots, float y[])}
 
 Computes the \emph{inverse} of the {\cf spline()} function, i.e., returns
 the value $x$ for which \\
-   \spc {\cf spline (basis, x, y...)}\\
+   \spc {\cf spline (basis, x, y...)}\\ 
 would return value
 $v$.  Results are undefined if the knots do not specify a monotonic
 (only increasing or only decreasing) set of values.
@@ -3834,7 +3835,7 @@ in $x$ between adjacent shading samples.
 \apiitem{float {\ce area} (point p)}
 \indexapi{area()}
 Returns the differential area of position $p$ corresponding to this
-shading sample.  If $p$ is the actual surface position \P, then
+shading sample.  If $p$ is the actual surface position \P, then 
 {\ce area(P)} will return the surface area of the section of the
 surface that is ``covered'' by this shading sample.
 \apiend
@@ -3853,7 +3854,7 @@ float {\ce aastep} (float edge, float s, float dedge, float ds)}
 Computes an antialiased step function, similar to {\cf step(edge,s)} but
 filtering the edge to take into account how rapidly {\cf s} and {\cf edge}
 are changing over the surface.  If the differentials {\cf ds} and/or
-{\cf dedge} are not passed explicitly, they will be automatically
+{\cf dedge} are not passed explicitly, they will be automatically 
 computed (using {\cf filterwidth()}).
 \apiend
 
@@ -3910,7 +3911,7 @@ the C language. The {\cf \%d}, {\cf \%i}, {\cf \%o}, and {\cf \%x}
 arguments expect an {\cf int} argument.  The {\cf \%f}, {\cf \%g}, and
 {\cf \%e} expect a \float, \color, point-like, or \matrix argument (for
 multi-component types such as \color, the format will be applied to each
-of the components).  The {\cf \%s} expects a {\cf string} or
+of the components).  The {\cf \%s} expects a {\cf string} or 
 {\cf closure} argument.
 
 All of the substitution commands follow the usual C/C++ formatting rules,
@@ -3965,7 +3966,7 @@ otherwise return 0.
 
 \apiitem{int {\ce stoi} (string str)}
 \indexapi{stoi()}
-Convert/decode the initial part of {\cf str} to an {\cf int}
+Convert/decode the initial part of {\cf str} to an {\cf int} 
 representation.  Base 10 is assumed.
 The return value will be {\cf 0} if the string doesn't appear to hold
 valid representation of the destination type.
@@ -4016,11 +4017,11 @@ Returns a deterministic, repeatable \emph{hash} of the string.
 \apiitem{int {\ce regex_search} (string subject, string regex) \\
 int {\ce regex_search} (string subject, int results[], string regex)}
 \indexapi{regex_search()}
-Returns 1 if any substring of \emph{subject} matches a standard POSIX
+Returns 1 if any substring of \emph{subject} matches a standard POSIX 
 regular expression \emph{regex}, 0 if it does not.
 
 In the form that also supplies a {\cf results} array, when a match is
-found, the array will be filled in as follows:
+found, the array will be filled in as follows: 
 
 \begin{tabular}{p{1.5in} p{3.5in}}
 {\cf\small results[0]} & the character index of the start of the
@@ -4184,7 +4185,7 @@ errors. The error message stored will be \qkw{} if no error occurred.
 
 \apiitem{"interp", <string>}
 \vspace{12pt}
-Overrides the texture interpolation method: \qkw{smartcubic} (the
+Overrides the texture interpolation method: \qkw{smartcubic} (the 
 default), \qkw{cubic}, \qkw{linear}, or \qkw{closest}.
 \apiend
 \vspace{-16pt}
@@ -4358,7 +4359,7 @@ The first channel to look up from the texture map (default: 0).
 
 \apiitem{"fill", <float>}
 \vspace{12pt}
-The value to return for any channels that are requested, but
+The value to return for any channels that are requested, but 
 not present in the texture file (default: 0).
 \apiend
 \vspace{-16pt}
@@ -4564,7 +4565,7 @@ maxpoints} of the data type in the file).
 
 Given a point cloud and a list of points {\cf indices[0..count-1]},
 store the attribute named by {\cf attr} for each point, respectively, in
-{\cf data[0..count-1]}.  Return 1 if successful, 0 for failure, which
+{\cf data[0..count-1]}.  Return 1 if successful, 0 for failure, which 
 could include the attribute not matching the type of {\cf data}, invalid
 indices, or an unknown point cloud file.
 
@@ -4653,19 +4654,19 @@ model.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{albedo}
   \vspace{12pt}
   Surface albedo.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness}
   \vspace{12pt}
   Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
   \apiend
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4681,7 +4682,7 @@ SIGGRAPH 1994, pp.239-246 (July, 1994).
 \apiitem{\colorclosure\ {\ce burley_diffuse_bsdf} (normal N, color albedo, float roughness)}
 \indexapi{burley_diffuse_bsdf()}
 
-Constructs a diffuse reflection BSDF based on the corresponding component of
+Constructs a diffuse reflection BSDF based on the corresponding component of 
 the Disney Principled shading model.
 
 \noindent Parameters include:
@@ -4691,19 +4692,19 @@ the Disney Principled shading model.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{albedo}
   \vspace{12pt}
   Surface albedo.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness}
   \vspace{12pt}
   Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
   \apiend
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4737,64 +4738,64 @@ interior to handle absorption and scattering inside the medium.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{U}
   \vspace{12pt}
   Tangent vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{reflection_tint}
   \vspace{12pt}
   Weight per color channel for the reflection lobe. Should be (1,1,1) for a physically-correct dielectric surface, but can be tweaked for artistic control. Set to (0,0,0) to disable reflection.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{transmission_tint}
   \vspace{12pt}
   Weight per color channel for the transmission lobe. Should be (1,1,1) for a physically-correct dielectric surface, but can be tweaked for artistic control. Set to (0,0,0) to disable transmission.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness_x}
   \vspace{12pt}
   Surface roughness in the U direction with a perceptually linear response over its range.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness_y}
   \vspace{12pt}
   Surface roughness in the V direction with a perceptually linear response
   over its range.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{ior}
   \vspace{12pt}
   Refraction index.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{distribution}
   \vspace{12pt}
   Microfacet distribution. An implementation is expected to support the
   following distributions: \qkw{ggx}
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{thinfilm_thickness}
   \vspace{12pt}
   Optional float parameter for thickness of an iridescent thin film layer on
   top of this BSDF. Given in nanometers.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{thinfilm_ior}
   \vspace{12pt}
   Optional float parameter for refraction index of the thin film layer.
   \apiend
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4819,57 +4820,57 @@ function can be used to convert from artistic to physical parameters.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{U}
   \vspace{12pt}
   Tangent vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness_x}
   \vspace{12pt}
   Surface roughness in the U direction with a perceptually linear response over its range.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness_y}
   \vspace{12pt}
   Surface roughness in the V direction with a perceptually linear response over its range.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{ior}
   \vspace{12pt}
   Refraction index.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{extinction}
   \vspace{12pt}
   Extinction coefficient.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{distribution}
   \vspace{12pt}
   Microfacet distribution. An implementation is expected to support the
   following distributions: \qkw{ggx}
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{thinfilm_thickness}
   \vspace{12pt}
   Optional float parameter for thickness of an iridescent thin film layer on
   top of this BSDF. Given in nanometers.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{thinfilm_ior}
   \vspace{12pt}
   Optional float parameter for refraction index of the thin film layer.
   \apiend
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4902,80 +4903,80 @@ handle absorption and scattering inside the medium.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{U}
   \vspace{12pt}
   Tangent vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{reflection_tint}
   \vspace{12pt}
   Weight per color channel for the reflection lobe. Set to (0,0,0) to disable
   reflection.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{transmission_tint}
   \vspace{12pt}
   Weight per color channel for the transmission lobe. Set to (0,0,0) to
   disable transmission.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness_x}
   \vspace{12pt}
   Surface roughness in the U direction with a perceptually linear response
   over its range.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness_y}
   \vspace{12pt}
   Surface roughness in the V direction with a perceptually linear response
   over its range.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{f0}
   \vspace{12pt}
   Reflectivity per color channel at facing angles.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{f90}
   \vspace{12pt}
   Reflectivity per color channel at grazing angles.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{exponent}
   \vspace{12pt}
   Variable exponent for the Schlick Fresnel curve, the default value should be
   5.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{distribution}
   \vspace{12pt}
   Microfacet distribution. An implementation is expected to support the
   following distributions: \qkw{ggx}
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{thinfilm_thickness}
   \vspace{12pt}
   Optional float parameter for thickness of an iridescent thin film layer on
   top of this BSDF. Given in nanometers.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{thinfilm_ior}
   \vspace{12pt}
   Optional float parameter for refraction index of the thin film layer.
   \apiend
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -4998,19 +4999,19 @@ reflectance model.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{albedo}
   \vspace{12pt}
   Surface albedo.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness}
   \vspace{12pt}
   Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
   \apiend
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5039,13 +5040,13 @@ Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{albedo}
   \vspace{12pt}
   Single-scattering albedo of the medium.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{transmission_depth}
   \vspace{12pt}
   Distance travelled inside the medium by white light before its color becomes
@@ -5054,7 +5055,7 @@ Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
   extinction coefficient of the medium.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{transmission_color}
   \vspace{12pt}
   Desired color resulting from white light transmitted a distance of
@@ -5062,15 +5063,15 @@ Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
   this determines the extinction coefficient of the medium.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{anisotropy}
   \vspace{12pt}
   Scattering anisotropy [-1,1]. Negative values give backwards scattering,
   positive values give forward scattering, and 0.0 gives uniform scattering.
   \apiend
-
+  
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5092,19 +5093,19 @@ energy that is not reflected will be transmitted to the base closure.
   Normal vector of the surface point being shaded.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{albedo}
   \vspace{12pt}
   Surface albedo.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{roughness}
   \vspace{12pt}
   Surface roughness [0,1].
   \apiend
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5130,20 +5131,20 @@ is supported and controlled by the anisotropy input.
   Single-scattering albedo of the medium.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{extinction}
   \vspace{12pt}
   Volume extinction coefficient.
   \apiend
-
+  
   \apiitem{anisotropy}
   \vspace{12pt}
   Scattering anisotropy [-1,1]. Negative values give backwards scattering,
   positive values give forward scattering, and 0.0 gives uniform scattering.
   \apiend
-
+  
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5168,7 +5169,7 @@ overlapping media.
   Single-scattering albedo of the medium.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{transmission_depth}
   \vspace{12pt}
   Distance travelled inside the medium by white light before its color becomes
@@ -5177,7 +5178,7 @@ overlapping media.
   extinction coefficient of the medium.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{transmission_color}
   \vspace{12pt}
   Desired color resulting from white light transmitted a distance of
@@ -5185,27 +5186,27 @@ overlapping media.
   this determines the extinction coefficient of the medium.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{anisotropy}
   \vspace{12pt}
   Scattering anisotropy [-1,1]. Negative values give backwards scattering,
   positive values give forward scattering, and 0.0 gives uniform scattering.
   \apiend
-
+  
   \apiitem{ior}
   \vspace{12pt}
   Refraction index of the medium.
   \apiend
   \vspace{-16pt}
-
+  
   \apiitem{priority}
   \vspace{12pt}
   Priority of this medium (for nested dielectrics).
   \apiend
   \vspace{-16pt}
-
+  
 %   \vspace{-16pt}
-
+  
   % \apiitem{label}
   % \vspace{12pt}
   % Optional string parameter to name this component. For use in AOVs / LPEs.
@@ -5252,7 +5253,7 @@ reflectance() calculates the directional albedo of a given top BSDF.
 \apiitem{\colorclosure\ {\ce holdout} ( )}
 \indexapi{holdout()}
 Returns a \colorclosure that does not represent any additional light
-reflection from the surface, but does signal to the renderer that
+reflection from the surface, but does signal to the renderer that 
 the surface is a \emph{holdout object} (appears transparent in
 the final output yet hides objects behind it).  ``Partial holdouts''
 may be designated by weighting the {\cf holdout()} closure by a
@@ -5297,7 +5298,7 @@ NOTE: This is not equal to 'f90' in a Schlick Fresnel parameterization.
 Output refraction index.
 \apiend
 \vspace{-16pt}
-
+  
 \apiitem{extinction}
 \vspace{12pt}
 Output extinction coefficient.
@@ -5376,7 +5377,7 @@ implemented as follows:
         float theta_i = acos (cos_theta_i);
         float alpha = max (theta_i, theta_r);
         float beta = min (theta_i, theta_r);
-        C += Cl * cos_theta_i *
+        C += Cl * cos_theta_i * 
                 (A + B * max(0,cos_phi_diff) * sin(alpha) * tan(beta));
     }
     return C;
@@ -5385,7 +5386,7 @@ implemented as follows:
 
 \apiend
 
-\apiitem{\colorclosure\ {\ce ward} (normal N, vector T,
+\apiitem{\colorclosure\ {\ce ward} (normal N, vector T, 
   float xrough, float yrough)}
 \indexapi{ward()}
 
@@ -5469,7 +5470,7 @@ objects ``behind'' the surface.  The \emph{eta} parameter is the ratio
 of the index of refraction of the medium on the ``inside'' of the
 surface divided by the index of refration of the medium on the
 ``outside'' of the surface.  The ``outside'' direction is the one
-specified by \N.
+specified by \N.  
 The refraction direction will be automatically computed based on the
 incident angle and \emph{eta}, and the radiance returned will be
 automatically scaled by the Fresnel factor for dielectrics.
@@ -5620,7 +5621,7 @@ assignment in OSL source code: {\cf int} to {\cf float}, {\cf float} to
 {\cf int} (truncation), {\cf float} (or {\cf int}) to \emph{triple}
 (replicating the value), any \emph{triple} to any other \emph{triple}.
 Additionally, the following conversions which are not allowed by
-assignment in OSL source code will also be performed by this call:
+assignment in OSL source code will also be performed by this call: 
 {\cf float} (or {\cf int}) to {\cf float[2]} (replication into both
 array elements), {\cf float[2]} to \emph{triple} (setting the third
 component to 0).
@@ -5774,9 +5775,9 @@ by the shader (via {\cf setmessage()}).
 \apiitem{float {\ce surfacearea} ()}
 \indexapi{surfacearea()}
 Returns the surface area of the area light geometry being shaded.  This
-is meant to be used in conjunction with {\cf emission()} in order to
+is meant to be used in conjunction with {\cf emission()} in order to 
 produce the correct emissive radiance given a user preference for a
-total wattage for the area light source.  The value of this function
+total wattage for the area light source.  The value of this function 
 is not expected to be meaningful for non-light shaders.
 \apiend
 
@@ -5811,7 +5812,7 @@ from the ``front'' or the ``outside'' of a closed object.
 \apiitem{int {\ce isconnected} (\emph{type} parameter)}
 \indexapi{isconnected()}
 Returns {\cf 1} if the argument is a shader parameter and is connected
-to an earlier layer in the shader group,
+to an earlier layer in the shader group, 
 {\cf 2} if the argument is a shader output parameter connected
 to a later layer in the shader group, {\cf 3} if connected to both
 earlier and later layers, otherwise returns {\cf 0}.
@@ -5909,16 +5910,16 @@ view-dependence into shaders.
 The return value is 0 if the ray missed all geometry, 1 if it hit
 anything within the distance range.
 
-The following optional key-value arguments
+The following optional key-value arguments 
 (see Section~\ref{sec:syntax:functioncalls}) can be passed:
 
 \apiitem{"mindist", <float>}
 \vspace{12pt}
 The minimum hit distance (default: 0).
 
-The units of the {\cf "mindist"} and {\cf "maxdist"} are determined by the renderer
-and are sometimes defined by the dir vector, which can lead to unexpected
-behavior.  So, generally, clearly written and portable shaders should pass
+The units of the {\cf "mindist"} and {\cf "maxdist"} are determined by the renderer 
+and are sometimes defined by the dir vector, which can lead to unexpected 
+behavior.  So, generally, clearly written and portable shaders should pass 
 a unit length (see Section~\ref{sec:stdlib:geom}) dir vector.
 \apiend
 \vspace{-16pt}
@@ -5931,7 +5932,7 @@ The maximum hit distance (default: infinite).
 
 \apiitem{"shade", <int>}
 \vspace{12pt}
-Defines whether objects hit will be shaded (default: 0).
+Defines whether objects hit will be shaded (default: 0).  
 \apiend
 \vspace{-16pt}
 
@@ -6018,7 +6019,7 @@ nothing (empty, no token).
 <number> ::= <integer>
 \alt <floating-point>
 
-<char-sequence> ::= \{ <any-char> \}
+<char-sequence> ::= \{ <any-char> \} 
 
 <stringliteral> ::= `"' <char-sequence> `"'
 
@@ -6031,12 +6032,12 @@ nothing (empty, no token).
 \begin{grammar}
 <shader-file> ::= \{ <global-declaration> \}
 
-<global-declaration> ::= <function-declaration>
+<global-declaration> ::= <function-declaration> 
 \alt <struct-declaration>
 \alt <shader-declaration>
 
-<shader-declaration> ::= \spc \\
-    <shadertype> <identifier> <metadata-block-opt>
+<shader-declaration> ::= \spc \\ 
+    <shadertype> <identifier> <metadata-block-opt> 
     "(" <shader-formal-params-opt> ")" "{" <statement-list> "}"
 
 <shadertype> ::= "displacement" |  "shader" | "surface" | "volume"
@@ -6058,7 +6059,7 @@ nothing (empty, no token).
 \section*{Declarations}
 \begin{grammar}
 
-<function-declaration> ::= \spc \\ <typespec> <identifier>
+<function-declaration> ::= \spc \\ <typespec> <identifier> 
       "(" <function-formal-params-opt> ")" "{" <statement-list> "}"
 
 <function-formal-params> ::= <function-formal-param> \{ "," <function-formal-param> \}
@@ -6100,11 +6101,11 @@ nothing (empty, no token).
 
 <init-expression> ::= <expression> | <compound-initializer>
 
-<typespec> ::= <simple-typename>
+<typespec> ::= <simple-typename> 
 \alt "closure" <simple-typename>
 \alt <identifier-structname>
 
-<simple-typename> ::=
+<simple-typename> ::= 
 "color"
 | "float"
 | "matrix"
@@ -6122,7 +6123,7 @@ nothing (empty, no token).
 
 <statement-list> ::= <statement> \{ <statement> \}
 
-<statement> ::=
+<statement> ::= 
 <compound-expression-opt> ";"
 \alt <scoped-statements>
 \alt <local-declaration>
@@ -6139,7 +6140,7 @@ nothing (empty, no token).
 
 <loop-statement> ::= \spc \\ "while" "(" <compound-expression> ")" <statement>
 \alt "do" <statement> "while" "(" <compound-expression> ")" ";"
-\alt "for" "(" <for-init-statement-opt>  <compound-expression-opt> ";"
+\alt "for" "(" <for-init-statement-opt>  <compound-expression-opt> ";" 
                 <compound-expression-opt> ")" <statement>
 
 <for-init-statement> ::= \spc \\ <expression-opt> ";"
@@ -6182,7 +6183,7 @@ nothing (empty, no token).
 \alt <variable_lvalue> "[" <expression> "]"
 \alt <variable_lvalue> "." <identifier>
 
-<variable-ref> ::= <identifier> <array-deref-opt>
+<variable-ref> ::= <identifier> <array-deref-opt> 
 
 <array-deref> ::= "[" <expression> "]"
 
@@ -6192,10 +6193,10 @@ nothing (empty, no token).
 <component-field> ::= "x" | "y" | "z" | "r" | "g" | "b"
 
 <binary-op> ::= "*" | "/" | "\%"
-\alt "+" | "-"
+\alt "+" | "-" 
 \alt "<<" | ">>"
-\alt "<" | "<=" | ">" | ">="
-\alt "==" | "!="
+\alt "<" | "<=" | ">" | ">=" 
+\alt "==" | "!=" 
 \alt "&"
 \alt "^"
 \alt "|"
@@ -6350,7 +6351,7 @@ unnecessary things or a bad idea.
 Right now, this is just a hodge-podge of topics.  Some day I will give
 it a more coherent form.
 
-\medskip
+\medskip 
 
 {\bf Meta-discussion: the editing of this chapter has NOT kept pace with
   development and solidification of the rest of the spec.  It's largely
@@ -6503,7 +6504,7 @@ anybody want to argue for any of the following to be included?
 \item Array assignment: {\cf A = B}, legal as long as {\cf A} and {\cf
   B} are the same type and have the same number of elements length?
 \item Casting to built-in types: Ability to assign an array of length 3
-  to a \color, \point, \vector, or \normal, and vice versa?
+  to a \color, \point, \vector, or \normal, and vice versa?  
 \item Array arithmetic: {\cf A + B}, and so on, defined as
   element-by-element addition, subtraction, etc., legal as long as the
   two arrays are the same type and have the same number of elements?
@@ -6611,13 +6612,13 @@ In this document, I'm tentatively using the RenderMan-inspired {\cf Ci}
 and for output radiance.  (The ``i'' is for
 \emph{incident}.)  In Gelato, we used {\cf C}, which I
 think was slightly less obtuse (though loses the advantage of being
-familiar to RenderMan experts).
+familiar to RenderMan experts).  
 
 
 \subsection{Global variables and view-dependence}
 
 Should we allow access to \I (incident viewing ray) from anyplace except
-inside the integrator?
+inside the integrator?  
 
 On one hand, it's just an invitation to inadvertently build
 view-dependence into material descriptions.
@@ -6650,7 +6651,7 @@ consistent for each ``side?''
 \subsection{Light loops -- to be, or not to be?}
 
 With closures, can we remove all facilities for an explicit loop over
-lights (i.e., what RenderMan calls {\cf illuminance})?  At least,
+lights (i.e., what RenderMan calls {\cf illuminance})?  At least, 
 unless/until we allow people to code integrators in the language itself?
 
 Or does it makes sense to allow explicit light loops, in case somebody
@@ -6673,7 +6674,7 @@ It's very tempting to extend the language itself to be able to express a
 primitive closure function or an integrator.  But I fear that (1) this
 will be more expensive than we want; and (2) we don't know the best way
 to do it yet; (3) it will require a variety of syntaxes, functions, and
-complications in the language that would not otherwise be needed.
+complications in the language that would not otherwise be needed.  
 
 So I'm currently leaning toward leaving this out of the language for
 now, and considering it for a future revision.  Comments?
@@ -6688,7 +6689,7 @@ back side of a surface; (2) Proper coherent refraction of objects
 primitive, usually employing a ``compositing'' method; (4) making an
 object ``disappear'' to form a ``stencil'' effect under shader control.
 
-It is clear that \#1 and \#2 are properly handled with our usual
+It is clear that \#1 and \#2 are properly handled with our usual 
 material closures ({\cf translucent} and {\cf refraction()},
 respectively).
 
@@ -6750,7 +6751,7 @@ But I want to throw a few additional options out here for debate:
   \end{code}
   Or even, {\cf refraction()} could serve the same purpose, and the
   renderer could just know that if the index of refraction is 1, it
-  should use the compositing trick.
+  should use the compositing trick.  
 
   Holdout mattes don't fall into this scheme especially well, so there's
   an orthogonal problem of whether to have a {\cf holdout} variable to
@@ -6921,7 +6922,7 @@ full control in the shader.
 % Canonical figure
 %\begin{figure}[ht]
 %\noindent
-%\includegraphics[width=5in]{Figures/foo}
+%\includegraphics[width=5in]{Figures/foo} 
 %\caption{Caption
 %\label{fig:foo}}
 %\end{figure}

--- a/src/liboslcomp/CMakeLists.txt
+++ b/src/liboslcomp/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries (${local_lib}
         # For OpenEXR <= 2.3:
         ${ILMBASE_LIBRARIES}
     PRIVATE
-        ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
+        ${CMAKE_DL_LIBS}
         ${CLANG_LIBRARIES} ${LLVM_LIBRARIES} ${LLVM_LDFLAGS}
         ${LLVM_SYSTEM_LIBRARIES})
 

--- a/src/liboslcomp/osllex.l
+++ b/src/liboslcomp/osllex.l
@@ -361,7 +361,7 @@ preprocess (const char *str, OSLCompilerImpl* oslcompiler, YYLTYPE* yyloc_param)
                     ++len;
                 std::string filename (f, len);
                 // Make it relative to the working directory, so error output
-                // isn't hugely cluttered (and also to make Boost::wave's
+                // isn't hugely cluttered (and also to make the preprocessor's
                 // error output match the standard cpp.
                 if (filename.find (oslcompiler->cwd()) == 0) {
                     filename.erase (0, oslcompiler->cwd().size());
@@ -371,6 +371,8 @@ preprocess (const char *str, OSLCompilerImpl* oslcompiler, YYLTYPE* yyloc_param)
                 }
                 ustring ufilename(filename);
                 oslcompiler->filename (ufilename);
+                // TODO: We no longer use Boost Wave, so verify if the
+                // workaround below is still needed ..
                 // Spooky workaround for Boost Wave bug: force_include
                 // is broken and doesn't give us the right lines/files, so
                 // instead we forcefully insert a '#include "stdosl.h"' into

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -197,7 +197,7 @@ if (USE_LLVM_BITCODE)
     list(APPEND include_dirs ${IMATH_INCLUDES})
     list(APPEND include_dirs ${OPENEXR_INCLUDES})
     list(APPEND include_dirs ${OpenImageIO_INCLUDES})
-    list(APPEND include_dirs ${Boost_INCLUDE_DIRS})
+    list(APPEND include_dirs ${ROBINMAP_INCLUDES})
 
     EMBED_LLVM_BITCODE_IN_CPP ( "${llvm_ops_srcs}" "_host" "osl_llvm_compiled_ops" lib_src "" "${include_dirs}")
 
@@ -580,7 +580,6 @@ target_link_libraries (${local_lib}
         ${ILMBASE_LIBRARIES}
     PRIVATE
         pugixml::pugixml
-        tsl::robin_map
         ${CMAKE_DL_LIBS}
         ${CLANG_LIBRARIES}
         ${LLVM_LIBRARIES} ${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBRARIES}
@@ -614,17 +613,17 @@ install_targets (${local_lib})
 # Unit tests
 if (OSL_BUILD_TESTS AND BUILD_TESTING)
     add_executable (accum_test accum_test.cpp)
-    target_link_libraries (accum_test PRIVATE oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (accum_test PRIVATE oslexec ${CMAKE_DL_LIBS})
     set_target_properties (accum_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_accum ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/accum_test)
 
     add_executable (dual_test dual_test.cpp)
-    target_link_libraries (dual_test PRIVATE OpenImageIO::OpenImageIO ${ILMBASE_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (dual_test PRIVATE OpenImageIO::OpenImageIO ${ILMBASE_LIBRARIES} ${CMAKE_DL_LIBS})
     set_target_properties (dual_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_dual ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dual_test)
 
     add_executable (llvmutil_test llvmutil_test.cpp)
-    target_link_libraries (llvmutil_test PRIVATE oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (llvmutil_test PRIVATE oslexec ${CMAKE_DL_LIBS})
     set_target_properties (llvmutil_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_llvmutil ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/llvmutil_test)
 endif ()

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -525,7 +525,7 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
             OpenImageIO::OpenImageIO
         )
     if (partio_FOUND)
-        target_link_libraries(${batched_target_lib} PRIVATE partio::partio)
+        target_link_libraries(${batched_target_lib} PRIVATE partio::partio ZLIB::ZLIB)
         target_compile_definitions (${batched_target_lib} PRIVATE USE_PARTIO=1)
     endif ()
         
@@ -548,7 +548,7 @@ target_compile_definitions (${local_lib}
         OSL_OPTIX_VERSION="${OPTIX_VERSION}"
     )
 if (partio_FOUND)
-    target_link_libraries(${local_lib} PRIVATE partio::partio)
+    target_link_libraries(${local_lib} PRIVATE partio::partio ZLIB::ZLIB)
     target_compile_definitions (${local_lib} PRIVATE USE_PARTIO=1)
 endif ()
 

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -62,13 +62,13 @@ set ( liboslexec_target_srcs
    ../liboslnoise/wide/wide_gabor_hybrid_disabled
    ../liboslnoise/wide/wide_gabor_hybrid_enabled
    ../liboslnoise/wide/wide_gabor_isotropic_disabled
-   ../liboslnoise/wide/wide_gabor_isotropic_enabled   
+   ../liboslnoise/wide/wide_gabor_isotropic_enabled
    ../liboslnoise/wide/wide_gabor3_anisotropic_disabled
    ../liboslnoise/wide/wide_gabor3_anisotropic_enabled
    ../liboslnoise/wide/wide_gabor3_hybrid_disabled
    ../liboslnoise/wide/wide_gabor3_hybrid_enabled
    ../liboslnoise/wide/wide_gabor3_isotropic_disabled
-   ../liboslnoise/wide/wide_gabor3_isotropic_enabled   
+   ../liboslnoise/wide/wide_gabor3_isotropic_enabled
     )
 
 
@@ -95,9 +95,9 @@ set ( liboslexec_override_limits
    ../liboslnoise/wide/wide_gabor3_hybrid_disabled
    ../liboslnoise/wide/wide_gabor3_hybrid_enabled
    ../liboslnoise/wide/wide_gabor3_isotropic_disabled
-   ../liboslnoise/wide/wide_gabor3_isotropic_enabled   
+   ../liboslnoise/wide/wide_gabor3_isotropic_enabled
     )
-    
+
 set ( liboslexec_require_INF_NaN
     shadingsys.cpp
     wide/wide_shadingsys
@@ -129,14 +129,14 @@ set (lib_src
           journal.cpp
     )
 if (OSL_BUILD_BATCHED)
-    list(APPEND lib_src 
+    list(APPEND lib_src
           batched_analysis.cpp
           batched_backendllvm.cpp
           batched_llvm_gen.cpp
           batched_llvm_instance.cpp
           batched_rendservices.cpp
         )
-endif()    
+endif()
 
 if (BUILD_SHARED_LIBS)
     # oslcomp symbols used in oslexec
@@ -162,7 +162,7 @@ set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTAN
 
 macro ( REQUIRE_INF_NAN SRC )
     if (CMAKE_COMPILER_IS_INTELCLANG)
-        # if -ffast-math is enabled to to the underlying compiler, 
+        # if -ffast-math is enabled to to the underlying compiler,
         # inf's and NaN's may not be handled properly (by design)
         if (MSVC)
             set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS "/fp:precise")
@@ -172,9 +172,9 @@ macro ( REQUIRE_INF_NAN SRC )
             # Disabling fast-math should be enough to enable proper support of INF and NaN
             #set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS "-fno-fast-math")
             # We can explicitly honor inf, nans, and signed 0's
-            set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS 
-                "-fhonor-infinities" 
-                "-fhonor-nans" 
+            set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS
+                "-fhonor-infinities"
+                "-fhonor-nans"
                 "-fsigned-zeros")
         endif()
     endif()
@@ -184,7 +184,7 @@ endmacro ( )
 foreach(src ${lib_src})
     if (${src} IN_LIST liboslexec_require_INF_NaN)
         set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/${src}")
-        REQUIRE_INF_NAN ( ${SRC} )  
+        REQUIRE_INF_NAN ( ${SRC} )
     endif()
 endforeach(src)
 
@@ -197,14 +197,14 @@ if (USE_LLVM_BITCODE)
     list(APPEND include_dirs ${IMATH_INCLUDES})
     list(APPEND include_dirs ${OPENEXR_INCLUDES})
     list(APPEND include_dirs ${OpenImageIO_INCLUDES})
-    list(APPEND include_dirs ${Boost_INCLUDE_DIRS})
+    list(APPEND include_dirs ${tsl-robin-map_INCLUDE_DIRS})
 
     EMBED_LLVM_BITCODE_IN_CPP ( "${llvm_ops_srcs}" "_host" "osl_llvm_compiled_ops" lib_src "" "${include_dirs}")
 
     set (rs_dependent_ops_srcs
          opmatrix.cpp opfmt.cpp
          )
-    # Achieve the effect of absorbing osl_llvm_compiled_ops by adding its 
+    # Achieve the effect of absorbing osl_llvm_compiled_ops by adding its
     # sources to rs_dependent_ops_srcs which avoids having to do it at runtime.
     list (APPEND rs_dependent_ops_srcs ${llvm_ops_srcs})
 
@@ -263,8 +263,8 @@ endif ()
 # For each target specific shared library being built, we need
 # we need to let a couple source files know so they can build
 # function mappings for those targets
-set_property(SOURCE "batched_llvm_instance.cpp"  "shadingsys.cpp"  
-    APPEND PROPERTY COMPILE_DEFINITIONS ${BATCHED_SUPPORT_DEFINES}) 
+set_property(SOURCE "batched_llvm_instance.cpp"  "shadingsys.cpp"
+    APPEND PROPERTY COMPILE_DEFINITIONS ${BATCHED_SUPPORT_DEFINES})
 
 set (BATCHED_TARGET_LIBS)
 foreach(batched_target ${BATCHED_TARGET_LIST})
@@ -279,28 +279,28 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
     if (NUM_TARGET_OPTS EQUAL 3)
         list (GET TARGET_OPTS 2 TARGET_OPT_FMA)
         set (TARGET_ISA "${TARGET_OPT_ISA}_${TARGET_OPT_FMA}")
-    endif() 
+    endif()
     string (SUBSTRING ${TARGET_OPT_SIZE} 1 -1 TARGET_BATCH_SIZE)
-    # Strategy is to make a copy of each cpp in liboslexec_target_srcs for 
-    # each target batch width and ISA combination, applying compiler flags to define 
+    # Strategy is to make a copy of each cpp in liboslexec_target_srcs for
+    # each target batch width and ISA combination, applying compiler flags to define
     # -D__OSL_WIDTH=[4|8|16]
     # -D__OSL_TARGET_ISA=[AVX512|AVX2|AVX|SSE4_2]
     # and compiler flags to choose correct target ISA for your compiler
     # You may then add/remove the desired  ${TARGET_SOURCES_B[4|8|16]_[AVX512|AVX2|AVX|SSE4_2]}
-    # to your add_library call 
+    # to your add_library call
     set (TARGET_LIB_SOURCES)
     set (TARGET_CXX_DEFS)
     set (TARGET_CXX_OPTS)
-    
+
     list (APPEND TARGET_CXX_OPTS
         "-I${CMAKE_CURRENT_SOURCE_DIR}/wide"
         "-I${CMAKE_CURRENT_SOURCE_DIR}/../liboslnoise/wide"
         )
-        
+
     list (APPEND TARGET_CXX_DEFS
         "__OSL_WIDTH=${TARGET_BATCH_SIZE}"
-        "__OSL_TARGET_ISA=${TARGET_ISA}"        
-        "OSL_OPENMP_SIMD"        
+        "__OSL_TARGET_ISA=${TARGET_ISA}"
+        "OSL_OPENMP_SIMD"
         )
 
     if (CMAKE_COMPILER_IS_INTEL)
@@ -319,20 +319,20 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
             else ()
                 message (FATAL_ERROR "Unknown ISA=${TARGET_OPT_ISA} extract from USE_BATCHED entry ${batched_target}")
             endif ()
-            
+
             if (${TARGET_OPT_FMA} STREQUAL "noFMA")
                 list (APPEND TARGET_CXX_OPTS "/Qfma-")
             endif ()
-            
-            list (APPEND TARGET_CXX_OPTS 
-                "/Qprec-div" 
+
+            list (APPEND TARGET_CXX_OPTS
+                "/Qprec-div"
                 "/Qopenmp-simd"
                 )
             if (VEC_REPORT)
                 list (APPEND TARGET_CXX_OPTS "/Qopt-report:5")
             endif ()
-                
-                
+
+
         else ()
             if (${TARGET_OPT_ISA} STREQUAL "AVX512")
                 list (APPEND TARGET_CXX_OPTS "-xCORE-AVX512")
@@ -348,27 +348,27 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
             else ()
                 message (FATAL_ERROR "Unknown ISA=${TARGET_OPT_ISA} extract from USE_BATCHED entry ${batched_target}")
             endif ()
-            
+
             if (${TARGET_OPT_FMA} STREQUAL "noFMA")
                 list (APPEND TARGET_CXX_OPTS "-no-fma")
             endif ()
-            
-            list (APPEND TARGET_CXX_OPTS 
-                "-prec-div" 
+
+            list (APPEND TARGET_CXX_OPTS
+                "-prec-div"
                 "-qopenmp-simd"
                 "-qno-opt-multiple-gather-scatter-by-shuffles"
                 )
-                
+
             if (VEC_REPORT)
                 list (APPEND TARGET_CXX_OPTS "-qopt-report=5")
             endif ()
-                
+
         endif ()
     endif ()
-    
+
     if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
         # REQUIRES CLANG 7+ to use successfully vectorize with OpenMP simd
-        
+
         if (${TARGET_OPT_ISA} STREQUAL "AVX512")
             list (APPEND TARGET_CXX_OPTS "-march=skylake-avx512")
             if (${TARGET_BATCH_SIZE} STREQUAL "16")
@@ -383,27 +383,27 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         else ()
             message (FATAL_ERROR "Unknown ISA=${TARGET_OPT_ISA} extract from USE_BATCHED entry ${batched_target}")
         endif ()
-        
+
         if (${TARGET_OPT_FMA} STREQUAL "noFMA")
             # Do NOT use "-mno-fma" as it may lower ISA to one without any FMA
-            # instructions (AVX512->AVX2).  Our intent is to not generate 
-            # FMA's but still use the available instructions and register 
-            # width. However math library calls may use still end up using 
-            # FMA's, but lets try turning of fused math ops because many OSL 
+            # instructions (AVX512->AVX2).  Our intent is to not generate
+            # FMA's but still use the available instructions and register
+            # width. However math library calls may use still end up using
+            # FMA's, but lets try turning of fused math ops because many OSL
             # math functions are from OIIO/IMath headers generate non FMA
             list (APPEND TARGET_CXX_OPTS "-ffp-contract=off")
         endif ()
-        
+
         if (NOT CMAKE_COMPILER_IS_INTELCLANG)
             # large SIMD function loops will exceed llvm's -inline-threshold default of 225.
-            # remark: loop not vectorized: call instruction cannot be vectorized [-Rpass-analysis]     
-            # choose to increase that limit via compiler flags vs. 
-            # workaround with __attribute__((flatten))     
+            # remark: loop not vectorized: call instruction cannot be vectorized [-Rpass-analysis]
+            # choose to increase that limit via compiler flags vs.
+            # workaround with __attribute__((flatten))
             list (APPEND TARGET_CXX_OPTS "-mllvm" "-inline-threshold=100000")
             # NOTE: INTELCLANG we use icx/icc specific "#pragma force inline recursive"
             #       to only inline the SIMD loops contents vs. everything.
         endif ()
-            
+
         # For loops with small loop bodies, clang was unrolling the loop before
         # #pragma omp simd
         # was processed.  Thus there was no loop left for the pragma to apply to
@@ -418,30 +418,30 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         else ()
             list (APPEND TARGET_CXX_OPTS "-fopenmp")
         endif ()
-        
+
         if (VEC_REPORT)
             if (CMAKE_COMPILER_IS_INTELCLANG)
-                list (APPEND TARGET_CXX_OPTS 
+                list (APPEND TARGET_CXX_OPTS
                     "-qopt-report=3"
                     )
             else ()
-                list (APPEND TARGET_CXX_OPTS 
-                    "-Rpass=loop-vectorize" 
-                    "-Rpass-analysis=loop-vectorize" 
+                list (APPEND TARGET_CXX_OPTS
+                    "-Rpass=loop-vectorize"
+                    "-Rpass-analysis=loop-vectorize"
                     # Uncomment next section to investigate failures in vectorization
                     #"-Rpass-missed=loop-vectorize"
                     )
             endif ()
         endif ()
     endif ()
-    
-    
+
+
     if (CMAKE_COMPILER_IS_GNUCC)
         # Experimental, not exhaustively tested with GCC.
         # More compiler options may be needed to successfully vectorize
-        # complex control flow 
+        # complex control flow
         list (APPEND TARGET_CXX_OPTS "-finline-limit=1000000")
-        
+
         if (${TARGET_OPT_ISA} STREQUAL "AVX512")
             list (APPEND TARGET_CXX_OPTS "-march=skylake-avx512")
             if (NOT ${GCC_VERSION} VERSION_LESS 8.1)
@@ -458,32 +458,32 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         else ()
             message (FATAL_ERROR "Unknown ISA=${TARGET_OPT_ISA} extract from USE_BATCHED entry ${batched_target}")
         endif ()
-        
+
         if (${TARGET_OPT_FMA} STREQUAL "noFMA")
             # Do NOT use "-mno-fma" as it may lower ISA to one without any FMA
-            # instructions (AVX512->AVX2).  Our intent is to not generate 
-            # FMA's but still use the available instructions and register 
-            # width. However math library calls may use still end up using 
-            # FMA's, but lets try turning of fused math ops because many OSL 
+            # instructions (AVX512->AVX2).  Our intent is to not generate
+            # FMA's but still use the available instructions and register
+            # width. However math library calls may use still end up using
+            # FMA's, but lets try turning of fused math ops because many OSL
             # math functions are from OIIO/IMath headers generate non FMA
             list (APPEND TARGET_CXX_OPTS "-ffp-contract=off")
         endif ()
-        
+
         list (APPEND TARGET_CXX_OPTS "-fopenmp-simd")
-    endif ()    
-        
+    endif ()
+
     foreach(target_src ${liboslexec_target_srcs})
         set(TARGET_SRC "${CMAKE_CURRENT_BINARY_DIR}/${target_src}_${batched_target}.cpp")
-        set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/${target_src}.cpp")        
+        set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/${target_src}.cpp")
         CONFIGURE_FILE("${SRC}" ${TARGET_SRC} COPYONLY)
         list(APPEND TARGET_LIB_SOURCES "${TARGET_SRC}")
-        
+
         set_property(SOURCE ${TARGET_SRC}
             APPEND PROPERTY COMPILE_DEFINITIONS ${TARGET_CXX_DEFS})
-            
-        set_property(SOURCE ${TARGET_SRC}  
+
+        set_property(SOURCE ${TARGET_SRC}
             APPEND PROPERTY COMPILE_OPTIONS ${TARGET_CXX_OPTS})
-            
+
         if (${target_src} IN_LIST liboslexec_override_limits)
             if (CMAKE_COMPILER_IS_INTEL)
                 if (MSVC)
@@ -493,9 +493,9 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
                 endif()
             endif()
         endif()
-        
+
         if (${target_src} IN_LIST liboslexec_require_INF_NaN)
-            REQUIRE_INF_NAN ( ${TARGET_SRC} ) 
+            REQUIRE_INF_NAN ( ${TARGET_SRC} )
         endif()
 
         if (CMAKE_COMPILER_IS_INTELCLANG)
@@ -503,16 +503,16 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
                 # NOTE: Some files still require increasing
                 #       inlining threshold to successfully vectorize.
                 #       Retest with future compiler versions
-                set_property(SOURCE ${TARGET_SRC} APPEND PROPERTY COMPILE_OPTIONS 
+                set_property(SOURCE ${TARGET_SRC} APPEND PROPERTY COMPILE_OPTIONS
                     "-mllvm" "-inline-threshold=100000")
             endif()
         endif()
 
 
     endforeach(target_src)
-    
+
     add_library ( ${batched_target_lib} MODULE ${TARGET_LIB_SOURCES} )
-      
+
     target_include_directories (${batched_target_lib}
         PUBLIC
             ${CMAKE_INSTALL_FULL_INCLUDEDIR}
@@ -526,7 +526,7 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         target_link_libraries(${batched_target_lib} PRIVATE partio::partio)
         target_compile_definitions (${batched_target_lib} PRIVATE USE_PARTIO=1)
     endif ()
-        
+
 endforeach(batched_target)
 
 add_library (${local_lib} ${lib_src})
@@ -580,7 +580,7 @@ target_link_libraries (${local_lib}
         ${ILMBASE_LIBRARIES}
     PRIVATE
         pugixml::pugixml
-        ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
+        ${CMAKE_DL_LIBS}
         ${CLANG_LIBRARIES}
         ${LLVM_LIBRARIES} ${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBRARIES}
     )
@@ -613,17 +613,17 @@ install_targets (${local_lib})
 # Unit tests
 if (OSL_BUILD_TESTS AND BUILD_TESTING)
     add_executable (accum_test accum_test.cpp)
-    target_link_libraries (accum_test PRIVATE oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (accum_test PRIVATE oslexec ${CMAKE_DL_LIBS})
     set_target_properties (accum_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_accum ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/accum_test)
 
     add_executable (dual_test dual_test.cpp)
-    target_link_libraries (dual_test PRIVATE OpenImageIO::OpenImageIO ${ILMBASE_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (dual_test PRIVATE OpenImageIO::OpenImageIO ${ILMBASE_LIBRARIES} ${CMAKE_DL_LIBS})
     set_target_properties (dual_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_dual ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dual_test)
 
     add_executable (llvmutil_test llvmutil_test.cpp)
-    target_link_libraries (llvmutil_test PRIVATE oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (llvmutil_test PRIVATE oslexec ${CMAKE_DL_LIBS})
     set_target_properties (llvmutil_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_llvmutil ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/llvmutil_test)
 endif ()

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -517,6 +517,8 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         PUBLIC
             ${CMAKE_INSTALL_FULL_INCLUDEDIR}
             ${IMATH_INCLUDES}
+        PRIVATE
+            ${tsl-robin-map_INCLUDE_DIRS}
         )
     target_link_libraries (${batched_target_lib}
         PUBLIC
@@ -535,6 +537,7 @@ target_include_directories (${local_lib}
         ${CMAKE_INSTALL_FULL_INCLUDEDIR}
         ${IMATH_INCLUDES}
     PRIVATE
+        ${tsl-robin-map_INCLUDE_DIRS}
         "${CMAKE_SOURCE_DIR}/src/liboslcomp"
     )
 target_compile_definitions (${local_lib}
@@ -580,6 +583,7 @@ target_link_libraries (${local_lib}
         ${ILMBASE_LIBRARIES}
     PRIVATE
         pugixml::pugixml
+        tsl::robin_map
         ${CMAKE_DL_LIBS}
         ${CLANG_LIBRARIES}
         ${LLVM_LIBRARIES} ${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBRARIES}

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -517,6 +517,8 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         PUBLIC
             ${CMAKE_INSTALL_FULL_INCLUDEDIR}
             ${IMATH_INCLUDES}
+        PRIVATE
+            ${ROBINMAP_INCLUDES}
         )
     target_link_libraries (${batched_target_lib}
         PUBLIC
@@ -536,6 +538,7 @@ target_include_directories (${local_lib}
         ${IMATH_INCLUDES}
     PRIVATE
         "${CMAKE_SOURCE_DIR}/src/liboslcomp"
+        ${ROBINMAP_INCLUDES}
     )
 target_compile_definitions (${local_lib}
     PRIVATE

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -62,13 +62,13 @@ set ( liboslexec_target_srcs
    ../liboslnoise/wide/wide_gabor_hybrid_disabled
    ../liboslnoise/wide/wide_gabor_hybrid_enabled
    ../liboslnoise/wide/wide_gabor_isotropic_disabled
-   ../liboslnoise/wide/wide_gabor_isotropic_enabled
+   ../liboslnoise/wide/wide_gabor_isotropic_enabled   
    ../liboslnoise/wide/wide_gabor3_anisotropic_disabled
    ../liboslnoise/wide/wide_gabor3_anisotropic_enabled
    ../liboslnoise/wide/wide_gabor3_hybrid_disabled
    ../liboslnoise/wide/wide_gabor3_hybrid_enabled
    ../liboslnoise/wide/wide_gabor3_isotropic_disabled
-   ../liboslnoise/wide/wide_gabor3_isotropic_enabled
+   ../liboslnoise/wide/wide_gabor3_isotropic_enabled   
     )
 
 
@@ -95,9 +95,9 @@ set ( liboslexec_override_limits
    ../liboslnoise/wide/wide_gabor3_hybrid_disabled
    ../liboslnoise/wide/wide_gabor3_hybrid_enabled
    ../liboslnoise/wide/wide_gabor3_isotropic_disabled
-   ../liboslnoise/wide/wide_gabor3_isotropic_enabled
+   ../liboslnoise/wide/wide_gabor3_isotropic_enabled   
     )
-
+    
 set ( liboslexec_require_INF_NaN
     shadingsys.cpp
     wide/wide_shadingsys
@@ -129,14 +129,14 @@ set (lib_src
           journal.cpp
     )
 if (OSL_BUILD_BATCHED)
-    list(APPEND lib_src
+    list(APPEND lib_src 
           batched_analysis.cpp
           batched_backendllvm.cpp
           batched_llvm_gen.cpp
           batched_llvm_instance.cpp
           batched_rendservices.cpp
         )
-endif()
+endif()    
 
 if (BUILD_SHARED_LIBS)
     # oslcomp symbols used in oslexec
@@ -162,7 +162,7 @@ set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTAN
 
 macro ( REQUIRE_INF_NAN SRC )
     if (CMAKE_COMPILER_IS_INTELCLANG)
-        # if -ffast-math is enabled to to the underlying compiler,
+        # if -ffast-math is enabled to to the underlying compiler, 
         # inf's and NaN's may not be handled properly (by design)
         if (MSVC)
             set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS "/fp:precise")
@@ -172,9 +172,9 @@ macro ( REQUIRE_INF_NAN SRC )
             # Disabling fast-math should be enough to enable proper support of INF and NaN
             #set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS "-fno-fast-math")
             # We can explicitly honor inf, nans, and signed 0's
-            set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS
-                "-fhonor-infinities"
-                "-fhonor-nans"
+            set_property(SOURCE ${SRC} APPEND PROPERTY COMPILE_OPTIONS 
+                "-fhonor-infinities" 
+                "-fhonor-nans" 
                 "-fsigned-zeros")
         endif()
     endif()
@@ -184,7 +184,7 @@ endmacro ( )
 foreach(src ${lib_src})
     if (${src} IN_LIST liboslexec_require_INF_NaN)
         set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/${src}")
-        REQUIRE_INF_NAN ( ${SRC} )
+        REQUIRE_INF_NAN ( ${SRC} )  
     endif()
 endforeach(src)
 
@@ -197,14 +197,14 @@ if (USE_LLVM_BITCODE)
     list(APPEND include_dirs ${IMATH_INCLUDES})
     list(APPEND include_dirs ${OPENEXR_INCLUDES})
     list(APPEND include_dirs ${OpenImageIO_INCLUDES})
-    list(APPEND include_dirs ${tsl-robin-map_INCLUDE_DIRS})
+    list(APPEND include_dirs ${Boost_INCLUDE_DIRS})
 
     EMBED_LLVM_BITCODE_IN_CPP ( "${llvm_ops_srcs}" "_host" "osl_llvm_compiled_ops" lib_src "" "${include_dirs}")
 
     set (rs_dependent_ops_srcs
          opmatrix.cpp opfmt.cpp
          )
-    # Achieve the effect of absorbing osl_llvm_compiled_ops by adding its
+    # Achieve the effect of absorbing osl_llvm_compiled_ops by adding its 
     # sources to rs_dependent_ops_srcs which avoids having to do it at runtime.
     list (APPEND rs_dependent_ops_srcs ${llvm_ops_srcs})
 
@@ -263,8 +263,8 @@ endif ()
 # For each target specific shared library being built, we need
 # we need to let a couple source files know so they can build
 # function mappings for those targets
-set_property(SOURCE "batched_llvm_instance.cpp"  "shadingsys.cpp"
-    APPEND PROPERTY COMPILE_DEFINITIONS ${BATCHED_SUPPORT_DEFINES})
+set_property(SOURCE "batched_llvm_instance.cpp"  "shadingsys.cpp"  
+    APPEND PROPERTY COMPILE_DEFINITIONS ${BATCHED_SUPPORT_DEFINES}) 
 
 set (BATCHED_TARGET_LIBS)
 foreach(batched_target ${BATCHED_TARGET_LIST})
@@ -279,28 +279,28 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
     if (NUM_TARGET_OPTS EQUAL 3)
         list (GET TARGET_OPTS 2 TARGET_OPT_FMA)
         set (TARGET_ISA "${TARGET_OPT_ISA}_${TARGET_OPT_FMA}")
-    endif()
+    endif() 
     string (SUBSTRING ${TARGET_OPT_SIZE} 1 -1 TARGET_BATCH_SIZE)
-    # Strategy is to make a copy of each cpp in liboslexec_target_srcs for
-    # each target batch width and ISA combination, applying compiler flags to define
+    # Strategy is to make a copy of each cpp in liboslexec_target_srcs for 
+    # each target batch width and ISA combination, applying compiler flags to define 
     # -D__OSL_WIDTH=[4|8|16]
     # -D__OSL_TARGET_ISA=[AVX512|AVX2|AVX|SSE4_2]
     # and compiler flags to choose correct target ISA for your compiler
     # You may then add/remove the desired  ${TARGET_SOURCES_B[4|8|16]_[AVX512|AVX2|AVX|SSE4_2]}
-    # to your add_library call
+    # to your add_library call 
     set (TARGET_LIB_SOURCES)
     set (TARGET_CXX_DEFS)
     set (TARGET_CXX_OPTS)
-
+    
     list (APPEND TARGET_CXX_OPTS
         "-I${CMAKE_CURRENT_SOURCE_DIR}/wide"
         "-I${CMAKE_CURRENT_SOURCE_DIR}/../liboslnoise/wide"
         )
-
+        
     list (APPEND TARGET_CXX_DEFS
         "__OSL_WIDTH=${TARGET_BATCH_SIZE}"
-        "__OSL_TARGET_ISA=${TARGET_ISA}"
-        "OSL_OPENMP_SIMD"
+        "__OSL_TARGET_ISA=${TARGET_ISA}"        
+        "OSL_OPENMP_SIMD"        
         )
 
     if (CMAKE_COMPILER_IS_INTEL)
@@ -319,20 +319,20 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
             else ()
                 message (FATAL_ERROR "Unknown ISA=${TARGET_OPT_ISA} extract from USE_BATCHED entry ${batched_target}")
             endif ()
-
+            
             if (${TARGET_OPT_FMA} STREQUAL "noFMA")
                 list (APPEND TARGET_CXX_OPTS "/Qfma-")
             endif ()
-
-            list (APPEND TARGET_CXX_OPTS
-                "/Qprec-div"
+            
+            list (APPEND TARGET_CXX_OPTS 
+                "/Qprec-div" 
                 "/Qopenmp-simd"
                 )
             if (VEC_REPORT)
                 list (APPEND TARGET_CXX_OPTS "/Qopt-report:5")
             endif ()
-
-
+                
+                
         else ()
             if (${TARGET_OPT_ISA} STREQUAL "AVX512")
                 list (APPEND TARGET_CXX_OPTS "-xCORE-AVX512")
@@ -348,27 +348,27 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
             else ()
                 message (FATAL_ERROR "Unknown ISA=${TARGET_OPT_ISA} extract from USE_BATCHED entry ${batched_target}")
             endif ()
-
+            
             if (${TARGET_OPT_FMA} STREQUAL "noFMA")
                 list (APPEND TARGET_CXX_OPTS "-no-fma")
             endif ()
-
-            list (APPEND TARGET_CXX_OPTS
-                "-prec-div"
+            
+            list (APPEND TARGET_CXX_OPTS 
+                "-prec-div" 
                 "-qopenmp-simd"
                 "-qno-opt-multiple-gather-scatter-by-shuffles"
                 )
-
+                
             if (VEC_REPORT)
                 list (APPEND TARGET_CXX_OPTS "-qopt-report=5")
             endif ()
-
+                
         endif ()
     endif ()
-
+    
     if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_APPLECLANG)
         # REQUIRES CLANG 7+ to use successfully vectorize with OpenMP simd
-
+        
         if (${TARGET_OPT_ISA} STREQUAL "AVX512")
             list (APPEND TARGET_CXX_OPTS "-march=skylake-avx512")
             if (${TARGET_BATCH_SIZE} STREQUAL "16")
@@ -383,27 +383,27 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         else ()
             message (FATAL_ERROR "Unknown ISA=${TARGET_OPT_ISA} extract from USE_BATCHED entry ${batched_target}")
         endif ()
-
+        
         if (${TARGET_OPT_FMA} STREQUAL "noFMA")
             # Do NOT use "-mno-fma" as it may lower ISA to one without any FMA
-            # instructions (AVX512->AVX2).  Our intent is to not generate
-            # FMA's but still use the available instructions and register
-            # width. However math library calls may use still end up using
-            # FMA's, but lets try turning of fused math ops because many OSL
+            # instructions (AVX512->AVX2).  Our intent is to not generate 
+            # FMA's but still use the available instructions and register 
+            # width. However math library calls may use still end up using 
+            # FMA's, but lets try turning of fused math ops because many OSL 
             # math functions are from OIIO/IMath headers generate non FMA
             list (APPEND TARGET_CXX_OPTS "-ffp-contract=off")
         endif ()
-
+        
         if (NOT CMAKE_COMPILER_IS_INTELCLANG)
             # large SIMD function loops will exceed llvm's -inline-threshold default of 225.
-            # remark: loop not vectorized: call instruction cannot be vectorized [-Rpass-analysis]
-            # choose to increase that limit via compiler flags vs.
-            # workaround with __attribute__((flatten))
+            # remark: loop not vectorized: call instruction cannot be vectorized [-Rpass-analysis]     
+            # choose to increase that limit via compiler flags vs. 
+            # workaround with __attribute__((flatten))     
             list (APPEND TARGET_CXX_OPTS "-mllvm" "-inline-threshold=100000")
             # NOTE: INTELCLANG we use icx/icc specific "#pragma force inline recursive"
             #       to only inline the SIMD loops contents vs. everything.
         endif ()
-
+            
         # For loops with small loop bodies, clang was unrolling the loop before
         # #pragma omp simd
         # was processed.  Thus there was no loop left for the pragma to apply to
@@ -418,30 +418,30 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         else ()
             list (APPEND TARGET_CXX_OPTS "-fopenmp")
         endif ()
-
+        
         if (VEC_REPORT)
             if (CMAKE_COMPILER_IS_INTELCLANG)
-                list (APPEND TARGET_CXX_OPTS
+                list (APPEND TARGET_CXX_OPTS 
                     "-qopt-report=3"
                     )
             else ()
-                list (APPEND TARGET_CXX_OPTS
-                    "-Rpass=loop-vectorize"
-                    "-Rpass-analysis=loop-vectorize"
+                list (APPEND TARGET_CXX_OPTS 
+                    "-Rpass=loop-vectorize" 
+                    "-Rpass-analysis=loop-vectorize" 
                     # Uncomment next section to investigate failures in vectorization
                     #"-Rpass-missed=loop-vectorize"
                     )
             endif ()
         endif ()
     endif ()
-
-
+    
+    
     if (CMAKE_COMPILER_IS_GNUCC)
         # Experimental, not exhaustively tested with GCC.
         # More compiler options may be needed to successfully vectorize
-        # complex control flow
+        # complex control flow 
         list (APPEND TARGET_CXX_OPTS "-finline-limit=1000000")
-
+        
         if (${TARGET_OPT_ISA} STREQUAL "AVX512")
             list (APPEND TARGET_CXX_OPTS "-march=skylake-avx512")
             if (NOT ${GCC_VERSION} VERSION_LESS 8.1)
@@ -458,32 +458,32 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         else ()
             message (FATAL_ERROR "Unknown ISA=${TARGET_OPT_ISA} extract from USE_BATCHED entry ${batched_target}")
         endif ()
-
+        
         if (${TARGET_OPT_FMA} STREQUAL "noFMA")
             # Do NOT use "-mno-fma" as it may lower ISA to one without any FMA
-            # instructions (AVX512->AVX2).  Our intent is to not generate
-            # FMA's but still use the available instructions and register
-            # width. However math library calls may use still end up using
-            # FMA's, but lets try turning of fused math ops because many OSL
+            # instructions (AVX512->AVX2).  Our intent is to not generate 
+            # FMA's but still use the available instructions and register 
+            # width. However math library calls may use still end up using 
+            # FMA's, but lets try turning of fused math ops because many OSL 
             # math functions are from OIIO/IMath headers generate non FMA
             list (APPEND TARGET_CXX_OPTS "-ffp-contract=off")
         endif ()
-
+        
         list (APPEND TARGET_CXX_OPTS "-fopenmp-simd")
-    endif ()
-
+    endif ()    
+        
     foreach(target_src ${liboslexec_target_srcs})
         set(TARGET_SRC "${CMAKE_CURRENT_BINARY_DIR}/${target_src}_${batched_target}.cpp")
-        set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/${target_src}.cpp")
+        set(SRC "${CMAKE_CURRENT_SOURCE_DIR}/${target_src}.cpp")        
         CONFIGURE_FILE("${SRC}" ${TARGET_SRC} COPYONLY)
         list(APPEND TARGET_LIB_SOURCES "${TARGET_SRC}")
-
+        
         set_property(SOURCE ${TARGET_SRC}
             APPEND PROPERTY COMPILE_DEFINITIONS ${TARGET_CXX_DEFS})
-
-        set_property(SOURCE ${TARGET_SRC}
+            
+        set_property(SOURCE ${TARGET_SRC}  
             APPEND PROPERTY COMPILE_OPTIONS ${TARGET_CXX_OPTS})
-
+            
         if (${target_src} IN_LIST liboslexec_override_limits)
             if (CMAKE_COMPILER_IS_INTEL)
                 if (MSVC)
@@ -493,9 +493,9 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
                 endif()
             endif()
         endif()
-
+        
         if (${target_src} IN_LIST liboslexec_require_INF_NaN)
-            REQUIRE_INF_NAN ( ${TARGET_SRC} )
+            REQUIRE_INF_NAN ( ${TARGET_SRC} ) 
         endif()
 
         if (CMAKE_COMPILER_IS_INTELCLANG)
@@ -503,22 +503,20 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
                 # NOTE: Some files still require increasing
                 #       inlining threshold to successfully vectorize.
                 #       Retest with future compiler versions
-                set_property(SOURCE ${TARGET_SRC} APPEND PROPERTY COMPILE_OPTIONS
+                set_property(SOURCE ${TARGET_SRC} APPEND PROPERTY COMPILE_OPTIONS 
                     "-mllvm" "-inline-threshold=100000")
             endif()
         endif()
 
 
     endforeach(target_src)
-
+    
     add_library ( ${batched_target_lib} MODULE ${TARGET_LIB_SOURCES} )
-
+      
     target_include_directories (${batched_target_lib}
         PUBLIC
             ${CMAKE_INSTALL_FULL_INCLUDEDIR}
             ${IMATH_INCLUDES}
-        PRIVATE
-            ${tsl-robin-map_INCLUDE_DIRS}
         )
     target_link_libraries (${batched_target_lib}
         PUBLIC
@@ -528,7 +526,7 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
         target_link_libraries(${batched_target_lib} PRIVATE partio::partio)
         target_compile_definitions (${batched_target_lib} PRIVATE USE_PARTIO=1)
     endif ()
-
+        
 endforeach(batched_target)
 
 add_library (${local_lib} ${lib_src})
@@ -537,7 +535,6 @@ target_include_directories (${local_lib}
         ${CMAKE_INSTALL_FULL_INCLUDEDIR}
         ${IMATH_INCLUDES}
     PRIVATE
-        ${tsl-robin-map_INCLUDE_DIRS}
         "${CMAKE_SOURCE_DIR}/src/liboslcomp"
     )
 target_compile_definitions (${local_lib}
@@ -617,17 +614,17 @@ install_targets (${local_lib})
 # Unit tests
 if (OSL_BUILD_TESTS AND BUILD_TESTING)
     add_executable (accum_test accum_test.cpp)
-    target_link_libraries (accum_test PRIVATE oslexec ${CMAKE_DL_LIBS})
+    target_link_libraries (accum_test PRIVATE oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     set_target_properties (accum_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_accum ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/accum_test)
 
     add_executable (dual_test dual_test.cpp)
-    target_link_libraries (dual_test PRIVATE OpenImageIO::OpenImageIO ${ILMBASE_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_link_libraries (dual_test PRIVATE OpenImageIO::OpenImageIO ${ILMBASE_LIBRARIES} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     set_target_properties (dual_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_dual ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dual_test)
 
     add_executable (llvmutil_test llvmutil_test.cpp)
-    target_link_libraries (llvmutil_test PRIVATE oslexec ${CMAKE_DL_LIBS})
+    target_link_libraries (llvmutil_test PRIVATE oslexec ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
     set_target_properties (llvmutil_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_llvmutil ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/llvmutil_test)
 endif ()

--- a/src/liboslexec/accum_test.cpp
+++ b/src/liboslexec/accum_test.cpp
@@ -163,7 +163,7 @@ main()
     for (int i = 0; test[i].path[0]; ++i)
         simulate(accum, test[i].path, i);
 
-    // And check. We unroll this loop for boost to give us a useful
+    // And check. We unroll this loop for the macros to give us a useful
     // error in case they fail
     OIIO_CHECK_ASSERT(aovs[beauty].check());
     OIIO_CHECK_ASSERT(aovs[diffuse2_3].check());

--- a/src/liboslexec/batched_analysis.cpp
+++ b/src/liboslexec/batched_analysis.cpp
@@ -4,12 +4,13 @@
 
 // #define OSL_DEV 1
 
-#include <boost/container/flat_set.hpp>
 #include <iterator>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#include <tsl/robin_set.h>
 
 #include <llvm/ADT/SmallVector.h>
 
@@ -154,7 +155,7 @@ does_op_implementation_require_masking(ustring opname)
 {
     // TODO: should OpDescriptor handle identifying operations that always
     // require masking vs. this lazy_lookup?  Perhaps a BatchedOpDescriptor?
-    static boost::container::flat_set<ustring> lazy_lookup(
+    static tsl::robin_set<ustring> lazy_lookup(
         { // safe_pows's implementation uses an OSL_UNLIKELY
           // which will perform a horizontal operation to check if
           // a condition is false for all data lane in order to skip
@@ -385,7 +386,7 @@ bool
 is_op_return_always_logically_boolean(ustring opname)
 {
     // Test if explicit comparison is faster or not
-    static boost::container::flat_set<ustring> lazy_lookup(
+    static tsl::robin_set<ustring> lazy_lookup(
         { Strings::op_getattribute, Strings::op_eq, Strings::op_ge,
           Strings::op_gt, Strings::op_le, Strings::op_lt, Strings::op_neq,
           Strings::op_and, Strings::op_or });

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -200,7 +200,7 @@ struct CStrHash {
     OSL_FORCEINLINE size_t operator()(const char* str) const
     {
         OSL_DASSERT(str != nullptr);
-        return OIIO::strhash(str);
+        return OIIO::Strutil::strhash(str);
     }
 };
 

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -2746,7 +2746,7 @@ BatchedBackendLLVM::run()
     // entry points, as well as for all the external functions that are
     // just declarations (not definitions) in the module (which we have
     // conveniently stashed in external_function_names).
-    tsl::robin_set<llvm::Function*> external_functions;
+    std::unordered_set<llvm::Function*> external_functions;
     external_functions.insert(init_func);
     for (int layer = 0; layer < nlayers; ++layer) {
         llvm::Function* f = funcs[layer];

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -26,9 +26,9 @@ examples), as you are just coding in C++, but there are some rules:
 * Argument passing: int and float (without derivs) are passed as int and
   float.  Aggregates (color/point/vector/normal/matrix), arrays of any
   types, or floats with derivatives are passed as a void* and to their
-  memory location you need to cast appropriately.  See the handy 
+  memory location you need to cast appropriately.  See the handy
   MAT, VEC, DFLOAT, DVEC macros for
-  handy/cheap casting of those void*'s to references to 
+  handy/cheap casting of those void*'s to references to
   Matrix44&, Vec3&, Dual2<float>&, and Dual2<Vec3>, respectively.
 
 * You must provide all allowable polymorphic and derivative combinations!
@@ -53,15 +53,15 @@ examples), as you are just coding in C++, but there are some rules:
   symbols are exported for LLVM to find them.
 
 * You may use full C++, including standard library.  You may have calls
-  to any other part of the OSL library software.  You may use Boost,
-  Ilmbase (Vec3, Matrix44, etc.) or any other external routines.  You
+  to any other part of the OSL library software.  You may use Ilmbase
+  (Vec3, Matrix44, etc.) or any other external routines.  You
   may write templates or helper functions (which do NOT need to use
   OSL_SHADEOP, since they don't need to be runtime-discoverable by LLVM.
 
 * If you need to access non-passed globals (P, N, etc.) or make renderer
   callbacks, just make the first argument to the function is an
   OpaqueExecContextPtr (void* ec) that is passed to get_*() functions to
-  the globals get_P(ec), get_N(ec), typed renderer state 
+  the globals get_P(ec), get_N(ec), typed renderer state
   get_rs<T>(ec), etc.
 
 */

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -1579,16 +1579,11 @@ RuntimeOptimizer::dealias_symbol(int symindex, int opnum)
 void
 RuntimeOptimizer::block_unalias(int symindex)
 {
-    FastIntMap::iterator i = m_block_aliases.find(symindex);
-    if (i != m_block_aliases.end())
-        i->second = -1;
+    m_block_aliases.erase(symindex);
     // In addition to the current block_aliases, unalias from any
     // saved alias lists.
-    for (auto& ba : m_block_aliases_stack) {
-        FastIntMap::iterator i = ba->find(symindex);
-        if (i != ba->end())
-            i->second = -1;
-    }
+    for (auto& ba : m_block_aliases_stack)
+        ba->erase(symindex);
 }
 
 

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -11,8 +11,8 @@
 #define USE_ROBIN_MAP 1
 
 #if USE_ROBIN_MAP
-#include <tsl/robin_map.h>
-#include <tsl/robin_set.h>
+#   include <tsl/robin_map.h>
+#   include <tsl/robin_set.h>
 #endif
 
 #include "oslexec_pvt.h"

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -11,8 +11,8 @@
 #define USE_ROBIN_MAP 1
 
 #if USE_ROBIN_MAP
-#   include <tsl/robin_map.h>
-#   include <tsl/robin_set.h>
+#    include <tsl/robin_map.h>
+#    include <tsl/robin_set.h>
 #endif
 
 #include "oslexec_pvt.h"

--- a/src/liboslexec/runtimeoptimize.h
+++ b/src/liboslexec/runtimeoptimize.h
@@ -8,9 +8,12 @@
 #include <set>
 #include <vector>
 
-#include <boost/container/flat_map.hpp>
-#include <boost/container/flat_set.hpp>
-#define USE_FLAT_MAP 1
+#define USE_ROBIN_MAP 1
+
+#if USE_ROBIN_MAP
+#include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
+#endif
 
 #include "oslexec_pvt.h"
 using namespace OSL;
@@ -21,9 +24,9 @@ OSL_NAMESPACE_ENTER
 
 namespace pvt {  // OSL::pvt
 
-#if USE_FLAT_MAP
-typedef boost::container::flat_map<int, int> FastIntMap;
-typedef boost::container::flat_set<int> FastIntSet;
+#if USE_ROBIN_MAP
+typedef tsl::robin_map<int, int> FastIntMap;
+typedef tsl::robin_set<int> FastIntSet;
 #else
 typedef std::map<int, int> FastIntMap;
 typedef std::set<int> FastIntSet;

--- a/src/liboslnoise/CMakeLists.txt
+++ b/src/liboslnoise/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries (${local_lib}
         # For OpenEXR <= 2.3:
         ${ILMBASE_LIBRARIES}
     PRIVATE
-        ${Boost_LIBRARIES} ${CMAKE_DL_LIBS}
+        ${CMAKE_DL_LIBS}
     )
 
 target_compile_features (${local_lib}

--- a/src/oslc/CMakeLists.txt
+++ b/src/oslc/CMakeLists.txt
@@ -12,5 +12,5 @@ if (NOT BUILD_SHARED_LIBS)
 endif ()
 
 add_executable ( oslc ${oslc_srcs} )
-target_link_libraries ( oslc PRIVATE oslcomp ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries ( oslc PRIVATE oslcomp ${CMAKE_DL_LIBS})
 install_targets (oslc)

--- a/src/osltoy/CMakeLists.txt
+++ b/src/osltoy/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries (osltoy
         $<TARGET_NAME_IF_EXISTS:Qt6::Core>
         $<TARGET_NAME_IF_EXISTS:Qt6::Gui>
         $<TARGET_NAME_IF_EXISTS:Qt6::Widgets>
-        ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+        ${CMAKE_DL_LIBS})
 if (Qt5_FOUND)
     target_compile_definitions(osltoy PRIVATE OSL_QT_MAJOR=5)
 endif ()

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -71,7 +71,6 @@ list(APPEND include_dirs ${CMAKE_BINARY_DIR}/include)
 list(APPEND include_dirs ${IMATH_INCLUDES})
 list(APPEND include_dirs ${OPENEXR_INCLUDES})
 list(APPEND include_dirs ${OpenImageIO_INCLUDES})
-list(APPEND include_dirs ${Boost_INCLUDE_DIRS})
 
 EMBED_LLVM_BITCODE_IN_CPP ( "${rs_srcs}" "_host" "testshade_llvm_compiled_rs" testshade_srcs "-DOSL_HOST_RS_BITCODE=1" "${include_dirs}")
 
@@ -116,7 +115,7 @@ if (NOT CODECOV)
     target_link_libraries (testshade_dso
                            PRIVATE
                                OpenImageIO::OpenImageIO
-                               ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} )
+                               ${CMAKE_DL_LIBS} )
     install (TARGETS testshade_dso RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
     osl_optix_target(libtestshade)
 endif ()


### PR DESCRIPTION
## Description

Replace the last few uses of boost with robin-map (which is already a dependency for OIIO, although it is new for OSL itself) and functions in OIIO.

## Tests

Testsuite passes on my mac laptop. Will keep an eye on how the CI steps go.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
