### PR TITLE
Mock gpu pointcloud_search calls with empty custom attributes

### DIFF
--- a/src/liboslexec/llvm_gen.cpp
+++ b/src/liboslexec/llvm_gen.cpp
@@ -3963,7 +3963,9 @@ LLVMGEN(llvm_gen_pointcloud_search)
                 else
                     clear_derivs_of.push_back(&Value);
             }
-        } else {
+        } else if (!rop.use_optix()) {
+            //TODO: Implement custom attribute arguments for OptiX
+
             // It is a regular attribute, push it to the arg list
             args.push_back(rop.llvm_load_value(Name));
             args.push_back(rop.ll.constant(simpletype));
@@ -3977,7 +3979,14 @@ LLVMGEN(llvm_gen_pointcloud_search)
                             capacity);
     }
 
-    args[9] = rop.ll.constant(extra_attrs);
+    if (rop.use_optix()) {
+        // TODO: Implement proper variadic arguments for OptiX.
+        // In the meantime, dropping the custom attributes lets shader ptx compile properly.
+        args[9] = rop.ll.constant(0);
+        args.push_back(rop.ll.void_ptr_null());
+    } else {
+        args[9] = rop.ll.constant(extra_attrs);
+    }
 
     if (Max_points.is_constant()) {
         // Compare capacity to the requested number of points.


### PR DESCRIPTION
## Description
The GPU calling convention for variadic shadeops is to pass a pointer to the extra parameters as the op's final argument. Currently calls to osl_pointcloud_search don't follow this convention, so their ptx fails to compile due to argument count mismatches.

This PR doesn't implement the full correct behavior, it just adds a nullptr to the end of OptiX calls to osl_pointcloud_search. This makes everything at least compile, so scenes that have pointcloud operations can fail more gracefully on GPU (for now).

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
