### PR TITLE
Reduce shared dependencies between liboslcomp and liboslexec

### DIFF
--- a/src/include/osl_pvt.h
+++ b/src/include/osl_pvt.h
@@ -98,6 +98,10 @@ public:
     /// is not responsible for freeing the characters.
     const char* c_str() const;
 
+    /// Return the c_str giving a human-readable name of a type, fully
+    /// accounting for exotic types like structs, etc.
+    const char* type_c_str() const;
+
     /// Stream output
     friend std::ostream& operator<<(std::ostream& o, const TypeSpec& t)
     {
@@ -372,6 +376,28 @@ public:
                || (dst.is_float_based() && !dst.is_array()
                    && (src.is_float() || src.is_int()));
     }
+
+    /// Given a pointer to a type code string that we use for argument
+    /// checking ("p", "v", etc.) return the TypeSpec of the first type
+    /// described by the string (UNKNOWN if it couldn't be recognized).
+    /// If 'advance' is non-NULL, set *advance to the number of
+    /// characters taken by the first code so the caller can advance
+    /// their pointer to the next code in the string.
+    static TypeSpec type_from_code(const char* code, int* advance = nullptr);
+
+    /// Return the argument checking code ("p", "v", etc.) corresponding
+    /// to the type.
+    std::string code_from_type() const;
+
+    /// Take a type code string (possibly containing many types)
+    /// and turn it into a human-readable string.
+    static std::string typelist_from_code(const char* code);
+
+    /// Take a type code string (possibly containing many types) and
+    /// turn it into a TypeSpec vector.
+    static void typespecs_from_codes(const char* code,
+                              std::vector<TypeSpec>& types);
+
 
 private:
     TypeDesc m_simple;  ///< Data if it's a simple type
@@ -1124,6 +1150,16 @@ private:
 
 
 typedef std::vector<Opcode> OpcodeVec;
+
+/// Called after code is generated, this function loops over all the ops
+/// and figures out the lifetimes of all variables, based on whether the
+/// args in each op are read or written. This function is used both in
+/// the compiler and the runtime optimizer.
+void track_variable_lifetimes_main(
+    const OpcodeVec& ircode,
+    const SymbolPtrVec& opargs,
+    const SymbolPtrVec& allsyms,
+    std::vector<int>* bblock_ids = nullptr);
 
 
 

--- a/src/liboslcomp/ast.cpp
+++ b/src/liboslcomp/ast.cpp
@@ -275,15 +275,6 @@ ASTNode::printchildren(std::ostream& out, int indentlevel) const
 }
 
 
