### PR TITLE
build(deps): Adjust to OIIO change to IC/TS API

### DIFF
--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -842,7 +842,8 @@ private:
     void setup_op_descriptors();
 
     RendererServices* m_renderer;  ///< Renderer services
-    TextureSystem* m_texturesys;   ///< Texture system
+    std::shared_ptr<TextureSystem> m_texturesys_sp;
+    TextureSystem* m_texturesys;  ///< Texture system
 
     ErrorHandler* m_err;  ///< Error handler
     mutable std::list<std::string> m_errseen, m_warnseen;

--- a/src/liboslexec/rendservices.cpp
+++ b/src/liboslexec/rendservices.cpp
@@ -19,6 +19,14 @@ using namespace OSL::pvt;
 OSL_NAMESPACE_ENTER
 
 
+#ifdef OIIO_TEXTURESYSTEM_CREATE_SHARED
+namespace {
+std::mutex shared_texturesys_mutex;
+std::shared_ptr<TextureSystem> shared_texturesys;
+}  // namespace
+#endif
+
+
 
 RendererServices::RendererServices(TextureSystem* texsys) : m_texturesys(texsys)
 {
@@ -31,7 +39,17 @@ RendererServices::RendererServices(TextureSystem* texsys) : m_texturesys(texsys)
         OSL_ASSERT(
             0 && "RendererServices was not passed a working TextureSystem*");
 #else
+#    ifdef OIIO_TEXTURESYSTEM_CREATE_SHARED
+        {
+            std::lock_guard<std::mutex> lock(shared_texturesys_mutex);
+            if (!shared_texturesys) {
+                shared_texturesys = TextureSystem::create(true /* shared */);
+            }
+            m_texturesys = shared_texturesys.get();
+        }
+#    else
         m_texturesys = TextureSystem::create(true /* shared */);
+#    endif
         // Make some good guesses about default options
         m_texturesys->attribute("automip", 1);
         m_texturesys->attribute("autotile", 64);

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1201,7 +1201,12 @@ ShadingSystemImpl::ShadingSystemImpl(RendererServices* renderer,
         OSL_ASSERT(0
                    && "ShadingSystem was not passed a working TextureSystem*");
 #else
+#    if OIIO_TEXTURESYSTEM_CREATE_SHARED
+        m_texturesys_sp = TextureSystem::create(true /* shared */);
+        m_texturesys    = m_texturesys_sp.get();
+#    else
         m_texturesys = TextureSystem::create(true /* shared */);
+#    endif
         // Make some good guesses about default options
         m_texturesys->attribute("automip", 1);
         m_texturesys->attribute("autotile", 64);

--- a/src/osl.imageio/oslinput.cpp
+++ b/src/osl.imageio/oslinput.cpp
@@ -218,7 +218,7 @@ static OIIO::mutex shading_mutex;
 static ShadingSystem* shadingsys       = NULL;
 static OIIO_RendererServices* renderer = NULL;
 static ErrorRecorder errhandler;
-
+static std::shared_ptr<TextureSystem> shared_texsys;
 
 
 static void
@@ -226,7 +226,14 @@ setup_shadingsys()
 {
     OIIO::lock_guard lock(shading_mutex);
     if (!shadingsys) {
-        renderer   = new OIIO_RendererServices(TextureSystem::create(true));
+#if OIIO_TEXTURESYSTEM_CREATE_SHARED
+        if (!shared_texsys)
+            shared_texsys = TextureSystem::create(true);
+        auto ts = shared_texsys.get();
+#else
+        auto ts = TextureSystem::create(true);
+#endif
+        renderer   = new OIIO_RendererServices(ts);
         shadingsys = new ShadingSystem(renderer, NULL, &errhandler);
     }
 }

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -129,7 +129,6 @@ static char* userdata_base_ptr = nullptr;
 static char* output_base_ptr   = nullptr;
 static bool use_rs_bitcode
     = false;  // use free function bitcode version of renderer services
-
 static int jbufferMB = 16;
 
 // Testshade thread tracking and assignment.
@@ -675,8 +674,12 @@ print_info()
     else
 #endif
         rend = new SimpleRenderer;
-    TextureSystem* texturesys = TextureSystem::create();
+    auto texturesys = TextureSystem::create();
+#if OIIO_TEXTURESYSTEM_CREATE_SHARED
+    shadingsys = new ShadingSystem(rend, texturesys.get(), &errhandler);
+#else
     shadingsys = new ShadingSystem(rend, texturesys, &errhandler);
+#endif
     rend->init_shadingsys(shadingsys);
     set_shadingsys_options();
 
@@ -1963,7 +1966,12 @@ test_shade(int argc, const char* argv[])
     // Request a TextureSystem (by default it will be the global shared
     // one). This isn't strictly necessary, if you pass nullptr to
     // ShadingSystem ctr, it will ask for the shared one internally.
+#if OIIO_TEXTURESYSTEM_CREATE_SHARED
+    std::shared_ptr<TextureSystem> texturesys_owned = TextureSystem::create();
+    TextureSystem* texturesys                       = texturesys_owned.get();
+#else
     TextureSystem* texturesys = TextureSystem::create();
+#endif
 
     // Create a new shading system.  We pass it the RendererServices
     // object that services callbacks from the shading system, the
@@ -2327,8 +2335,8 @@ test_shade(int argc, const char* argv[])
         std::cout << "ERRORS left in TextureSystem:\n" << err << "\n";
         retcode = EXIT_FAILURE;
     }
-    OIIO::ImageCache* ic = texturesys->imagecache();
-    err                  = ic ? ic->geterror() : std::string();
+    auto ic = texturesys->imagecache();
+    err     = ic ? ic->geterror() : std::string();
     if (!err.empty()) {
         std::cout << "ERRORS left in ImageCache:\n" << err << "\n";
         retcode = EXIT_FAILURE;


### PR DESCRIPTION
On the OIIO side, there's a PR in review that changes the ImageCache and TextureSystem APIs to return shared_ptr instead of raw. (https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4377) This is destined for the upcoming OIIO 3.0 release.

This patch on the OSL side ensures that we build cleanly against both OIIO 2.x and 3.0 after that patch is merged.
