### PR TITLE
build(deps): Fixes to using OIIO::ArgParse for OIIO 3.0

### DIFF
--- a/src/liboslexec/llvmutil_test.cpp
+++ b/src/liboslexec/llvmutil_test.cpp
@@ -23,7 +23,6 @@ static int memtest  = 0;
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     OIIO::ArgParse ap;
     // clang-format off
     ap.intro("llvmutil_test\n" OIIO_INTRO_STRING);
@@ -35,15 +34,7 @@ getargs(int argc, char* argv[])
     ap.arg("--memtest %d:ITERATIONS", &memtest)
       .help("Memory test mode");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+    ap.parse_args(argc, (const char**)argv);
 }
 
 

--- a/src/liboslnoise/oslnoise_test.cpp
+++ b/src/liboslnoise/oslnoise_test.cpp
@@ -369,7 +369,6 @@ test_hash()
 static void
 getargs(int argc, const char* argv[])
 {
-    bool help = false;
     OIIO::ArgParse ap;
     // clang-format off
     ap.intro("oslnoise_test  (" OSL_INTRO_STRING ")");
@@ -384,15 +383,7 @@ getargs(int argc, const char* argv[])
       .help("Number of trials");
     // clang-format on
 
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+    ap.parse_args(argc, (const char**)argv);
 }
 
 

--- a/src/oslinfo/oslinfo.cpp
+++ b/src/oslinfo/oslinfo.cpp
@@ -251,12 +251,9 @@ main(int argc, char* argv[])
       .help("Output information about just this parameter");
     // clang-format on
 
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        return EXIT_FAILURE;
-    } else if (filenames.empty()) {
-        ap.usage();
+    ap.parse_args(argc, (const char**)argv);
+    if (filenames.empty()) {
+        ap.print_help();
         return EXIT_SUCCESS;
     }
 

--- a/src/osltoy/osltoymain.cpp
+++ b/src/osltoy/osltoymain.cpp
@@ -45,7 +45,6 @@ static std::vector<std::string> include_paths;
 static void
 getargs(int argc, char* argv[])
 {
-    bool help = false;
     OIIO::ArgParse ap;
     // clang-format off
     ap.intro("osltoy -- interactive OSL plaything\n" OSL_INTRO_STRING);
@@ -63,15 +62,7 @@ getargs(int argc, char* argv[])
       .action([&](cspan<const char*> argv){ include_paths.emplace_back(argv[1]); })
       .help("Add DIRPATH to the list of header search paths.");
     // clang-format on
-    if (ap.parse(argc, (const char**)argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (help) {
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+    ap.parse_args(argc, (const char**)argv);
 }
 
 

--- a/src/testrender/testrender.cpp
+++ b/src/testrender/testrender.cpp
@@ -224,24 +224,15 @@ getargs(int argc, const char* argv[])
       .help("Set extra TextureSystem options");
 
     // clang-format on
-    if (ap["help"].get<int>()) {
-        ap.print_help();
-        ap.abort();
-        exit(EXIT_SUCCESS);
-    }
-    if (ap.parse(argc, argv) < 0) {
-        std::cerr << ap.geterror() << "\n\n";
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
+    ap.parse_args(argc, argv);
     if (scenefile.empty()) {
         std::cerr << "testrender: Must specify an xml scene file to open\n\n";
-        ap.usage();
+        ap.print_help();
         exit(EXIT_FAILURE);
     }
     if (imagefile.empty()) {
         std::cerr << "testrender: Must specify a filename for output render\n\n";
-        ap.usage();
+        ap.print_help();
         exit(EXIT_FAILURE);
     }
 }

--- a/src/testshade/testshade.cpp
+++ b/src/testshade/testshade.cpp
@@ -711,8 +711,6 @@ getargs(int argc, const char* argv[])
     ap.arg("filename")
       .hidden()
       .action([&](cspan<const char*> argv){ stash_shader_arg(argv); });
-    ap.arg("--help")
-      .help("Print help message");
     ap.arg("-v", &verbose)
       .help("Verbose messages");
     ap.arg("-t %d:NTHREADS", &num_threads)
@@ -863,16 +861,7 @@ getargs(int argc, const char* argv[])
       .help("journal jbuffer size in MB");
 
     // clang-format on
-    if (ap.parse(argc, argv) < 0) {
-        std::cerr << ap.geterror() << std::endl;
-        ap.usage();
-        exit(EXIT_FAILURE);
-    }
-    if (ap["help"].get<int>()) {
-        ap.usage();
-        print_info();
-        exit(EXIT_SUCCESS);
-    }
+    ap.parse_args(argc, argv);
 }
 
 
@@ -909,7 +898,7 @@ process_shader_setup_args(int argc, const char* argv[])
       .action([&](cspan<const char*> argv){ specify_expr(argv); });
 
     // clang-format on
-    if (ap.parse(argc, argv) < 0
+    if (ap.parse_args(argc, argv) < 0
         || (shadernames.empty() && groupspec.empty())) {
         std::cerr << "ERROR: No shader or group was specified.\n";
         std::cerr << ap.geterror() << std::endl;


### PR DESCRIPTION
OIIO 3.0 will finally warn aggressively about some long-deprecated ArgParse methods. Switch to the newer idioms on the OSL side.


