### PR TITLE
cleanup: Swich away from deprecated OIIO function names

### DIFF
--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -1418,9 +1418,9 @@ batched_save_outputs(SimpleRenderer* rend, ShadingSystem* shadingsys,
                     int y    = by[batchIndex];
                     int data = batchResults[batchIndex];
                     float pixel[1];
-                    OIIO::convert_types(TypeDesc::BASETYPE(t.basetype), &data,
-                                        TypeDesc::FLOAT, &pixel[0],
-                                        1 /*nchans*/);
+                    OIIO::convert_pixel_values(TypeDesc::BASETYPE(t.basetype),
+                                               &data, TypeDesc::FLOAT,
+                                               &pixel[0], 1 /*nchans*/);
                     outputimg->setpixel(x, y, &pixel[0]);
                     if (print_outputs) {
                         *oStreams[batchIndex]
@@ -1442,9 +1442,9 @@ batched_save_outputs(SimpleRenderer* rend, ShadingSystem* shadingsys,
                         intPixel[c] = batchResults[batchIndex][c];
                     }
 
-                    OIIO::convert_types(TypeDesc::BASETYPE(t.basetype),
-                                        intPixel, TypeDesc::FLOAT, floatPixel,
-                                        3 /*nchans*/);
+                    OIIO::convert_pixel_values(TypeDesc::BASETYPE(t.basetype),
+                                               intPixel, TypeDesc::FLOAT,
+                                               floatPixel, 3 /*nchans*/);
                     outputimg->setpixel(x, y, floatPixel);
                     if (print_outputs) {
                         (*oStreams[batchIndex])


### PR DESCRIPTION
This was breaking OSL's CI after a recent OIIO master merge that more thoroughly hit certain long-deprecated functions.
