### PR TITLE
build(deps): Adjust to OIIO changes to TextureOpt structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,10 +139,6 @@ ifneq (${USE_SIMD},)
 MY_CMAKE_FLAGS += -DUSE_SIMD:STRING="${USE_SIMD}"
 endif
 
-ifneq (${USE_BATCHED},)
-MY_CMAKE_FLAGS += -DUSE_BATCHED:STRING="${USE_BATCHED}"
-endif
-
 ifneq (${VEC_REPORT},)
 MY_CMAKE_FLAGS += -DVEC_REPORT:BOOL="${VEC_REPORT}"
 endif
@@ -379,7 +375,7 @@ help:
 	@echo "                                  avx, avx2, avx512f)"
 	@echo "      OSL_USE_OPTIX=1          Build the OptiX test renderer"
 	@echo "      USE_BATCHED=targets      Build batched SIMD execution of shaders for (comma-separated choices:"
-	@echo "                                  0, b8_AVX, b8_AVX2, b8_AVX2_noFMA,"
+	@echo "                                  0, b4_SSE2, b8_AVX, b8_AVX2, b8_AVX2_noFMA,"
 	@echo "                                  b8_AVX512, b8_AVX512_noFMA,"
 	@echo "                                  b16_AVX512, b16_AVX512_noFMA)"
 	@echo "      VEC_REPORT=0             Generate compiler vectorization reports"

--- a/src/cmake/compiler.cmake
+++ b/src/cmake/compiler.cmake
@@ -338,7 +338,7 @@ endif ()
 #
 # The USE_BATCHED option may be set to indicate that support for batched
 # SIMD shader execution be compiled along with targe specific libraries
-set (USE_BATCHED "" CACHE STRING "Build batched SIMD shader execution for (0, b4_SSE2, b8_AVX, b8_AVX2, b8_AVX2_noFMA, b8_AVX512, b8_AVX512_noFMA, b16_AVX512, b16_AVX512_noFMA)")
+set_cache (USE_BATCHED "" "Build batched SIMD shader execution for (0, b4_SSE2, b8_AVX, b8_AVX2, b8_AVX2_noFMA, b8_AVX512, b8_AVX512_noFMA, b16_AVX512, b16_AVX512_noFMA)")
 option (VEC_REPORT "Enable compiler's reporting system for vectorization" OFF)
 set (BATCHED_SUPPORT_DEFINES "")
 set (BATCHED_TARGET_LIBS "")

