### PR TITLE
testing: Update ref output for OptiX execution order variance

### DIFF
--- a/testsuite/array-copy/ref/out-alt.txt
+++ b/testsuite/array-copy/ref/out-alt.txt
@@ -1,0 +1,18 @@
+Compiled test.osl -> test.oso
+farray3=[-5,-6,5]
+farray3=[-5,-6,5]
+farray3=[-5,-6,5]
+farray3=[-5,-6,5]
+farray3=[-5,-6,5]
+farray3=[-5,-6,5]
+farray3=[-5,-6,5]
+farray3=[-5,-6,5]
+farray3=[7,9,5]
+farray3=[7,9,5]
+farray3=[7,9,5]
+farray3=[7,9,5]
+farray3=[-5,-3,5]
+farray3=[-5,-3,5]
+farray3=[-5,-3,5]
+farray3=[8,10,6]
+


### PR DESCRIPTION
Was spuriously failing tests only because on GPU, the points didn't always execute in the same order.

(This just adds an additional reference output with same results, but different point order.)
