### PR TITLE
Fix the OptiX path in testrender and testshade

### DIFF
--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -210,7 +210,7 @@ static_assert(sizeof(TypeDesc_pod) == sizeof(TypeDesc),
               "TypeDesc size differs from its POD counterpart");
 
 /// Convenience function to convert to a TypeDesc.
-inline TypeDesc
+OSL_HOSTDEVICE inline TypeDesc
 TypeDesc_from(TypeDesc_pod type)
 {
     return OSL::bitcast<OSL::TypeDesc>(type);

--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -21,6 +21,7 @@ if (OSL_USE_OPTIX)
 
     set (testrender_rend_lib_srcs
         cuda/rend_lib.cu
+        ../testshade/rs_simplerend.cpp
         )
 
     # We need to make sure that the PTX files are regenerated whenever these

--- a/src/testrender/cuda/rend_lib.cu
+++ b/src/testrender/cuda/rend_lib.cu
@@ -364,35 +364,6 @@ make_float3(const float4& a)
 
 
 
-// FIXME:
-// clang++ 9.0 seems to have trouble with tex2d<float4>() look-ups,
-// so we'll declare this external and implement texture lookups in
-// CUDA files compiled by nvcc (optix_grid_renderer.cu and
-// optix_raytrace.cu).
-// (clang++ 9.0 error 'undefined __nv_tex_surf_handler')
-extern __device__ float4
-osl_tex2DLookup(void* handle, float s, float t);
-
-__device__ int
-osl_texture(void* sg_, OSL::ustringhash_pod name, void* handle, void* opt_,
-            float s, float t, float dsdx, float dtdx, float dsdy, float dtdy,
-            int chans, void* result, void* dresultdx, void* dresultdy,
-            void* alpha, void* dalphadx, void* dalphady,
-            void* ustringhash_errormessage)
-{
-    if (!handle)
-        return 0;
-    // cudaTextureObject_t texID = cudaTextureObject_t(handle);
-    float4 fromTexture = osl_tex2DLookup(handle, s, t);
-    // see note above
-    // float4 fromTexture = tex2D<float4>(texID, s, t);
-    *((float3*)result) = make_float3(fromTexture.x, fromTexture.y,
-                                     fromTexture.z);
-    return 1;
-}
-
-
-
 __device__ int
 osl_range_check_err(int indexvalue, int length, OSL::ustringhash_pod symname,
                     void* sg, OSL::ustringhash_pod sourcefile, int sourceline,

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -21,6 +21,7 @@ if (OSL_USE_OPTIX)
 
     set (testshade_rend_lib_srcs
         ../testrender/cuda/rend_lib.cu
+        rs_simplerend.cpp
         )
 
     set ( testshade_cuda_headers

--- a/src/testshade/cuda/optix_grid_renderer.cu
+++ b/src/testshade/cuda/optix_grid_renderer.cu
@@ -168,8 +168,6 @@ __raygen__()
     output_buffer[pixel] = { f_output[1], f_output[2], f_output[3] };
 }
 
-
-
 // Because clang++ 9.0 seems to have trouble with some of the texturing "intrinsics"
 // let's do the texture look-ups in this file.
 extern "C" __device__ float4


### PR DESCRIPTION
## Description

The recent free function change (#1852) put the OptiX paths in testrender and testshade in a non-working state (issue #1894). The bitcode for the free functions wasn't plumbed through for OptiX. This PR rolls the free function definitions into the existing "rendlib" bitcode and PTX. This is somewhat of a stopgap fix; eventually we'll want to handle the free function more explicitly.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

No new tests added. But all existing OptiX tests pass.


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
