### PR TITLE
Fix typo in stdlib.md

### DIFF
--- a/src/doc/stdlib.md
+++ b/src/doc/stdlib.md
@@ -453,7 +453,7 @@ the computations are performed component-by-component (separately for `x`,
 
   : Returns 0 if $x < {\mathit edge}$ and 1 if $x \ge {\mathit edge}$.
 
-    The *`type`* may be any of of `float`, `color`, `point`, `vector`, or
+    The *`type`* may be any of `float`, `color`, `point`, `vector`, or
     `normal`.  For `color` and `point`-like types, the computations are
     performed component-by-component (separately for $x$, $y$, and $z$).
 
@@ -474,7 +474,7 @@ the computations are performed component-by-component (separately for `x`,
     `edge1`. This is useful in cases where you would want a thresholding
     function with a smooth transition.
 
-    The *`type`* may be any of of `float`, `color`, `point`, `vector`, or
+    The *`type`* may be any of `float`, `color`, `point`, `vector`, or
     `normal`.  For `color` and `point`-like types, the computations are
     performed component-by-component.
 


### PR DESCRIPTION
## Description
Fix tiny typos in stdlib documentation.
<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests
Not Applicable.
<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
