### PR TITLE
Remove unnecessary ustring lookup

### DIFF
--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -184,8 +184,7 @@ OSL_SHADEOP void
 osl_texture_set_interp(void* opt, ustringhash_pod modename_)
 {
     ustringhash modename_hash = ustringhash_from(modename_);
-    ustring modename          = ustring_from(modename_hash);
-    int mode                  = tex_interp_to_code(modename);
+    int mode                  = tex_interp_to_code(modename_hash);
     if (mode >= 0)
         ((TextureOpt*)opt)->interpmode = (TextureOpt::InterpMode)mode;
 }


### PR DESCRIPTION
## Description

I missed an unnecessary ustringhash to ustring conversion back in #1792. Looking up the interp value directly from the ustringhash fixes a performance regression caused by the conversion.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
