### PR TITLE
anisotropic_vdf closure should not set IOR

### DIFF
--- a/src/testrender/shading.cpp
+++ b/src/testrender/shading.cpp
@@ -1653,8 +1653,6 @@ process_medium_closure(const OSL::ShaderGlobals& sg, ShadingResult& result,
         result.sigma_t               = cw * params.extinction;
         result.sigma_s               = params.albedo * result.sigma_t;
         result.medium_g              = params.anisotropy;
-        result.refraction_ior        = 1.0f;
-        result.priority = 0;  // TODO: should this closure have a priority?
         break;
     }
     case MX_MEDIUM_VDF_ID: {


### PR DESCRIPTION
## Description

The MaterialX team noticed this issue here: https://github.com/AcademySoftwareFoundation/MaterialX/pull/2016

Basically, if you add a medium through the `anisotropic_vdf` closure, it should not force the ior back to 1.0 as this IOR might have been changed by one of the microfacet closures. The IOR already defaults to 1.0 so cases that do not involve a microfacet closure are not affected.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