-
-const char*
-ASTNode::type_c_str(const TypeSpec& type) const
-{
-    return m_compiler->type_c_str(type);
-}
-
-
-
 void
 ASTNode::list_to_vec(const ref& A, std::vector<ref>& vec)
 {
@@ -401,14 +392,14 @@ ASTfunction_declaration::ASTfunction_declaration(OSLCompilerImpl* comp,
 
     // Build up the argument signature for this declared function
     m_typespec           = type;
-    std::string argcodes = m_compiler->code_from_type(m_typespec);
+    std::string argcodes = m_typespec.code_from_type();
     for (ASTNode* arg = form; arg; arg = arg->nextptr()) {
         const TypeSpec& t(arg->typespec());
         if (t == TypeSpec() /* UNKNOWN */) {
             m_typespec = TypeDesc::UNKNOWN;
             return;
         }
-        argcodes += m_compiler->code_from_type(t);
+        argcodes += t.code_from_type();
         OSL_ASSERT(arg->nodetype() == variable_declaration_node);
         ASTvariable_declaration* v = (ASTvariable_declaration*)arg;
         if (v->init())

--- a/src/liboslcomp/ast.h
+++ b/src/liboslcomp/ast.h
@@ -349,11 +349,6 @@ protected:
     /// coercion if acceptfloat is false.
     Symbol* coerce(Symbol* sym, const TypeSpec& type, bool acceptfloat = false);
 
-    /// Return the c_str giving a human-readable name of a type, fully
-    /// accounting for exotic types like structs, etc.
-    /// N.B.: just conveniently wraps the compiler's identical method.
-    const char* type_c_str(const TypeSpec& type) const;
-
     /// Assign the struct variable named by srcsym to the struct
     /// variable named by dstsym by assigning each field individually.
     /// In the case of dstsym naming an array of structs, arrayindex

--- a/src/liboslcomp/codegen.cpp
+++ b/src/liboslcomp/codegen.cpp
@@ -1812,8 +1812,8 @@ ASTfunction_call::codegen(Symbol* dest)
     std::vector<TypeSpec> polyargs;
     const char* param_argcodes = func()->argcodes().c_str();
     int len;
-    m_compiler->type_from_code(param_argcodes, &len);  // skip ret type
-    m_compiler->typespecs_from_codes(param_argcodes + len, polyargs);
+    TypeSpec::type_from_code(param_argcodes, &len);  // skip ret type
+    TypeSpec::typespecs_from_codes(param_argcodes + len, polyargs);
 
     // Generate code for all the individual arguments.  Remember the
     // individual indices for arguments that are array elements or

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -192,27 +192,6 @@ public:
     }
     bool declaring_shader_formals() const { return m_declaring_shader_formals; }
 
-    /// Given a pointer to a type code string that we use for argument
-    /// checking ("p", "v", etc.) return the TypeSpec of the first type
-    /// described by the string (UNKNOWN if it couldn't be recognized).
-    /// If 'advance' is non-NULL, set *advance to the number of
-    /// characters taken by the first code so the caller can advance
-    /// their pointer to the next code in the string.
-    static TypeSpec type_from_code(const char* code, int* advance = NULL);
-
-    /// Return the argument checking code ("p", "v", etc.) corresponding
-    /// to the type.
-    std::string code_from_type(TypeSpec type) const;
-
-    /// Take a type code string (possibly containing many types)
-    /// and turn it into a human-readable string.
-    std::string typelist_from_code(const char* code) const;
-
-    /// Take a type code string (possibly containing many types) and
-    /// turn it into a TypeSpec vector.
-    void typespecs_from_codes(const char* code,
-                              std::vector<TypeSpec>& types) const;
-
     /// Emit a single IR opcode -- append one op to the list of
     /// intermediate code, returning the label (address) of the new op.
     int emitcode(const char* opname, size_t nargs, Symbol** args,
@@ -326,10 +305,6 @@ public:
         return loops ? m_loop_nesting : m_total_nesting;
     }
 
-    /// Return the c_str giving a human-readable name of a type, fully
-    /// accounting for exotic types like structs, etc.
-    const char* type_c_str(const TypeSpec& type) const;
-
     /// Given symbols sym1 and sym2, both the same kind of struct, and the
     /// index of a field we're interested, find the symbols that represent
     /// that field in the each sym and place them in field1 and field2,
@@ -346,10 +321,6 @@ public:
                            ustring sym1, ustring sym2, Symbol*& field1,
                            Symbol*& field2);
 
-    static void track_variable_lifetimes(const OpcodeVec& ircode,
-                                         const SymbolPtrVec& opargs,
-                                         const SymbolPtrVec& allsyms,
-                                         std::vector<int>* bblock_ids = NULL);
     static void coalesce_temporaries(SymbolPtrVec& symtab);
 
     ustring main_filename() const { return m_main_filename; }
@@ -399,7 +370,7 @@ private:
 
     void track_variable_lifetimes()
     {
-        track_variable_lifetimes(m_ircode, m_opargs, symtab().allsyms());
+        track_variable_lifetimes_main(m_ircode, m_opargs, symtab().allsyms());
     }
 
     void track_variable_dependencies();

--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -326,7 +326,7 @@ SymbolTable::print()
             const char* args        = f->argcodes().c_str();
             int advance             = 0;
             args += advance;
-            std::cout << " function (" << m_comp.typelist_from_code(args)
+            std::cout << " function (" << TypeSpec::typelist_from_code(args)
                       << ") ";
         }
         std::cout << "\n";
