### PR TITLE
Fix the subsurface_bssrdf parameters

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -5049,27 +5049,19 @@ Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
   
   \apiitem{albedo}
   \vspace{12pt}
-  Single-scattering albedo of the medium.
+  Effective albedo of the medium (after multiple scattering). The renderer is expected to
+  invert this color to derive the appropriate single-scattering albedo that will produce
+  this color for the average random walk.
   \apiend
   \vspace{-16pt}
   
-  \apiitem{transmission_depth}
+  \apiitem{radius}
   \vspace{12pt}
-  Distance travelled inside the medium by white light before its color becomes
-  transmission_color by Beer's law. Given in scene length units, range
-  [0,infinity). Together with transmission_color this determines the
-  extinction coefficient of the medium.
+  Average distance travelled inside the medium per color channel. This is typically taken
+  to be the mean-free path of the volume.
   \apiend
   \vspace{-16pt}
-  
-  \apiitem{transmission_color}
-  \vspace{12pt}
-  Desired color resulting from white light transmitted a distance of
-  'transmission_depth' through the medium. Together with transmission_depth
-  this determines the extinction coefficient of the medium.
-  \apiend
-  \vspace{-16pt}
-  
+
   \apiitem{anisotropy}
   \vspace{12pt}
   Scattering anisotropy [-1,1]. Negative values give backwards scattering,

--- a/src/doc/stdlib.md
+++ b/src/doc/stdlib.md
@@ -1506,14 +1506,11 @@ properties of the physically-based shading nodes of MaterialX v1.38
       : Normal vector of the surface point being shaded.
     
     `albedo`
-      : Single-scattering albedo of the medium.
+      : Effective albedo of the medium (after multiple scattering). The renderer is expected to invert this color to derive the appropriate single-scattering albedo that will produce this color for the average random walk.
     
-    `transmission_depth`
-      : Distance travelled inside the medium by white light before its color becomes transmission_color by Beer's law. Given in scene length units, range [0,infinity). Together with transmission_color this determines the extinction coefficient of the medium.
-    
-    `transmission_color`
-      : Desired color resulting from white light transmitted a distance of 'transmission_depth' through the medium. Together with transmission_depth this determines the extinction coefficient of the medium.
-    
+    `radius`
+      : Average distance travelled inside the medium per color channel. This is typically taken to be the mean-free path of the volume.
+
     `anisotropy`
       : Scattering anisotropy [-1,1]. Negative values give backwards scattering, positive values give forward scattering, and 0.0 gives uniform scattering.
     

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -587,17 +587,13 @@ closure color transparent_bsdf() BUILTIN;
 // Constructs a BSSRDF for subsurface scattering within a homogeneous medium.
 //
 //  \param  N                   Normal vector of the surface point being shaded.
-//  \param  albedo              Single-scattering albedo of the medium.
-//  \param  transmission_depth  Distance travelled inside the medium by white light before its color becomes transmission_color by Beer's law.
-//                              Given in scene length units, range [0,infinity). Together with transmission_color this determines the extinction
-//                              coefficient of the medium.
-//  \param  transmission_color  Desired color resulting from white light transmitted a distance of 'transmission_depth' through the medium.
-//                              Together with transmission_depth this determines the extinction coefficient of the medium.
+//  \param  albedo              Effective albedo of the medium (after multiple scattering). The renderer is expected to invert this color to derive the appropriate single-scattering albedo that will produce this color for the average random walk.
+//  \param  radius              Average distance travelled inside the medium per color channel. This is typically taken to be the mean-free path of the volume.
 //  \param  anisotropy          Scattering anisotropy [-1,1]. Negative values give backwards scattering, positive values give forward scattering, 
 //                              and 0.0 gives uniform scattering.
 //  \param  label               Optional string parameter to name this component. For use in AOVs / LPEs.
 //
-closure color subsurface_bssrdf(normal N, color albedo, float transmission_depth, color transmission_color, float anisotropy) BUILTIN;
+closure color subsurface_bssrdf(normal N, color albedo, color radius, float anisotropy) BUILTIN;
 
 // Constructs a microfacet BSDF for the back-scattering properties of cloth-like materials.
 // This closure may be vertically layered over a base BSDF, where energy that is not reflected

--- a/src/testrender/shading.cpp
+++ b/src/testrender/shading.cpp
@@ -196,8 +196,7 @@ struct MxTranslucentParams {
 struct MxSubsurfaceParams {
     Vec3 N;
     Color3 albedo;
-    float transmission_depth;
-    Color3 transmission_color;
+    Color3 radius;
     float anisotropy;
     // optional
     ustringhash label;
@@ -389,8 +388,7 @@ register_closures(OSL::ShadingSystem* shadingsys)
           MX_SUBSURFACE_ID,
           { CLOSURE_VECTOR_PARAM(MxSubsurfaceParams, N),
             CLOSURE_COLOR_PARAM(MxSubsurfaceParams, albedo),
-            CLOSURE_FLOAT_PARAM(MxSubsurfaceParams, transmission_depth),
-            CLOSURE_COLOR_PARAM(MxSubsurfaceParams, transmission_color),
+            CLOSURE_COLOR_PARAM(MxSubsurfaceParams, radius),
             CLOSURE_FLOAT_PARAM(MxSubsurfaceParams, anisotropy),
             CLOSURE_STRING_KEYPARAM(MxSubsurfaceParams, label, "label"),
             CLOSURE_FINISH_PARAM(MxSubsurfaceParams) } },


### PR DESCRIPTION

## Description

We intended this closure to take the effective color and radius so that the SSS color remapping can be controlled by the renderer.

## Tests

The implementation in testrender uses a simple diffuse response (which was effectively assuming it got a multiple-scattered albedo. So all that was needed was renaming the parameters and updating docs.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
