### PR TITLE
cleanup: OIIO deprecations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ add_definitions (-DOSL_INTERNAL=1)
 
 # To make sure we aren't relying on deprecated OIIO features, we define
 # OIIO_DISABLE_DEPRECATED before including any OIIO headers.
-add_definitions (-DOIIO_DISABLE_DEPRECATED=1)
+add_definitions (-DOIIO_DISABLE_DEPRECATED=900000)
 
 # Set the default namespace. For symbol hiding reasons, it's important that
 # the project name is a subset of the namespace name.

--- a/src/include/OSL/oslnoise.h
+++ b/src/include/OSL/oslnoise.h
@@ -154,28 +154,28 @@ bitcast_to_uint (float x)
 OSL_FORCEINLINE void
 bjmix(vint4& a, vint4& b, vint4& c)
 {
-    using OIIO::simd::rotl32;
-    a -= c;  a ^= rotl32(c, 4);  c += b;
-    b -= a;  b ^= rotl32(a, 6);  a += c;
-    c -= b;  c ^= rotl32(b, 8);  b += a;
-    a -= c;  a ^= rotl32(c,16);  c += b;
-    b -= a;  b ^= rotl32(a,19);  a += c;
-    c -= b;  c ^= rotl32(b, 4);  b += a;
+    using OIIO::simd::rotl;
+    a -= c;  a ^= rotl(c, 4);  c += b;
+    b -= a;  b ^= rotl(a, 6);  a += c;
+    c -= b;  c ^= rotl(b, 8);  b += a;
+    a -= c;  a ^= rotl(c,16);  c += b;
+    b -= a;  b ^= rotl(a,19);  a += c;
+    c -= b;  c ^= rotl(b, 4);  b += a;
 }
 
 // Perform a bjfinal (see OpenImageIO/hash.h) on 4 sets of values at once.
 OSL_FORCEINLINE vint4
 bjfinal(const vint4& a_, const vint4& b_, const vint4& c_)
 {
-    using OIIO::simd::rotl32;
+    using OIIO::simd::rotl;
     vint4 a(a_), b(b_), c(c_);
-    c ^= b; c -= rotl32(b,14);
-    a ^= c; a -= rotl32(c,11);
-    b ^= a; b -= rotl32(a,25);
-    c ^= b; c -= rotl32(b,16);
-    a ^= c; a -= rotl32(c,4);
-    b ^= a; b -= rotl32(a,14);
-    c ^= b; c -= rotl32(b,24);
+    c ^= b; c -= rotl(b,14);
+    a ^= c; a -= rotl(c,11);
+    b ^= a; b -= rotl(a,25);
+    c ^= b; c -= rotl(b,16);
+    a ^= c; a -= rotl(c,4);
+    b ^= a; b -= rotl(a,14);
+    c ^= b; c -= rotl(b,24);
     return c;
 }
 #endif

--- a/src/liboslexec/llvm_ops.cpp
+++ b/src/liboslexec/llvm_ops.cpp
@@ -628,19 +628,19 @@ osl_step_vvv(void* result, void* edge, void* x)
 OSL_SHADEOP int
 osl_isnan_if(float f)
 {
-    return OIIO::isnan(f);
+    return std::isnan(f);
 }
 
 OSL_SHADEOP int
 osl_isinf_if(float f)
 {
-    return OIIO::isinf(f);
+    return std::isinf(f);
 }
 
 OSL_SHADEOP int
 osl_isfinite_if(float f)
 {
-    return OIIO::isfinite(f);
+    return std::isfinite(f);
 }
 
 
@@ -694,7 +694,7 @@ safe_div(float a, float b)
     // to see if is finite and return 0.0f when it is not.
     // Typical implementation isfinite is (fabs(v) != INF), so not too expensive.
     float q = a / b;