@@ -334,6 +334,90 @@ SymbolTable::print()
     std::cout << "\n";
 }
 
+static ustring op_for("for");
+static ustring op_while("while");
+static ustring op_dowhile("dowhile");
+
+void
+track_variable_lifetimes_main(const OpcodeVec& code,
+                              const SymbolPtrVec& opargs,
+                              const SymbolPtrVec& allsyms,
+                              std::vector<int>* bblockids)
+{
+    // Clear the lifetimes for all symbols
+    for (auto&& s : allsyms)
+        s->clear_rw();
+
+    // Keep track of the nested loops we're inside. We track them by pairs
+    // of begin/end instruction numbers for that loop body, including
+    // conditional evaluation (skip the initialization). Note that the end
+    // is inclusive. We use this vector of ranges as a stack.
+    typedef std::pair<int, int> intpair;
+    std::vector<intpair> loop_bounds;
+
+    // For each op, mark its arguments as being used at that op
+    int opnum = 0;
+    for (auto&& op : code) {
+        if (op.opname() == op_for || op.opname() == op_while
+            || op.opname() == op_dowhile) {
+            // If this is a loop op, we need to mark its control variable
+            // (the only arg) as used for the duration of the loop!
+            OSL_DASSERT(op.nargs() == 1);  // loops should have just one arg
+            SymbolPtr s  = opargs[op.firstarg()];
+            int loopcond = op.jump(0);  // after initialization, before test
+            int loopend  = op.farthest_jump() - 1;  // inclusive end
+            s->mark_rw(opnum + 1, true, true);
+            s->mark_rw(loopend, true, true);
+            // Also push the loop bounds for this loop
+            loop_bounds.push_back(std::make_pair(loopcond, loopend));
+        }
+
+        // Some work to do for each argument to the op...
+        for (int a = 0; a < op.nargs(); ++a) {
+            SymbolPtr s = opargs[op.firstarg() + a];
+            OSL_DASSERT(s->dealias() == s);  // Make sure it's de-aliased
+
+            // Mark that it's read and/or written for this op
+            bool readhere    = op.argread(a);
+            bool writtenhere = op.argwrite(a);
+            s->mark_rw(opnum, readhere, writtenhere);
+
+            // Adjust lifetimes of symbols whose values need to be preserved
+            // between loop iterations.
+            for (auto oprange : loop_bounds) {
+                int loopcond = oprange.first;
+                int loopend  = oprange.second;
+                OSL_DASSERT(s->firstuse() <= loopend);
+                // Special case: a temp or local, even if written inside a
+                // loop, if it's entire lifetime is within one basic block
+                // and it's strictly written before being read, then its
+                // lifetime is truly local and doesn't need to be expanded
+                // for the duration of the loop.
+                if (bblockids
+                    && (s->symtype() == SymTypeLocal
+                        || s->symtype() == SymTypeTemp)
+                    && (*bblockids)[s->firstuse()] == (*bblockids)[s->lastuse()]
+                    && s->lastwrite() < s->firstread()) {
+                    continue;
+                }
+                // Syms written before or inside the loop, and referenced
+                // inside or after the loop, need to preserve their value
+                // for the duration of the loop. We know it's referenced
+                // inside the loop because we're here examining it!
+                if (s->firstwrite() <= loopend) {
+                    s->mark_rw(loopcond, readhere, writtenhere);
+                    s->mark_rw(loopend, readhere, writtenhere);
+                }
+            }
+        }
+
+        ++opnum;  // Advance to the next op index
+
+        // Pop any loop bounds for loops we've just exited
+        while (!loop_bounds.empty() && loop_bounds.back().second < opnum)
+            loop_bounds.pop_back();
+    }
+}
 
 
 };  // namespace pvt

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -141,11 +141,7 @@ endif()
 if (BUILD_SHARED_LIBS)
     # oslcomp symbols used in oslexec
     list(APPEND lib_src
-        ../liboslcomp/ast.cpp
-        ../liboslcomp/codegen.cpp
-        ../liboslcomp/oslcomp.cpp
         ../liboslcomp/symtab.cpp
-        ../liboslcomp/typecheck.cpp
         )
 endif ()
 
