### PR TITLE
docs: Fixes to documentation of new oren_nayar_diffuse_bsdf parameters

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -67,7 +67,7 @@ Editor: Larry Gritz \\
 \emph{lg@imageworks.com}
 }
 \date{{\large Date: 27 Oct 2023 \\
-% (with corrections, 24 Nov 2021)
+ (with corrections, 24 May 2024)
 }
 \bigskip
 \bigskip
@@ -4640,7 +4640,7 @@ properties of the physically-based shading nodes of MaterialX v1.38
 
 \subsection{Surface BSDF closures}
 
-\apiitem{\closurecolor\ {\ce oren_nayar_diffuse_bsdf}(normal N, color albedo, float roughness)}
+\apiitem{\closurecolor\ {\ce oren_nayar_diffuse_bsdf}(normal N, color albedo, float roughness, int energy_compensation=0)}
 \indexapi{oren_nayar_diffuse_bsdf()}
 
 Constructs a diffuse reflection BSDF based on the Oren-Nayar reflectance

--- a/src/doc/stdlib.md
+++ b/src/doc/stdlib.md
@@ -1267,7 +1267,7 @@ properties of the physically-based shading nodes of MaterialX v1.38
 
 ### Surface BSDF closures
 
-`closure color` **`oren_nayar_diffuse_bsdf`** `(normal N, color albedo, float roughness)`
+`closure color` **`oren_nayar_diffuse_bsdf`** `(normal N, color albedo, float roughness, int energy_compensation=0)`
 
   : Constructs a diffuse reflection BSDF based on the Oren-Nayar reflectance
     model.
@@ -1283,10 +1283,14 @@ properties of the physically-based shading nodes of MaterialX v1.38
     `roughness`
       : Surface roughness [0,1]. A value of 0.0 gives Lambertian reflectance.
 
+    `energy_compensation`
+      : Optional int parameter to select if energy compensation should be applied.
+
     The Oren-Nayar reflection model is described in  M. Oren and S. K.
     Nayar, "Generalization of Lambert's Reflectance Model," Proceedings of
     SIGGRAPH 1994, pp.239-246 (July, 1994).
 
+    The energy compensated model is described in the white paper: "An energy-preserving Qualitative Oren-Nayar model" by Jamie Portsmouth.
 
 `closure color` **`burley_diffuse_bsdf`** `(normal N, color albedo, float roughness)`
 


### PR DESCRIPTION
* The new parameter was explained, but not added to the function prototype in the docs.
* The semi-deprecated languagespec.tex was fixed, but it slipped our minds that we've shifted the docs to markdown for ReadTheDocs (the real place we should have changed was stdlib.md).