-    return OIIO::isfinite(q) ? q : 0.0f;
+    return std::isfinite(q) ? q : 0.0f;
     // TODO: add a FTZ mode and only add checking the result when FTZ is disabled
 #endif
 }

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -4599,7 +4599,7 @@ osl_naninf_check(int ncomps, const void* vals_, int has_derivs, void* sg,
     for (int d = 0; d < (has_derivs ? 3 : 1); ++d) {
         for (int c = firstcheck, e = c + nchecks; c < e; ++c) {
             int i = d * ncomps + c;
-            if (!OIIO::isfinite(vals[i])) {
+            if (!std::isfinite(vals[i])) {
                 OSL::errorfmt(ec, "Detected {} value in {}{} at {}:{} (op {})",
                               vals[i], d > 0 ? "the derivatives of " : "",
                               OSL::ustringhash_from(symbolname_),
@@ -4635,7 +4635,7 @@ osl_uninit_check(long long typedesc_, void* vals_, void* sg,
     if (typedesc.basetype == TypeDesc::FLOAT) {
         float* vals = (float*)vals_;
         for (int c = firstcheck, e = firstcheck + nchecks; c < e; ++c)
-            if (!OIIO::isfinite(vals[c])) {
+            if (!std::isfinite(vals[c])) {
                 uninit  = true;
                 vals[c] = 0;
             }

--- a/src/liboslexec/wide/wide_optest_float.cpp
+++ b/src/liboslexec/wide/wide_optest_float.cpp
@@ -25,17 +25,14 @@ OSL_USING_DATA_WIDTH(__OSL_WIDTH)
 
 #include "define_opname_macros.h"
 
-#define __OSL_XMACRO_ARGS (isnan, OIIO::isnan)
-//#define __OSL_XMACRO_ARGS (isnan,std::isnan)
+#define __OSL_XMACRO_ARGS (isnan, std::isnan)
 #include "wide_optest_float_xmacro.h"
 
-#define __OSL_XMACRO_ARGS (isinf, OIIO::isinf)
+#define __OSL_XMACRO_ARGS (isinf, std::isinf)
 //#define __OSL_XMACRO_ARGS (isinf, sfm::isinf)
-//#define __OSL_XMACRO_ARGS (isinf, std::isinf)
 #include "wide_optest_float_xmacro.h"
 
-#define __OSL_XMACRO_ARGS (isfinite, OIIO::isfinite)
-//#define __OSL_XMACRO_ARGS (isfinite,std::isfinite)
+#define __OSL_XMACRO_ARGS (isfinite, std::isfinite)
 #include "wide_optest_float_xmacro.h"
 
 

--- a/src/liboslexec/wide/wide_shadingsys.cpp
+++ b/src/liboslexec/wide/wide_shadingsys.cpp
@@ -39,7 +39,7 @@ __OSL_OP(naninf_check)(int ncomps, const void* vals_, int has_derivs,
     for (int d = 0; d < (has_derivs ? 3 : 1); ++d) {
         for (int c = firstcheck, e = c + nchecks; c < e; ++c) {
             int i = d * ncomps + c;
-            if (!OIIO::isfinite(vals[i])) {
+            if (!std::isfinite(vals[i])) {
                 ctx->errorfmt("Detected {} value in {}{} at {}:{} (op {})",
                               vals[i], d > 0 ? "the derivatives of " : "",
                               USTR(symbolname), USTR(sourcefile), sourceline,
@@ -68,7 +68,7 @@ __OSL_MASKED_OP1(naninf_check_offset,
         for (int c = firstcheck, e = c + nchecks; c < e; ++c) {
             int i = d * ncomps + c;
             mask.foreach ([=](ActiveLane lane) -> void {
-                if (!OIIO::isfinite(vals[i * __OSL_WIDTH + lane])) {
+                if (!std::isfinite(vals[i * __OSL_WIDTH + lane])) {
                     ctx->errorfmt(
                         "Detected {} value in {}{} at {}:{} (op {}) batch lane:{}",
                         vals[i * __OSL_WIDTH + lane],
@@ -107,7 +107,7 @@ __OSL_MASKED_OP1(naninf_check_offset,
             int firstcheck = wOffsets[lane];
             for (int c = firstcheck, e = c + nchecks; c < e; ++c) {
                 int i = d * ncomps + c;
-                if (!OIIO::isfinite(vals[i * __OSL_WIDTH + lane])) {
+                if (!std::isfinite(vals[i * __OSL_WIDTH + lane])) {
                     ctx->errorfmt(
                         "Detected {} value in {}{} at {}:{} (op {}) batch lane:{}",
                         vals[i * __OSL_WIDTH + lane],
@@ -143,7 +143,7 @@ __OSL_OP2(uninit_check_values_offset, X,
     if (typedesc.basetype == TypeDesc::FLOAT) {
         float* vals = (float*)vals_;
         for (int c = firstcheck, e = firstcheck + nchecks; c < e; ++c)
-            if (!OIIO::isfinite(vals[c])) {
+            if (!std::isfinite(vals[c])) {
                 uninit  = true;
                 vals[c] = 0;
             }
@@ -200,7 +200,7 @@ __OSL_MASKED_OP2(uninit_check_values_offset, WX,
         float* vals = (float*)vals_;
         for (int c = firstcheck, e = firstcheck + nchecks; c < e; ++c)
             mask.foreach ([=, &lanes_uninit](ActiveLane lane) -> void {
-                if (!OIIO::isfinite(vals[c * __OSL_WIDTH + lane])) {
+                if (!std::isfinite(vals[c * __OSL_WIDTH + lane])) {
                     lanes_uninit.set_on(lane);
                     vals[c * __OSL_WIDTH + lane] = 0;
                 }
@@ -265,7 +265,7 @@ __OSL_MASKED_OP2(uninit_check_values_offset, X,
         mask.foreach ([=, &lanes_uninit](ActiveLane lane) -> void {
             int firstcheck = wOffsets[lane];
             for (int c = firstcheck, e = firstcheck + nchecks; c < e; ++c)
-                if (!OIIO::isfinite(vals[c])) {
+                if (!std::isfinite(vals[c])) {
                     lanes_uninit.set_on(lane);
                     vals[c] = 0;
                 }
@@ -331,7 +331,7 @@ __OSL_MASKED_OP2(uninit_check_values_offset, WX,
         mask.foreach ([=, &lanes_uninit](ActiveLane lane) -> void {
             int firstcheck = wOffsets[lane];
             for (int c = firstcheck, e = firstcheck + nchecks; c < e; ++c)
-                if (!OIIO::isfinite(vals[c * __OSL_WIDTH + lane])) {
+                if (!std::isfinite(vals[c * __OSL_WIDTH + lane])) {
                     lanes_uninit.set_on(lane);
                     vals[c * __OSL_WIDTH + lane] = 0;
                 }

--- a/src/liboslnoise/gabornoise.cpp
+++ b/src/liboslnoise/gabornoise.cpp
@@ -175,7 +175,7 @@ gabor_cell(GaborParams& gp, const Vec3& c_i, const Dual2<Vec3>& x_c_i,
                 Dual2<float> gk     = gabor_kernel(w_i_t_s_f, omega_i_t_s_f,
                                                    phi_i_t_s_f, a_i_t_s_f,
                                                    x_k_i_t);  // 2D
-                if (!OIIO::isfinite(gk.val())) {
+                if (!std::isfinite(gk.val())) {
                     // Numeric failure of the filtered version.  Fall
                     // back on the unfiltered.
                     gk = gabor_kernel(gp.weight, omega_i, phi_i, gp.a,

--- a/src/liboslnoise/sfm_gabornoise.h
+++ b/src/liboslnoise/sfm_gabornoise.h
@@ -367,7 +367,7 @@ gabor_cell(const sfm::GaborUniformParams& gup, const sfm::GaborParams& gp,
                 //bool not_finite = std::isnan(gk.val()) | std::isinf(gk.val());
                 bool not_finite = std::isnan(gk.val()) || std::isinf(gk.val());
 #else
-                bool not_finite = !OIIO::isfinite(gk.val());
+                bool not_finite = !std::isfinite(gk.val());
 #endif
                 if (OSL_UNLIKELY(not_finite)) {
                     // Numeric failure of the filtered version.  Fall

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1269,8 +1269,8 @@ save_outputs(SimpleRenderer* rend, ShadingSystem* shadingsys,
             // We are outputting an integer variable, so we need to
             // convert it to floating point.
             float* pixel = OSL_ALLOCA(float, nchans);
-            OIIO::convert_types(TypeDesc::BASETYPE(t.basetype), data,
-                                TypeDesc::FLOAT, pixel, nchans);
+            OIIO::convert_pixel_values(TypeDesc::BASETYPE(t.basetype), data,
+                                       TypeDesc::FLOAT, pixel, nchans);
             outputimg->setpixel(x, y, &pixel[0]);
             if (print_outputs) {
                 print("  {} :", outputvarnames[i]);


### PR DESCRIPTION
Various minor changes to eliminate references to long-ago deprecated OIIO items (mostly which simply alias to std versions).