@@ -153,9 +149,6 @@ file (GLOB exec_headers "*.h")
 file (GLOB compiler_headers "../liboslcomp/*.h")
 
 FLEX_BISON ( osolex.l osogram.y oso lib_src exec_headers )
-if (BUILD_SHARED_LIBS)
-    FLEX_BISON ( ../liboslcomp/osllex.l ../liboslcomp/oslgram.y osl lib_src compiler_headers )
-endif()
 
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS" )
 
@@ -581,7 +574,6 @@ target_link_libraries (${local_lib}
     PRIVATE
         pugixml::pugixml
         ${CMAKE_DL_LIBS}
-        ${CLANG_LIBRARIES}
         ${LLVM_LIBRARIES} ${LLVM_LDFLAGS} ${LLVM_SYSTEM_LIBRARIES}
     )
 

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -154,7 +154,7 @@ possibly_wide_type_from_code(const char* code, int* advance, bool& is_uniform)
         is_uniform = true;
     }
 
-    TypeSpec t = OSLCompilerImpl::type_from_code(code + i, advance);
+    TypeSpec t = TypeSpec::type_from_code(code + i, advance);
 
     if (advance)
         *advance += i;

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -1899,11 +1899,11 @@ BackendLLVM::initialize_llvm_group()
         bool varargs      = false;
         const char* types = i->second.argtypes;
         int advance;
-        TypeSpec rettype = OSLCompilerImpl::type_from_code(types, &advance);
+        TypeSpec rettype = TypeSpec::type_from_code(types, &advance);
         types += advance;
         std::vector<llvm::Type*> params;
         while (*types) {
-            TypeSpec t = OSLCompilerImpl::type_from_code(types, &advance);
+            TypeSpec t = TypeSpec::type_from_code(types, &advance);
             if (t.simpletype().basetype == TypeDesc::UNKNOWN) {
                 OSL_DASSERT(*types == '*');
                 if (*types == '*')

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -163,7 +163,7 @@ ShaderMaster::resolve_syms()
     oparg_ptrs.reserve(m_args.size());
     for (auto&& a : m_args)
         oparg_ptrs.push_back(symbol(a));
-    OSLCompilerImpl::track_variable_lifetimes(m_ops, oparg_ptrs, allsymptrs);
+    track_variable_lifetimes_main(m_ops, oparg_ptrs, allsymptrs);
 
     // Figure out which ray types are queried
     m_raytype_queries = 0;

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -46,6 +46,7 @@ static ustring u_calculatenormal("calculatenormal");
 static ustring u_flipHandedness("flipHandedness");
 static ustring u_N("N");
 static ustring u_I("I");
+static ustring main_method_name("___main___");
 
 
 OSL_NAMESPACE_ENTER
@@ -541,7 +542,7 @@ RuntimeOptimizer::insert_code(int opnum, ustring opname,
     std::vector<int>& opargs(inst()->args());
     ustring method = (opnum < (int)code.size())
                          ? code[opnum].method()
-                         : OSLCompilerImpl::main_method_name();
+                         : main_method_name;
     int nargs      = args_to_add.size();
     Opcode op(opname, method, opargs.size(), nargs);
     code.insert(code.begin() + opnum, op);
@@ -675,7 +676,7 @@ RuntimeOptimizer::insert_useparam(size_t opnum,
         code[opnum].method(code[opnum + 1].method());
     } else {
         // If there IS no "next" instruction, just call it main
-        code[opnum].method(OSLCompilerImpl::main_method_name());
+        code[opnum].method(main_method_name);
     }
 }
 
@@ -746,7 +747,7 @@ RuntimeOptimizer::add_useparam(SymbolPtrVec& allsyms)
                         params.push_back(opargs[argind]);
                     // mark as already initialized unconditionally, if we do
                     if (op_is_unconditionally_executed(opnum)
-                        && op.method() == OSLCompilerImpl::main_method_name())
+                        && op.method() == main_method_name)
                         s->initialized(true);
                 }
             }
