### PR TITLE
fix: make backfacing shadeop indicate backfacing shader-global is needed

### DIFF
--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3348,8 +3348,7 @@ RuntimeOptimizer::run()
                     m_unknown_closures_needed = true;
                 }
             } else if (op.opname() == u_backfacing) {
-                m_globals_needed.insert(u_N);
-                m_globals_needed.insert(u_I);
+                m_globals_needed.insert(u_backfacing);
             } else if (op.opname() == u_calculatenormal) {
                 m_globals_needed.insert(u_flipHandedness);
             } else if (op.opname() == u_getattribute) {

--- a/testsuite/globals-needed/ref/out.txt
+++ b/testsuite/globals-needed/ref/out.txt
@@ -1,2 +1,2 @@
-Need 2 globals:  I N
+Need 1 globals:  backfacing
 Need 2 globals:  P flipHandedness


### PR DESCRIPTION

## Description

The backfacing shadeop now directly accesses the backfacing field on the shader globals rather than calculating it from N and I. 

## Tests

This updates the shader-globals-needed query to reflect that change.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
