### PR TITLE
deps: Add include to deal with OIIO 3.0 deprecations

### DIFF
--- a/src/testshade/rs_simplerend.cpp
+++ b/src/testshade/rs_simplerend.cpp
@@ -6,6 +6,8 @@
 #    error OSL_HOST_RS_BITCODE must be defined by your build system.
 #endif
 
+#include <OpenImageIO/fmath.h>
+
 #include <OSL/fmt_util.h>
 #include <OSL/journal.h>
 #include <OSL/rendererservices.h>


### PR DESCRIPTION
OIIO 3.0 shifts some things around slightly and requires us to include fmath.h directly in a place where we had been inadvertently relying on it getting included transitively (but now is not).