@@ -2517,8 +2518,7 @@ RuntimeOptimizer::track_variable_lifetimes(const SymbolPtrVec& allsymptrs)
     if (m_bblockids.size() != inst()->ops().size())
         find_basic_blocks();
 
-    OSLCompilerImpl::track_variable_lifetimes(inst()->ops(), oparg_ptrs,
-                                              allsymptrs, &m_bblockids);
+    track_variable_lifetimes_main(inst()->ops(), oparg_ptrs, allsymptrs, &m_bblockids);
 }
 
 

--- a/src/liboslexec/typespec.cpp
+++ b/src/liboslexec/typespec.cpp
@@ -76,6 +76,15 @@ TypeSpec::c_str() const
 }
 
 
+const char*
+TypeSpec::type_c_str() const
+{
+    if (is_structure())
+        return ustring::fmtformat("struct {}", structspec()->name()).c_str();
+    else
+        return c_str();
+}
+
 
 int
 TypeSpec::structure_id(const char* name, bool add)
@@ -109,6 +118,157 @@ TypeSpec::new_struct(StructSpec* n)
     return (int)m_structs.size() - 1;
 }
 
+TypeSpec TypeSpec::type_from_code(const char* code, int* advance)
+{
+    TypeSpec t;
+    int i = 0;
+    switch (code[i]) {
+    case 'i': t = TypeInt; break;
+    case 'f': t = TypeFloat; break;
+    case 'c': t = TypeColor; break;
+    case 'p': t = TypePoint; break;
+    case 'v': t = TypeVector; break;
+    case 'n': t = TypeNormal; break;
+    case 'm': t = TypeMatrix; break;
+    case 's': t = TypeString; break;
+    case 'h': t = OSL::TypeUInt64; break;  // ustringhash_pod
+    case 'x': t = TypeDesc(TypeDesc::NONE); break;
+    case 'X': t = TypeDesc(TypeDesc::PTR); break;
+    case 'L': t = TypeDesc(TypeDesc::LONGLONG); break;
+    case 'C':  // color closure
+        t = TypeSpec(TypeColor, true);
+        break;
+    case 'S':  // structure
+        // Following the 'S' is the numeric structure ID
+        t = TypeSpec("struct", atoi(code + i + 1));
+        // Skip to the last digit
+        while (isdigit(code[i + 1]))
+            ++i;
+        break;
+    case '?': break;  // anything will match, so keep 'UNKNOWN'
+    case '*': break;  // anything will match, so keep 'UNKNOWN'
+    case '.': break;  // anything will match, so keep 'UNKNOWN'
+    default:
+        OSL_DASSERT_MSG(0, "Don't know how to decode type code '%d'",
+                        (int)code[0]);
+        if (advance)
+            *advance = 1;
+        return TypeSpec();
+    }
+    ++i;
+
+    if (code[i] == '[') {
+        ++i;
+        t.make_array(-1);  // signal arrayness, unknown length
+        if (isdigit(code[i]) || code[i] == ']') {
+            if (isdigit(code[i]))
+                t.make_array(atoi(code + i));
+            while (isdigit(code[i]))
+                ++i;
+            if (code[i] == ']')
+                ++i;
+        }
+    }
+
+    if (advance)
+        *advance = i;
+    return t;
+}
+
+std::string
+TypeSpec::typelist_from_code(const char* code)
+{
+    std::string ret;
+    while (*code) {
+        // Handle some special cases
+        int advance = 1;
+        if (ret.length())
+            ret += ", ";
+        if (*code == '.') {
+            ret += "...";
+        } else if (*code == 'T') {
+            ret += "...";
+        } else if (*code == '?') {
+            ret += "<any>";
+        } else {
+            TypeSpec t = TypeSpec::type_from_code(code, &advance);
+            ret += t.type_c_str();
+        }
+        code += advance;
+        if (*code == '[') {
+            ret += "[]";
+            ++code;
+            while (isdigit(*code))
+                ++code;
+            if (*code == ']')
+                ++code;
+        }
+    }
+
+    return ret;
+}
+
+
+
+std::string
+TypeSpec::code_from_type() const
+{
+    std::string out;
+    TypeDesc elem = elementtype().simpletype();
+    if (is_structure() || is_structure_array()) {
+        out = Strutil::fmt::format("S{}", structure());
+    } else if (is_closure() || is_closure_array()) {
+        out = 'C';
+    } else {
+        if (elem == TypeInt)
+            out = 'i';
+        else if (elem == TypeFloat)
+            out = 'f';
+        else if (elem == TypeColor)
+            out = 'c';
+        else if (elem == TypePoint)
+            out = 'p';
+        else if (elem == TypeVector)
+            out = 'v';
+        else if (elem == TypeNormal)
+            out = 'n';
+        else if (elem == TypeMatrix)
+            out = 'm';
+        else if (elem == TypeString)
+            out = 's';
+        else if (elem == TypeDesc::NONE)
+            out = 'x';
+        else {
+            out = 'x';
+            // This only happens in error circumstances. Seems safe to
+            // return the code for 'void' and hope everything sorts itself
+            // out with the downstream errors.
+        }
+    }
+
+    if (is_array()) {
+        if (is_unsized_array())
+            out += "[]";
+        else
+            out += Strutil::fmt::format("[{}]", arraylength());
+    }
+
+    return out;
+}
+
+
+
+void
+TypeSpec::typespecs_from_codes(const char* code,
+                                      std::vector<TypeSpec>& types)
+{
+    types.clear();
+    while (code && *code) {
+        int advance;
+        types.push_back(TypeSpec::type_from_code(code, &advance));
+        code += advance;
+    }
+}
 
 
 bool

