### PR TITLE
build: Default to C++17 mode

### DIFF
--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -25,7 +25,7 @@ message (STATUS  "CMAKE_CXX_COMPILER_ID  = ${CMAKE_CXX_COMPILER_ID}")
 ###########################################################################
 # C++ language standard
 #
-set (CMAKE_CXX_STANDARD 14 CACHE STRING
+set (CMAKE_CXX_STANDARD 17 CACHE STRING
      "C++ standard to build with (14, 17, 20, etc.)")
 set (DOWNSTREAM_CXX_STANDARD 14 CACHE STRING
      "C++ minimum standard to impose on downstream clients")


### PR DESCRIPTION
This does not change the minimum C++ standard, which is still C++14, even in main. But it does change the default in main to build in C++17 mode, and to get 14 you have to say so explicitly.

We do anticipate bumping the minimum before this fall's release, and this is just a half step to get us ready. Maybe it will help shake loose any compatibility problems and remind people on main that they are using a branch that in a few months will have a new minimum C++.

This will not be backported to the release.
