### PR TITLE
osltoy - Feature Request: custom #include search paths

### DIFF
--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -352,11 +352,12 @@ public:
 #endif
 };
 
+
+
 class OSLToySearchPathLine final : public QLineEdit {
     // Q_OBJECT
 public:
     explicit OSLToySearchPathLine(OSLToySearchPathEditor* editor, int index);
-
 
     bool previouslyHadContent() const { return m_previouslyHadContent; }
 
@@ -375,20 +376,17 @@ private:
             return Qt::white;
     }
 
-
     bool m_previouslyHadContent = false;
     int m_index;
     OSLToySearchPathEditor* m_editor = nullptr;
 };
 
 
+
 // More generically, this is a popup window with a list (that grows as needed) of editable text items.
 class OSLToySearchPathEditor final : public QWidget {
-    // Q_OBJECT
-
     using UpdatePathListAction
         = std::function<void(const std::vector<std::string>&)>;
-
 public:
     OSLToySearchPathEditor(QWidget* parent,
                            UpdatePathListAction updatePathsAction)
@@ -399,12 +397,9 @@ public:
     {
         window()->setWindowTitle(tr("#include Search Path List"));
 
-
         int thisWidth  = parent->width();   // / 3;
         int thisHeight = parent->height();  // / 4;
-
         resize(thisWidth, thisHeight);
-
         setFixedSize(size());
 
         class MyScrollArea : public QScrollArea {
@@ -432,62 +427,38 @@ public:
 
         auto scroll_area = new MyScrollArea(this);
         scroll_area->setWidgetResizable(true);
-
         auto frame = new MyFrame(scroll_area);
-        // frame->setWidgetResizable(true);
-
         auto layout = new QVBoxLayout();
         layout->setSpacing(0);
-        // int topMargin = thisWidth / 6;
-        // layout->setContentsMargins(topMargin / 2, topMargin, topMargin / 2, topMargin / 2);
-
         frame->setLayout(layout);
-
         frame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-
         scroll_area->setWidget(frame);
-
-        m_layout = layout;
-
         scroll_area->show();
+        m_layout = layout;
         m_scrollArea = scroll_area;
     }
-
 
     void set_path_list(const std::vector<std::string>& paths)
     {
         while (!m_lines.empty())
             pop_line();
-
-
         m_maxIndexWithContent
             = (int)paths.size()
               - 1;  // ok that this is -1 if the paths are empty
-
-
-
         auto initialLineCount = required_lines();
-
         m_lines.reserve(initialLineCount);
-
-        while (m_lines.size() < initialLineCount) {
+        while (m_lines.size() < initialLineCount) 
             push_line();
-        }
-
-        for (size_t i = 0; i < paths.size(); ++i) {
+        for (size_t i = 0; i < paths.size(); ++i) 
             m_lines[i]->setText(QString::fromStdString(paths[i]));
-        }
-
         update_path_list();
     }
-
 
     void observe_changed_text()
     {
         // Only listen to signals from OSLToySearchPathLine objects
         if (auto changedLine = dynamic_cast<OSLToySearchPathLine*>(sender())) {
             bool isNowEmpty = changedLine->text().isEmpty();
-
             if (changedLine->previouslyHadContent() && isNowEmpty) {
                 if (changedLine->getIndex() == m_maxIndexWithContent) {
                     // Find the next max index with content, or -1 if none.
@@ -515,7 +486,6 @@ protected:
     {
         // On close, collate the list of search paths, and if there has been any change, update.
         bool has_updated = false;
-
         for (auto line : m_lines) {
             if (line->isModified()) {
                 if (!has_updated) {
@@ -529,16 +499,13 @@ protected:
         ev->accept();
     }
 
-
 private:
     void push_line()
     {
         auto l = new OSLToySearchPathLine(this, (int)m_lines.size());
-
         m_layout->addWidget(l);
         m_lines.push_back(l);
     }
-
 
     void pop_line()
     {
@@ -568,7 +535,6 @@ private:
     void grow_as_needed()
     {
         auto newReqLines = required_lines();
-
         while (m_lines.size() < newReqLines) {
             push_line();
         }
@@ -577,13 +543,10 @@ private:
     void shrink_as_needed()
     {
         auto newReqLines = required_lines();
-
         while (m_lines.size() > newReqLines) {
             pop_line();
         }
     }
-
-
 
     int m_minLineCount             = 12;
     int m_guaranteedEmptyLineCount = 5;
@@ -605,22 +568,23 @@ OSLToySearchPathLine::OSLToySearchPathLine(OSLToySearchPathEditor* editor,
     auto p = this->palette();
     p.setColor(QPalette::Base, getColor(index));
     setPalette(p);
-
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-
     QObject::connect(this, &OSLToySearchPathLine::editingFinished, editor,
                      &OSLToySearchPathEditor::observe_changed_text);
 
     // Maybe add a QCompleter that completes known paths
-    // setCompletion
     show();
 }
+
+
 
 QSize
 OSLToySearchPathLine::sizeHint() const
 {
     return QSize(m_editor->width() - 4, 10);
 }
+
+
 
 void
 #if OSL_QT_MAJOR < 6
@@ -672,9 +636,6 @@ OSLToyMainWindow::OSLToyMainWindow(OSLToyRenderer* rend, int xr, int yr)
     // read_settings ();
 
     setWindowTitle(tr("OSL Toy"));
-
-    // Set size of the window
-    // setFixedSize(100, 50);
 
     createActions();
     createMenus();
@@ -793,8 +754,6 @@ OSLToyMainWindow::createActions()
                &OSLToyMainWindow::recompile_shaders);
     add_action("Enter Full Screen", "", "",
                &OSLToyMainWindow::action_fullscreen);
-
-
     add_action("search-path-popup", "Edit #include search paths...",
                "Shift-Ctrl+P",
                &OSLToyMainWindow::action_open_search_path_popup);

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -387,6 +387,7 @@ private:
 class OSLToySearchPathEditor final : public QWidget {
     using UpdatePathListAction
         = std::function<void(const std::vector<std::string>&)>;
+
 public:
     OSLToySearchPathEditor(QWidget* parent,
                            UpdatePathListAction updatePathsAction)
@@ -427,14 +428,14 @@ public:
 
         auto scroll_area = new MyScrollArea(this);
         scroll_area->setWidgetResizable(true);
-        auto frame = new MyFrame(scroll_area);
+        auto frame  = new MyFrame(scroll_area);
         auto layout = new QVBoxLayout();
         layout->setSpacing(0);
         frame->setLayout(layout);
         frame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         scroll_area->setWidget(frame);
         scroll_area->show();
-        m_layout = layout;
+        m_layout     = layout;
         m_scrollArea = scroll_area;
     }
 
@@ -447,9 +448,9 @@ public:
               - 1;  // ok that this is -1 if the paths are empty
         auto initialLineCount = required_lines();
         m_lines.reserve(initialLineCount);
-        while (m_lines.size() < initialLineCount) 
+        while (m_lines.size() < initialLineCount)
             push_line();
-        for (size_t i = 0; i < paths.size(); ++i) 
+        for (size_t i = 0; i < paths.size(); ++i)
             m_lines[i]->setText(QString::fromStdString(paths[i]));
         update_path_list();
     }

--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -355,36 +355,29 @@ public:
 class OSLToySearchPathLine final : public QLineEdit {
     // Q_OBJECT
 public:
-
     explicit OSLToySearchPathLine(OSLToySearchPathEditor* editor, int index);
 
 
-    bool previouslyHadContent() const {
-        return m_previouslyHadContent;
-    }
+    bool previouslyHadContent() const { return m_previouslyHadContent; }
 
-    void setPreviouslyHadContent(bool value) {
-        m_previouslyHadContent = value;
-    }
+    void setPreviouslyHadContent(bool value) { m_previouslyHadContent = value; }
 
-    int getIndex() const {
-        return m_index;
-    }
+    int getIndex() const { return m_index; }
 
     QSize sizeHint() const override;
 
 private:
-
-    static QColor getColor(int index) {
+    static QColor getColor(int index)
+    {
         if (index % 2)
-            return QColor(0xFFE0F0FF); // light blue
+            return QColor(0xFFE0F0FF);  // light blue
         else
             return Qt::white;
     }
 
 
     bool m_previouslyHadContent = false;
-    int  m_index;
+    int m_index;
     OSLToySearchPathEditor* m_editor = nullptr;
 };
 
@@ -393,75 +386,83 @@ private:
 class OSLToySearchPathEditor final : public QWidget {
     // Q_OBJECT
 
-    using UpdatePathListAction = std::function<void(const std::vector<std::string>&)>;
+    using UpdatePathListAction
+        = std::function<void(const std::vector<std::string>&)>;
+
 public:
-
-    OSLToySearchPathEditor(QWidget* parent, UpdatePathListAction updatePathsAction) 
-        : QWidget(parent, static_cast<Qt::WindowFlags>(Qt::Tool | Qt::WindowStaysOnTopHint)),
-        m_lines(),
-        m_updateAction(updatePathsAction)
-        {
-            window()->setWindowTitle(tr("#include Search Path List"));
-
-
-            int thisWidth = parent->width(); // / 3;
-            int thisHeight = parent->height(); // / 4;
-
-            resize(thisWidth, thisHeight);
-
-            setFixedSize(size());
-
-            class MyScrollArea : public QScrollArea {
-                QWidget* m_parent;
-            public:
-                explicit MyScrollArea(QWidget* parent) : QScrollArea(parent), m_parent(parent) { }
-
-                QSize sizeHint() const override {
-                    return m_parent->size();
-                }
-            };
-
-            class MyFrame : public QFrame {
-                QWidget* m_parent;
-            public:
-                explicit MyFrame(QWidget* parent) : QFrame(parent), m_parent(parent) { }
-
-                QSize sizeHint() const override {
-                    return m_parent->size();
-                }
-            };
-
-            auto scroll_area = new MyScrollArea(this);
-            scroll_area->setWidgetResizable(true);
-
-            auto frame = new MyFrame(scroll_area);
-            // frame->setWidgetResizable(true);
-
-            auto layout = new QVBoxLayout();
-            layout->setSpacing(0);
-            // int topMargin = thisWidth / 6;
-            // layout->setContentsMargins(topMargin / 2, topMargin, topMargin / 2, topMargin / 2);
-
-            frame->setLayout(layout);
-
-            frame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-
-            scroll_area->setWidget(frame);
-
-            m_layout = layout;
-
-            scroll_area->show();
-            m_scrollArea = scroll_area;
-        }
+    OSLToySearchPathEditor(QWidget* parent,
+                           UpdatePathListAction updatePathsAction)
+        : QWidget(parent, static_cast<Qt::WindowFlags>(
+                              Qt::Tool | Qt::WindowStaysOnTopHint))
+        , m_lines()
+        , m_updateAction(updatePathsAction)
+    {
+        window()->setWindowTitle(tr("#include Search Path List"));
 
 
-    void set_path_list(const std::vector<std::string>& paths) {
+        int thisWidth  = parent->width();   // / 3;
+        int thisHeight = parent->height();  // / 4;
 
+        resize(thisWidth, thisHeight);
+
+        setFixedSize(size());
+
+        class MyScrollArea : public QScrollArea {
+            QWidget* m_parent;
+
+        public:
+            explicit MyScrollArea(QWidget* parent)
+                : QScrollArea(parent), m_parent(parent)
+            {
+            }
+
+            QSize sizeHint() const override { return m_parent->size(); }
+        };
+
+        class MyFrame : public QFrame {
+            QWidget* m_parent;
+
+        public:
+            explicit MyFrame(QWidget* parent) : QFrame(parent), m_parent(parent)
+            {
+            }
+
+            QSize sizeHint() const override { return m_parent->size(); }
+        };
+
+        auto scroll_area = new MyScrollArea(this);
+        scroll_area->setWidgetResizable(true);
+
+        auto frame = new MyFrame(scroll_area);
+        // frame->setWidgetResizable(true);
+
+        auto layout = new QVBoxLayout();
+        layout->setSpacing(0);
+        // int topMargin = thisWidth / 6;
+        // layout->setContentsMargins(topMargin / 2, topMargin, topMargin / 2, topMargin / 2);
+
+        frame->setLayout(layout);
+
+        frame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+        scroll_area->setWidget(frame);
+
+        m_layout = layout;
+
+        scroll_area->show();
+        m_scrollArea = scroll_area;
+    }
+
+
+    void set_path_list(const std::vector<std::string>& paths)
+    {
         while (!m_lines.empty())
             pop_line();
 
 
-        m_maxIndexWithContent = (int)paths.size() - 1; // ok that this is -1 if the paths are empty
+        m_maxIndexWithContent
+            = (int)paths.size()
+              - 1;  // ok that this is -1 if the paths are empty
 
 
 
@@ -481,24 +482,24 @@ public:
     }
 
 
-    void observe_changed_text() {
+    void observe_changed_text()
+    {
         // Only listen to signals from OSLToySearchPathLine objects
         if (auto changedLine = dynamic_cast<OSLToySearchPathLine*>(sender())) {
             bool isNowEmpty = changedLine->text().isEmpty();
 
             if (changedLine->previouslyHadContent() && isNowEmpty) {
                 if (changedLine->getIndex() == m_maxIndexWithContent) {
-
                     // Find the next max index with content, or -1 if none.
                     do {
                         --m_maxIndexWithContent;
-                    } while(m_maxIndexWithContent >= 0 && 
-                            !m_lines[m_maxIndexWithContent]->previouslyHadContent());
+                    } while (m_maxIndexWithContent >= 0
+                             && !m_lines[m_maxIndexWithContent]
+                                     ->previouslyHadContent());
 
                     shrink_as_needed();
                 }
-            }
-            else if (!changedLine->previouslyHadContent() && !isNowEmpty) {
+            } else if (!changedLine->previouslyHadContent() && !isNowEmpty) {
                 if (changedLine->getIndex() > m_maxIndexWithContent) {
                     m_maxIndexWithContent = changedLine->getIndex();
                     grow_as_needed();
@@ -510,8 +511,8 @@ public:
     }
 
 protected:
-
-    void closeEvent(QCloseEvent *ev) override {
+    void closeEvent(QCloseEvent* ev) override
+    {
         // On close, collate the list of search paths, and if there has been any change, update.
         bool has_updated = false;
 
@@ -530,26 +531,23 @@ protected:
 
 
 private:
-
-    
-
-    void push_line() 
+    void push_line()
     {
         auto l = new OSLToySearchPathLine(this, (int)m_lines.size());
-        
+
         m_layout->addWidget(l);
         m_lines.push_back(l);
     }
 
 
-    void pop_line() 
+    void pop_line()
     {
         auto line = m_lines.back();
         m_lines.pop_back();
         m_layout->removeWidget(line);
     }
 
-    void update_path_list() 
+    void update_path_list()
     {
         std::vector<std::string> path_list;
         for (auto line : m_lines) {
@@ -560,11 +558,15 @@ private:
         m_updateAction(path_list);
     }
 
-    size_t required_lines() const {
-        return static_cast<size_t>((std::max)(m_minLineCount, m_maxIndexWithContent + m_guaranteedEmptyLineCount + 1));
+    size_t required_lines() const
+    {
+        return static_cast<size_t>(
+            (std::max)(m_minLineCount,
+                       m_maxIndexWithContent + m_guaranteedEmptyLineCount + 1));
     }
 
-    void grow_as_needed() {
+    void grow_as_needed()
+    {
         auto newReqLines = required_lines();
 
         while (m_lines.size() < newReqLines) {
@@ -572,7 +574,8 @@ private:
         }
     }
 
-    void shrink_as_needed() {
+    void shrink_as_needed()
+    {
         auto newReqLines = required_lines();
 
         while (m_lines.size() > newReqLines) {
@@ -582,39 +585,40 @@ private:
 
 
 
-    int m_minLineCount = 12;
+    int m_minLineCount             = 12;
     int m_guaranteedEmptyLineCount = 5;
-    int m_maxIndexWithContent = -1;
+    int m_maxIndexWithContent      = -1;
     std::vector<OSLToySearchPathLine*> m_lines;
-    QLayout* m_layout = nullptr;
+    QLayout* m_layout         = nullptr;
     QScrollArea* m_scrollArea = nullptr;
     UpdatePathListAction m_updateAction;
 };
 
 
 
-OSLToySearchPathLine::OSLToySearchPathLine(OSLToySearchPathEditor* editor, int index) 
-        : QLineEdit(),
-        m_index(index),
-        m_editor(editor)
-        { 
-            setFrame(true);
+OSLToySearchPathLine::OSLToySearchPathLine(OSLToySearchPathEditor* editor,
+                                           int index)
+    : QLineEdit(), m_index(index), m_editor(editor)
+{
+    setFrame(true);
 
-            auto p = this->palette();
-            p.setColor(QPalette::Base, getColor(index));
-            setPalette(p);
+    auto p = this->palette();
+    p.setColor(QPalette::Base, getColor(index));
+    setPalette(p);
 
-            setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
-            QObject::connect(this, &OSLToySearchPathLine::editingFinished, 
-                             editor, &OSLToySearchPathEditor::observe_changed_text);
+    QObject::connect(this, &OSLToySearchPathLine::editingFinished, editor,
+                     &OSLToySearchPathEditor::observe_changed_text);
 
-            // Maybe add a QCompleter that completes known paths
-            // setCompletion
-            show();
-        }
+    // Maybe add a QCompleter that completes known paths
+    // setCompletion
+    show();
+}
 
-QSize OSLToySearchPathLine::sizeHint() const {
+QSize
+OSLToySearchPathLine::sizeHint() const
+{
     return QSize(m_editor->width() - 4, 10);
 }
 
@@ -725,9 +729,10 @@ OSLToyMainWindow::OSLToyMainWindow(OSLToyRenderer* rend, int xr, int yr)
             &OSLToyMainWindow::restart_time);
     control_area_layout->addWidget(restartButton);
 
-    searchPathEditor = new OSLToySearchPathEditor(this, [this](auto&& paths) mutable {
-        update_include_search_paths(paths);
-    });
+    searchPathEditor
+        = new OSLToySearchPathEditor(this, [this](auto&& paths) mutable {
+              update_include_search_paths(paths);
+          });
 
     auto editorarea = new QWidget;
     QFontMetrics fontmetrics(CodeEditor::fixedFont());
@@ -790,9 +795,8 @@ OSLToyMainWindow::createActions()
                &OSLToyMainWindow::action_fullscreen);
 
 
-    add_action("search-path-popup", 
-               "Edit #include search paths...", 
-               "Shift-Ctrl+P", 
+    add_action("search-path-popup", "Edit #include search paths...",
+               "Shift-Ctrl+P",
                &OSLToyMainWindow::action_open_search_path_popup);
 }
 
@@ -989,17 +993,17 @@ OSLToyMainWindow::open_file(const std::string& filename)
 }
 
 
-void 
-OSLToyMainWindow::set_include_search_paths(const std::vector<std::string>& paths) 
+void
+OSLToyMainWindow::set_include_search_paths(const std::vector<std::string>& paths)
 {
     searchPathEditor->set_path_list(paths);
 }
 
-void 
-OSLToyMainWindow::update_include_search_paths(const std::vector<std::string>& paths) 
+void
+OSLToyMainWindow::update_include_search_paths(
+    const std::vector<std::string>& paths)
 {
-
-    m_include_search_paths = paths;
+    m_include_search_paths              = paths;
     m_should_regenerate_compile_options = true;
 
     // Open question: Do we want to force a recompile whenever the list is updated?
@@ -1053,7 +1057,9 @@ OSLToyMainWindow::action_save()
 
 
 
-void OSLToyMainWindow::action_open_search_path_popup () {
+void
+OSLToyMainWindow::action_open_search_path_popup()
+{
     auto centeredXPos = x() + (width() - searchPathEditor->width()) / 2;
     auto centeredYPos = y() + (height() - searchPathEditor->height()) / 2;
     searchPathEditor->move(centeredXPos, centeredYPos);
@@ -1140,18 +1146,18 @@ private:
 };
 
 
-void 
+void
 OSLToyMainWindow::regenerate_compile_options()
 {
     // Right now, the only option we consider is include search path (-I)
-    
-    // Annoyingly, oslcomp only supports -I flags without any seperator between 
+
+    // Annoyingly, oslcomp only supports -I flags without any seperator between
     // the -I and the path itself, but OIIO::ArgParse does not support parsing
     // arguments in this manner. Oy vey.
 
     m_compile_options.clear();
 
-    for (auto&& path : m_include_search_paths) 
+    for (auto&& path : m_include_search_paths)
         m_compile_options.push_back(std::string("-I").append(path));
 
 
@@ -1189,14 +1195,13 @@ OSLToyMainWindow::recompile_shaders()
             if (m_should_regenerate_compile_options)
                 regenerate_compile_options();
 
-            ok = oslcomp.compile_buffer(source, osooutput, m_compile_options, "",
-                                        briefname);
+            ok = oslcomp.compile_buffer(source, osooutput, m_compile_options,
+                                        "", briefname);
 
             auto error_message = OIIO::Strutil::fmt::format(
-                    "{}\n\nCompiled {} with options: {}", 
-                    OIIO::Strutil::join(errhandler.errors, "\n"),
-                    briefname, 
-                    OIIO::Strutil::join(m_compile_options, " "));
+                "{}\n\nCompiled {} with options: {}",
+                OIIO::Strutil::join(errhandler.errors, "\n"), briefname,
+                OIIO::Strutil::join(m_compile_options, " "));
             set_error_message(tab, error_message);
 
             if (ok) {

--- a/src/osltoy/osltoyapp.h
+++ b/src/osltoy/osltoyapp.h
@@ -57,6 +57,7 @@ public:
 };
 
 class OSLToyRenderView;
+class OSLToySearchPathEditor;
 
 class OSLToyMainWindow final : public QMainWindow {
     Q_OBJECT
@@ -91,7 +92,8 @@ public:
 
     bool open_file(const std::string& filename);
 
-    void add_include_search_path(const std::string& path);
+    void set_include_search_paths(const std::vector<std::string>& paths);
+    void update_include_search_paths(const std::vector<std::string>& paths);
 
     void rerender_needed() { m_rerender_needed = 1; }
 
@@ -105,6 +107,7 @@ private:
     // for deleting.
     QSplitter* centralSplitter;
     OSLToyRenderView* renderView = nullptr;
+    OSLToySearchPathEditor* searchPathEditor = nullptr;
     QTabWidget* textTabs         = nullptr;
     QScrollArea* paramScroll     = nullptr;
     QWidget* paramWidget         = nullptr;
@@ -166,6 +169,8 @@ private:
     void action_drill() {}
     void action_fullscreen() {}
     void action_about() {}
+
+    void action_open_search_path_popup();
 
     void set_ui_to_paramval(ParamRec* param);
     void reset_param_to_default(ParamRec* param);

--- a/src/osltoy/osltoyapp.h
+++ b/src/osltoy/osltoyapp.h
@@ -106,12 +106,12 @@ private:
     // Non-owning pointers to all the widgets we create. Qt is responsible
     // for deleting.
     QSplitter* centralSplitter;
-    OSLToyRenderView* renderView = nullptr;
+    OSLToyRenderView* renderView             = nullptr;
     OSLToySearchPathEditor* searchPathEditor = nullptr;
-    QTabWidget* textTabs         = nullptr;
-    QScrollArea* paramScroll     = nullptr;
-    QWidget* paramWidget         = nullptr;
-    QGridLayout* paramLayout     = nullptr;
+    QTabWidget* textTabs                     = nullptr;
+    QScrollArea* paramScroll                 = nullptr;
+    QWidget* paramWidget                     = nullptr;
+    QGridLayout* paramLayout                 = nullptr;
     QLabel* statusFPS;
     QMenu *fileMenu, *editMenu, *viewMenu, *toolsMenu, *helpMenu;
     QPushButton *recompileButton, *pauseButton, *restartButton;

--- a/src/osltoy/osltoyapp.h
+++ b/src/osltoy/osltoyapp.h
@@ -91,6 +91,8 @@ public:
 
     bool open_file(const std::string& filename);
 
+    void add_include_search_path(const std::string& path);
+
     void rerender_needed() { m_rerender_needed = 1; }
 
 private slots:
@@ -183,6 +185,8 @@ private:
     void make_param_adjustment_row(ParamRec* param, QGridLayout* layout,
                                    int row);
 
+    void regenerate_compile_options();
+
     void rebuild_param_area();
     void inventory_params();
     OIIO::ImageBuf& framebuffer();
@@ -196,6 +200,13 @@ private:
     std::string m_firstshadername;
     std::string m_groupname;
     bool m_shader_uses_time = false;
+
+    std::vector<std::string> m_include_search_paths;
+
+
+    bool m_should_regenerate_compile_options = true;
+    std::vector<std::string> m_compile_options;
+
 
     // Access control mutex for handing things off between the GUI thread
     // and the shading thread.

--- a/src/osltoy/osltoymain.cpp
+++ b/src/osltoy/osltoymain.cpp
@@ -99,8 +99,7 @@ main(int argc, char* argv[])
     OSLToyMainWindow mainwin(rend, xres, yres);
     mainwin.show();
 
-    for (auto&& path : include_paths)
-        mainwin.add_include_search_path(path);
+    mainwin.set_include_search_paths(include_paths);
 
     for (auto&& filename : filenames)
         mainwin.open_file(filename);

--- a/src/osltoy/osltoymain.cpp
+++ b/src/osltoy/osltoymain.cpp
@@ -39,6 +39,7 @@ static bool foreground_mode = true;
 static int threads          = 0;
 static int xres = 512, yres = 512;
 static std::vector<std::string> filenames;
+static std::vector<std::string> include_paths;
 
 
 static void
@@ -58,6 +59,9 @@ getargs(int argc, char* argv[])
       .help("Set thread count (0=cores)");
     ap.arg("--res %d:XRES %d:YRES", &xres, &yres)
       .help("Set resolution");
+    ap.arg("-I DIRPATH")
+      .action([&](cspan<const char*> argv){ include_paths.emplace_back(argv[1]); })
+      .help("Add DIRPATH to the list of header search paths.");
     // clang-format on
     if (ap.parse(argc, (const char**)argv) < 0) {
         std::cerr << ap.geterror() << std::endl;
@@ -94,6 +98,10 @@ main(int argc, char* argv[])
     QApplication app(argc, argv);
     OSLToyMainWindow mainwin(rend, xres, yres);
     mainwin.show();
+
+    for (auto&& path : include_paths)
+        mainwin.add_include_search_path(path);
+
     for (auto&& filename : filenames)
         mainwin.open_file(filename);
 


### PR DESCRIPTION
## Description

For Dev Days

#1862 

Addressing a osltoy feature request, I've added the ability to specify custom search paths. 
The changes consist of the following:

- Added a command line option `-I <path>` to specify search paths (`OIIO::ArgParse` unfortunately can't mirror `OSLCompiler`'s `-Ipath` syntax)
- OSLToyMainWindow now stores an array of `OSLCompiler` options alongside a flag indicating whether or not they should be regenerated before compilation. The only option currently able to be specified is `-Ipath`, but this should ease any future extension.
- Added a GUI component consiting of a window with a mutable list of the current set of search paths. This list is initially populated with any paths passed via the command line, but any modifications to the list will be reflected when the shader is next recompiled. Modifying this list does not currently force recompilation.
- Added an entry to the Tools menu to open the new GUI component.
- Added a line of output to the error window indicating what options the compiler was invoked with. I've defaulted to having it print for every run, but this may want to only print on failure.

## Tests

I did not add any automated tests for this feature, as is consistent with the rest of osltoy. I did, however, do some manual testing to make sure the functionality works as expected.

Shaders that failed to `#include` some file instead succeeded when the parent directory of that file was added to the list of search paths via both the command line and the GUI component. Respectively, when said search path is then removed via
the GUI component, any subsequent compilation attempts fail again. The GUI component otherwise behaves as expected.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