--- a/src/osl.imageio/CMakeLists.txt
+++ b/src/osl.imageio/CMakeLists.txt
@@ -53,4 +53,4 @@ endmacro ()
 
 
 add_oiio_plugin (oslinput.cpp
-        LINK_LIBRARIES oslexec)
+        LINK_LIBRARIES oslexec oslcomp)

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -77,7 +77,7 @@ add_executable ( testshade ${testshade_srcs} testshademain.cpp )
 
 target_link_libraries (testshade
                        PRIVATE
-                           oslexec oslquery)
+                           oslexec oslquery oslcomp)
 
 install (TARGETS testshade RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
@@ -104,7 +104,7 @@ if (NOT CODECOV)
 
     target_link_libraries (libtestshade
                            PRIVATE
-                               oslexec oslquery)
+                               oslexec oslquery oslcomp)
     set_target_properties (libtestshade PROPERTIES PREFIX "")
 
     install_targets ( libtestshade )


### PR DESCRIPTION

## Description

This PR reduces some of the code sharing going on between `liboslcomp` and `liboslexec`. In particular, we no longer need access to `OSLCompilerImpl` from `liboslexec` which lets us avoid pulling in `libclang` for this library, as well as avoids needing a copy of the `.osl` lexer/parser in `liboslexec`.

Most of the shared code centered around a few utility functions related to `TypeDesc`. I've extracted these as standalone methods in that class instead.

The only really substantial function is `track_variable_lifetimes` which is used both by `liboslcomp` and `liboslexec`. Luckily it is totally standalone, so I've now extracted it from its parent class and left it as a free function. Further refactors may enable us to move it to only one of the two libraries.

I discovered this while working on swapping out the preprocessor.

## Tests

Unit tests are passing on my machine.

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
