### PR TITLE
Fix reparameter string representation

### DIFF
--- a/src/cmake/testing.cmake
+++ b/src/cmake/testing.cmake
@@ -348,7 +348,7 @@ macro (osl_add_all_tests)
                 printf-reg
                 printf-whole-array
                 raytype raytype-reg raytype-specialized regex-reg
-                reparam reparam-arrays testoptix-reparam
+                reparam reparam-arrays reparam-string testoptix-reparam
                 render-background render-bumptest
                 render-cornell render-furnace-diffuse
                 render-mx-furnace-burley-diffuse

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -3290,7 +3290,13 @@ RuntimeOptimizer::run()
                 offset = OIIO::round_to_multiple_of_pow2(offset, alignment);
                 interactive_data.resize(offset + totalsize);
                 // Copy from the instance value to the interactive block
-                memcpy(&interactive_data[offset], s.data(), typesize);
+                // If the value is a string, copy its hash.
+                if (s.typespec().is_string()) {
+                    ustring string_data = *reinterpret_cast<ustring*>(s.data());
+                    ustringhash string_hash(string_data);
+                    memcpy(&interactive_data[offset], &string_hash, typesize);
+                } else
+                    memcpy(&interactive_data[offset], s.data(), typesize);
                 if (totalsize > typesize)
                     memset(&interactive_data[offset] + typesize, 0,
                            totalsize - typesize);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -3398,12 +3398,22 @@ ShadingSystemImpl::ReParameter(ShaderGroup& group, string_view layername_,
     size_t size = type.size();
     m_stat_reparam_calls_total += 1;
     m_stat_reparam_bytes_total += size;
-    if (memcmp(group.interactive_arena_ptr() + offset, val, size)) {
-        memcpy(group.interactive_arena_ptr() + offset, val, type.size());
+
+    // Copy ustringhashes instead of ustrings
+    const void* payload;
+    ustringhash string_hash;
+    if (type == TypeDesc::STRING) {
+        string_hash = ustringhash_from(*reinterpret_cast<const ustring*>(val));
+        payload     = &string_hash;
+    } else
+        payload = val;
+
+    if (memcmp(group.interactive_arena_ptr() + offset, payload, size)) {
+        memcpy(group.interactive_arena_ptr() + offset, payload, type.size());
         if (use_optix())
             renderer()->copy_to_device(group.device_interactive_arena().d_get()
                                            + offset,
-                                       val, type.size());
+                                       payload, type.size());
         m_stat_reparam_calls_changed += 1;
         m_stat_reparam_bytes_changed += size;
     }

--- a/testsuite/reparam-string/ref/out.txt
+++ b/testsuite/reparam-string/ref/out.txt
@@ -1,0 +1,4 @@
+Compiled test.osl -> test.oso
+test_string = initial value
+test_string = updated value
+

--- a/testsuite/reparam-string/run.py
+++ b/testsuite/reparam-string/run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+command += testshade(" ".join([
+    "--layer lay0",
+    "--param:type=string:interactive=1 test_string 'initial value'",
+    "test --iters 2",
+    "--reparam:type=string:interactive=1 lay0 test_string 'updated value'",
+]))
+
+outputs = [ "out.txt" ]
+

--- a/testsuite/reparam-string/test.osl
+++ b/testsuite/reparam-string/test.osl
@@ -1,0 +1,8 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+shader test(string test_string = "override me" [[ int interactive = 1 ]])
+{
+    printf("test_string = %s\n", test_string);
+}


### PR DESCRIPTION
## Description

This PR fixes a regression that went unnoticed during the ustringhash conversion.

Right now OSL expects strings to be represented at runtime as ustringhashes, but interactive parameters' values are still being stored as ustrings. This requires fixing in two locations, first the code that sets the initial value of an interactive parameter, and second the code that copies updated parameters into the interactive buffer.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

New reparameter-strings test.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