--- a/src/include/OSL/batched_texture.h
+++ b/src/include/OSL/batched_texture.h
@@ -18,9 +18,11 @@ using OIIO::Tex::Wrap;
 
 struct UniformTextureOptions {
     // Options that must be the same for all points we're texturing at once
-    int firstchannel = 0;                  ///< First channel of the lookup
-    int subimage     = 0;                  ///< Subimage or face ID
-    ustring subimagename;                  ///< Subimage name
+    int firstchannel = 0;  ///< First channel of the lookup
+    int subimage     = 0;  ///< Subimage or face ID
+    ustring subimagename;  ///< Subimage name
+#if defined(OIIO_TEXTUREOPTBATCH_VERSION) && OIIO_TEXTUREOPTBATCH_VERSION >= 2
+    // Future expansion of an ideal v2 of OIIO's TextureOptBatch. But not yet.
     Tex::Wrap swrap = Tex::Wrap::Default;  ///< Wrap mode in the s direction
     Tex::Wrap twrap = Tex::Wrap::Default;  ///< Wrap mode in the t direction
     Tex::Wrap rwrap
@@ -28,8 +30,19 @@ struct UniformTextureOptions {
     Tex::MipMode mipmode = Tex::MipMode::Default;  ///< Mip mode
     Tex::InterpMode interpmode
         = Tex::InterpMode::SmartBicubic;  ///< Interpolation mode
-    int anisotropic           = 32;       ///< Maximum anisotropic ratio
-    int conservative_filter   = 1;        ///< True: over-blur rather than alias
+    int anisotropic         = 32;         ///< Maximum anisotropic ratio
+    int conservative_filter = 1;          ///< True: over-blur rather than alias
+#else
+    // Original (v1) sizing and layout of the TextureOptBatch struct.
+    int swrap      = int(Tex::Wrap::Default);  ///< Wrap mode in the s direction
+    int twrap      = int(Tex::Wrap::Default);  ///< Wrap mode in the t direction
+    int rwrap      = int(Tex::Wrap::Default);  ///< Wrap mode in r (volumetric)
+    int mipmode    = int(Tex::MipMode::Default);  ///< Mip mode
+    int interpmode = int(
+        Tex::InterpMode::SmartBicubic);  ///< Interpolation mode
+    int anisotropic         = 32;        ///< Maximum anisotropic ratio
+    int conservative_filter = 1;         ///< True: over-blur rather than alias
+#endif
     float fill                = 0.0f;     ///< Fill value for missing channels
     const float* missingcolor = nullptr;  ///< Color for missing texture
 };

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -745,14 +745,24 @@ BatchedBackendLLVM::llvm_type_batched_texture_options()
     sg_types.push_back(ll.type_wide_float());  // rnd
 
     // Uniform values of the batch
-    sg_types.push_back(ll.type_int());                 // firstchannel
-    sg_types.push_back(ll.type_int());                 // subimage
-    sg_types.push_back(vp);                            // subimagename
-    sg_types.push_back(ll.type_int());                 // swrap
-    sg_types.push_back(ll.type_int());                 // twrap
-    sg_types.push_back(ll.type_int());                 // rwrap
-    sg_types.push_back(ll.type_int());                 // mipmode
-    sg_types.push_back(ll.type_int());                 // interpmode
+    sg_types.push_back(ll.type_int());  // firstchannel
+    sg_types.push_back(ll.type_int());  // subimage
+    sg_types.push_back(vp);             // subimagename
+#if defined(OIIO_TEXTUREOPTBATCH_VERSION) && OIIO_TEXTUREOPTBATCH_VERSION >= 2
+    // Possible future TextureOptBatch v2 -- not active yet
+    sg_types.push_back(ll.type_int8());  // swrap
+    sg_types.push_back(ll.type_int8());  // twrap
+    sg_types.push_back(ll.type_int8());  // rwrap
+    sg_types.push_back(ll.type_int8());  // mipmode
+    sg_types.push_back(ll.type_int8());  // interpmode
+#else
+    // OIIO <= 3.0
+    sg_types.push_back(ll.type_int());  // swrap
+    sg_types.push_back(ll.type_int());  // twrap
+    sg_types.push_back(ll.type_int());  // rwrap
+    sg_types.push_back(ll.type_int());  // mipmode
+    sg_types.push_back(ll.type_int());  // interpmode
+#endif
     sg_types.push_back(ll.type_int());                 // anisotropic
     sg_types.push_back(ll.type_int());                 // conservative_filter
     sg_types.push_back(ll.type_float());               // fill

--- a/src/liboslexec/constfold.cpp
+++ b/src/liboslexec/constfold.cpp
@@ -2501,10 +2501,10 @@ DECLFOLDER(constfold_texture)
 // Keep from repeating the same tedious code for {s,t,r, }{width,blur,wrap}
 #define CHECK(field, ctype, osltype)                                      \
     if (name == Strings::field && !field##_set) {                         \
-        if (valuetype == osltype && *(ctype*)value == opt.field)          \
+        if (valuetype == osltype && *(ctype*)value == (ctype)opt.field)   \
             elide = true;                                                 \
         else if (osltype == TypeDesc::FLOAT && valuetype == TypeDesc::INT \
-                 && *(int*)value == opt.field)                            \
+                 && *(int*)value == (int)opt.field)                       \
             elide = true;                                                 \
         else                                                              \
             field##_set = true;                                           \
@@ -2520,8 +2520,8 @@ DECLFOLDER(constfold_texture)
     {                                                                          \
         if (valuetype == osltype) {                                            \
             ctype* v = (ctype*)value;                                          \
-            if (*v == opt.s##field && *v == opt.t##field                       \
-                && *v == opt.r##field)                                         \
+            if (*v == (ctype)opt.s##field && *v == (ctype)opt.t##field         \
+                && *v == (ctype)opt.r##field)                                  \
                 elide = true;                                                  \
             else {                                                             \
                 s##field##_set = true;                                         \
@@ -2530,8 +2530,8 @@ DECLFOLDER(constfold_texture)
             }                                                                  \
         } else if (osltype == TypeDesc::FLOAT && valuetype == TypeDesc::INT) { \
             int* v = (int*)value;                                              \
-            if (*v == opt.s##field && *v == opt.t##field                       \
-                && *v == opt.r##field)                                         \
+            if (*v == (ctype)opt.s##field && *v == (ctype)opt.t##field         \
+                && *v == (ctype)opt.r##field)                                  \
                 elide = true;                                                  \
             else {                                                             \
                 s##field##_set = true;                                         \
@@ -2573,7 +2573,8 @@ DECLFOLDER(constfold_texture)
             else if (name == Strings::interp && !interp_set)
             {
                 if (value && valuetype == TypeDesc::STRING
-                    && tex_interp_to_code(*(ustring*)value) == opt.interpmode)
+                    && tex_interp_to_code(*(ustring*)value)
+                           == (int)opt.interpmode)
                     elide = true;
                 else
                     interp_set = true;

--- a/src/liboslexec/optexture.cpp
+++ b/src/liboslexec/optexture.cpp
@@ -28,8 +28,10 @@ namespace pvt {
 OSL_SHADEOP OSL_HOSTDEVICE void
 osl_init_texture_options(OpaqueExecContextPtr oec, void* opt)
 {
+#if defined(OIIO_TEXTUREOPT_VERSION) && OIIO_TEXTUREOPT_VERSION >= 2
+    new (opt) TextureOpt;
+#else
     // TODO: Simplify when TextureOpt() has __device__ marker.
-    // new (opt) TextureOpt;
     TextureOpt* o          = reinterpret_cast<TextureOpt*>(opt);
     o->firstchannel        = 0;
     o->subimage            = 0;
@@ -46,20 +48,21 @@ osl_init_texture_options(OpaqueExecContextPtr oec, void* opt)
     o->twidth              = 1.0f;
     o->fill                = 0.0f;
     o->missingcolor        = nullptr;
-    o->time                = 0.0f;
+    o->time                = 0.0f;  // Deprecated
     o->rnd                 = -1.0f;
-    o->samples             = 1;
+    o->samples             = 1;  // Deprecated
     o->rwrap               = TextureOpt::WrapDefault;
     o->rblur               = 0.0f;
     o->rwidth              = 1.0f;
-#ifdef OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE
+#    ifdef OIIO_TEXTURESYSTEM_SUPPORTS_COLORSPACE
     o->colortransformid = 0;
     int* envlayout      = (int*)&o->colortransformid + 1;
-#else
+#    else
     int* envlayout = (int*)&o->rwidth + 1;
-#endif
+#    endif
     // envlayout is private so we access it from the last public member for now.
     *envlayout = 0;
+#endif
 }
 
 
@@ -89,7 +92,7 @@ decode_wrapmode(ustringhash_pod name_)
 OSL_SHADEOP OSL_HOSTDEVICE int
 osl_texture_decode_wrapmode(ustringhash_pod name_)
 {
-    return decode_wrapmode(name_);
+    return (int)decode_wrapmode(name_);
 }
 
 OSL_SHADEOP OSL_HOSTDEVICE void
@@ -202,7 +205,8 @@ osl_texture_set_fill(void* opt, float x)
 OSL_SHADEOP OSL_HOSTDEVICE void
 osl_texture_set_time(void* opt, float x)
 {
-    ((TextureOpt*)opt)->time = x;
+    // Not used by the texture system
+    // ((TextureOpt*)opt)->time = x;
 }
 
 OSL_SHADEOP OSL_HOSTDEVICE int

--- a/src/liboslexec/oslexec_pvt.h
+++ b/src/liboslexec/oslexec_pvt.h
@@ -23,9 +23,12 @@
 #    include <OSL/hashes.h>
 #endif
 
+#include <OpenImageIO/Imath.h>
+
 #include <OpenImageIO/color.h>
 #include <OpenImageIO/paramlist.h>
 #include <OpenImageIO/refcnt.h>
+#include <OpenImageIO/texture.h>
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/ustring.h>
 
@@ -2491,13 +2494,13 @@ tex_interp_to_code(ustringhash modename)
 {
     int mode = -1;
     if (modename == Hashes::smartcubic)
-        mode = TextureOpt::InterpSmartBicubic;
+        mode = (int)TextureOpt::InterpSmartBicubic;
     else if (modename == Hashes::linear)
-        mode = TextureOpt::InterpBilinear;
+        mode = (int)TextureOpt::InterpBilinear;
     else if (modename == Hashes::cubic)
-        mode = TextureOpt::InterpBicubic;
+        mode = (int)TextureOpt::InterpBicubic;
     else if (modename == Hashes::closest)
-        mode = TextureOpt::InterpClosest;
+        mode = (int)TextureOpt::InterpClosest;
     return mode;
 }
 
@@ -2507,13 +2510,13 @@ tex_interp_to_code(ustring modename)
 {
     int mode = -1;
     if (modename == Strings::smartcubic)
-        mode = TextureOpt::InterpSmartBicubic;
+        mode = (int)TextureOpt::InterpSmartBicubic;
     else if (modename == Strings::linear)
-        mode = TextureOpt::InterpBilinear;
+        mode = (int)TextureOpt::InterpBilinear;
     else if (modename == Strings::cubic)
-        mode = TextureOpt::InterpBicubic;
+        mode = (int)TextureOpt::InterpBicubic;
     else if (modename == Strings::closest)
-        mode = TextureOpt::InterpClosest;
+        mode = (int)TextureOpt::InterpClosest;
     return mode;
 }
 #endif


### PR DESCRIPTION
OIIO 3.0 changes the TextureOpt structure a bit, and we need to adjust on the OSL end, too.

To have context for this, you need to be aware of https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4485 and https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4490.