### PR TITLE
api: Switch shade_image to use current OIIO::paropt

### DIFF
--- a/src/include/OSL/oslexec.h
+++ b/src/include/OSL/oslexec.h
@@ -1159,7 +1159,7 @@ shade_image(ShadingSystem& shadingsys, ShaderGroup& group,
             const ShaderGlobals* defaultsg, OIIO::ImageBuf& buf,
             cspan<ustring> outputs,
             ShadeImageLocations shadelocations = ShadePixelCenters,
-            OIIO::ROI roi = OIIO::ROI(), OIIO::parallel_options popt = 0);
+            OIIO::ROI roi = OIIO::ROI(), OIIO::paropt popt = 0);
 
 #endif
 

--- a/src/liboslexec/shadeimage.cpp
+++ b/src/liboslexec/shadeimage.cpp
@@ -26,7 +26,7 @@ bool
 shade_image(ShadingSystem& shadingsys, ShaderGroup& group,
             const ShaderGlobals* defaultsg, OIIO::ImageBuf& buf,
             cspan<ustring> outputs, ShadeImageLocations shadelocations,
-            OIIO::ROI roi, OIIO::parallel_options popt)
+            OIIO::ROI roi, OIIO::paropt popt)
 {
     using namespace OIIO;
     using namespace ImageBufAlgo;
@@ -172,5 +172,17 @@ shade_image(ShadingSystem& shadingsys, ShaderGroup& group,
 }
 
 
+
+// DEPRECATED(1.14)
+OSLEXECPUBLIC
+bool
+shade_image(ShadingSystem& shadingsys, ShaderGroup& group,
+            const ShaderGlobals* defaultsg, OIIO::ImageBuf& buf,
+            cspan<ustring> outputs, ShadeImageLocations shadelocations,
+            OIIO::ROI roi, OIIO::parallel_options popt)
+{
+    return shade_image(shadingsys, group, defaultsg, buf, outputs,
+                       shadelocations, roi, OIIO::paropt(popt));
+}
 
 OSL_NAMESPACE_EXIT

--- a/src/osltoy/osltoyrenderer.cpp
+++ b/src/osltoy/osltoyrenderer.cpp
@@ -130,11 +130,7 @@ OSLToyRenderer::render_image()
             OIIO::ImageSpec(m_xres, m_yres, 3, TypeDesc::FLOAT));
 
     static ustring outputs[] = { ustring("Cout") };
-    //    OIIO::Timer timer;
-    OIIO::parallel_options popt;
-    popt.minitems  = 4096;
-    popt.splitdir  = OIIO::Split_Tile;
-    popt.recursive = true;
+    OIIO::paropt popt(0, OIIO::paropt::SplitDir::Tile, 4096);
     shade_image(*shadingsys(), *shadergroup(), &m_shaderglobals_template,
                 m_framebuffer, outputs, ShadePixelCenters, OIIO::ROI(), popt);
     //    std::cout << timer() << "\n";


### PR DESCRIPTION
... instead of long-deprecated parallel_options.

This is an API compatible change because OIIO itself has a paropt constructor that takes a parallel_options, and I'll leave that deprecated but present for a bit longer in OIIO.

For the sake of link compatibility, we leave the old function defined in shade_image.cpp, so this should not present an ABI change. We'll remove the old version later when it's safe.
