### PR TITLE
Fix LLVM find package picking up system-wide libraries

### DIFF
--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -78,10 +78,12 @@ string (REPLACE " " ";" LLVM_SYSTEM_LIBRARIES "${LLVM_SYSTEM_LIBRARIES}")
 
 find_library ( LLVM_LIBRARY
                NAMES LLVM-${LLVM_VERSION} LLVM
-               PATHS ${LLVM_LIB_DIR})
+               PATHS ${LLVM_LIB_DIR}
+               NO_DEFAULT_PATH)
 find_library ( LLVM_MCJIT_LIBRARY
                NAMES LLVMMCJIT
-               PATHS ${LLVM_LIB_DIR})
+               PATHS ${LLVM_LIB_DIR}
+               NO_DEFAULT_PATH)
 
 if (NOT LLVM_LIBRARY)
     # if no single library was found, use llvm-config to generate the list
@@ -99,8 +101,9 @@ execute_process (COMMAND ${LLVM_CONFIG} --shared-mode
        OUTPUT_STRIP_TRAILING_WHITESPACE)
 if (LLVM_VERSION VERSION_GREATER_EQUAL 9.0 AND (LLVM_SHARED_MODE STREQUAL "shared"))
     find_library ( _CLANG_CPP_LIBRARY
-		  NAMES "clang-cpp"
-		  PATHS ${LLVM_LIB_DIR})
+                   NAMES "clang-cpp"
+                   PATHS ${LLVM_LIB_DIR}
+                   NO_DEFAULT_PATH)
     if (_CLANG_CPP_LIBRARY)
         list (APPEND CLANG_LIBRARIES ${_CLANG_CPP_LIBRARY})
     endif ()
@@ -112,7 +115,8 @@ foreach (COMPONENT clangFrontend clangDriver clangSerialization
                    clangSupport clangAPINotes)
     find_library ( _CLANG_${COMPONENT}_LIBRARY
                   NAMES ${COMPONENT}
-                  PATHS ${LLVM_LIB_DIR})
+                  PATHS ${LLVM_LIB_DIR}
+                  NO_DEFAULT_PATH)
     if (_CLANG_${COMPONENT}_LIBRARY)
         list (APPEND CLANG_LIBRARIES ${_CLANG_${COMPONENT}_LIBRARY})
     endif ()


### PR DESCRIPTION
## Description

This change fixes LLVM find package ignoring the library path provided by LLVM_CONFIG and picking up a system-wide library instead.

This happens when a custom LLVM is compiled statically, and there is a system-wide LLVM of the version which OSL expects.

The solution is to pass NO_DEFAULT_PATH to the find_library so that the function only considers paths explicitly coming from the LLVM's configuration executable.

It is a bit unclear what is the expected behavior of this module when LLVM_CONFIG is not available. It is possible to limit possible side effects of this change by only ignoring default paths if the LLVM CONFIG executable is found.

In practice this issue happened in Blender's build environment where HIP is used for OpenImageDenoiser: HIP toolchain pulls in LLVM system wide. While it is not an issue on itself (as it is only a compile time dependency for HIP support in OIDN) in conflicts with the logic in the OSL's find_package(LLVM).

## Tests

The change has been tested in the build environment which is used for official Blender libraries builds. For the details of this environment one might read its [documentation](https://developer.blender.org/docs/handbook/release_process/build/rocky_8/).

Running the official testsuite produces a fair amount of failures before this change. Could be due to the side effects of how that specific VM is setup, didn't have time yet to dig into exact details.

## Checklist:

- [X] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [X] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
