### PR TITLE
Update osltoyrenderer.cpp: auto-detect output variable -- doesn't need to be Cout if there's only on

### DIFF
--- a/src/osltoy/osltoyrenderer.cpp
+++ b/src/osltoy/osltoyrenderer.cpp
@@ -129,12 +129,31 @@ OSLToyRenderer::render_image()
         m_framebuffer.reset(
             OIIO::ImageSpec(m_xres, m_yres, 3, TypeDesc::FLOAT));
 
-    static ustring outputs[] = { ustring("Cout") };
+    std::vector<ustring> output_vars;
+
+    // Get the list of output variables from the shader group
+    shadingsys()->getattribute(shadergroup(), "renderer_outputs", output_vars);
+
+    // If no output variables are found, default to Cout
+    if (output_vars.empty()) {
+        output_vars.push_back(ustring("Cout"));
+    }
+
+    // If there's only one output variable, automatically use it
+    const ustring* outputs = &output_vars[0];
+    if (output_vars.size() == 1) {
+        outputs = &output_vars[0]; // auto-detect and use the single output
+    } else {
+        // If there are multiple outputs, you could implement additional logic here
+        // to choose between them or provide the user with a choice.
+        outputs = &output_vars[0]; // default to the first output
+    }
+
     OIIO::paropt popt(0, OIIO::paropt::SplitDir::Tile, 4096);
     shade_image(*shadingsys(), *shadergroup(), &m_shaderglobals_template,
                 m_framebuffer, outputs, ShadePixelCenters, OIIO::ROI(), popt);
-    //    std::cout << timer() << "\n";
 }
+
 
 
 


### PR DESCRIPTION
auto-detect output variable -- doesn't need to be Cout if there's only one


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
