### PR TITLE
fix: Fix testrender GPU regression with bad destruction order

### DIFF
--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -1253,7 +1253,7 @@ OptixRaytracer::finalize_pixel_buffer()
 void
 OptixRaytracer::clear()
 {
-    shaders().clear();
+    SimpleRaytracer::clear();
     OPTIX_CHECK(optixDeviceContextDestroy(m_optix_ctx));
     m_optix_ctx = 0;
 }

--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -1101,4 +1101,10 @@ SimpleRaytracer::render(int xres, int yres)
 
 
 
+void
+SimpleRaytracer::clear()
+{
+    shaders().clear();
+}
+
 OSL_NAMESPACE_EXIT

--- a/src/testrender/simpleraytracer.h
+++ b/src/testrender/simpleraytracer.h
@@ -82,7 +82,7 @@ public:
     virtual void prepare_render();
     virtual void warmup() {}
     virtual void render(int xres, int yres);
-    virtual void clear() {}
+    virtual void clear();
 
     // After render, get the pixels into pixelbuf, if they aren't already.
     virtual void finalize_pixel_buffer() {}

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -368,7 +368,7 @@ main(int argc, const char* argv[])
 
     // We're done with the shading system now, destroy it
     rend->clear();
-    delete rend;
     delete shadingsys;
+    delete rend;
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
A few months back, PR #1733 seems to have switched the order that testrender destroys the shading system versus the renderer (services).

This made some subtle bugs that were only symptomatic for GPU renders, but it's because of the destructor order, where the shadingsystem's dtr still references the renderer, which cannot be destroyed yet.

The clue is that the SS's constructor takes the RS pointer as an argument. The RS, then, must have been constructed before the SS, and therefore we should expect it to be a requirement for the RS to outlast the lifetime of the SS. (Complex objects should be destroyed in the opposite order that they were constructed, if they contain references to each other.)
