### PR TITLE
build: llvm 18 compat issue - include libclangAPINotes

### DIFF
--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -109,7 +109,7 @@ endif ()
 foreach (COMPONENT clangFrontend clangDriver clangSerialization
                    clangParse clangSema clangAnalysis clangAST
                    clangASTMatchers clangBasic clangEdit clangLex
-                   clangSupport)
+                   clangSupport clangAPINotes)
     find_library ( _CLANG_${COMPONENT}_LIBRARY
                   NAMES ${COMPONENT}
                   PATHS ${LLVM_LIB_DIR})


### PR DESCRIPTION
Fixes #1809
