### PR TITLE
deps: Raise dependencies: cmake 3.19, OIIO 2.5, LLVM 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: gcc9/C++17 llvm11 py3.7 oiio2.4 sse4 batch-b8avx2
+          - desc: gcc9/C++17 llvm11 py3.7 oiio2.5 sse4 batch-b8avx2
             nametag: linux-vfx2021
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2021-clang11
@@ -46,7 +46,7 @@ jobs:
             old_node: 1
             cxx_std: 17
             openexr_ver: v3.1.3
-            openimageio_ver: v2.4.13.0
+            openimageio_ver: v2.5.4.0
             python_ver: 3.7
             pybind11_ver: v2.7.0
             simd: sse4.2
@@ -72,25 +72,26 @@ jobs:
             old_node: 1
             cxx_std: 17
             opencolorio_ver: v2.2.1
-            openimageio_ver: main
+            openimageio_ver: v3.0.2.0
             python_ver: 3.9
             pybind11_ver: v2.7.0
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
             setenvs: USE_OPENVDB=0
-          - desc: gcc9/C++17 llvm11 py3.9 exr3.1 oiio2.3 sse2 batch-b4sse2
+          - desc: gcc9/C++17 llvm11 py3.9 exr3.1 oiio3.0 sse2 batch-b4sse2
             nametag: linux-vfx2021
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2022-clang13
             vfxyear: 2022
             old_node: 1
             cxx_std: 17
-            openimageio_ver: release
+            opencolorio_ver: v2.2.0
+            openimageio_ver: dev-3.0
             python_ver: 3.9
             pybind11_ver: v2.9.0
             simd: sse2
             batched: b4_SSE2
-          - desc: oldest everything gcc9/C++17 llvm9 py3.7 oiio2.3 no-simd
+          - desc: oldest everything gcc9/C++17 llvm9 py3.7 oiio2.5 no-simd
             nametag: linux-oldest
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2021-clang11
@@ -98,12 +99,12 @@ jobs:
             old_node: 1
             cxx_std: 17
             openexr_ver: v3.1.0
-            openimageio_ver: v2.4.13.0
+            openimageio_ver: v2.5.4.0
             python_ver: 3.7
             pybind11_ver: v2.7.0
-            simd: 0
+            # simd: 0
             setenvs: export PUGIXML_VERSION=v1.8
-                            CMAKE_VERSION=3.15.5
+                            CMAKE_VERSION=3.19.0
                             ENABLE_OPENVDB=0
 
 
@@ -307,7 +308,7 @@ jobs:
             cc_compiler: gcc
             cxx_compiler: g++
             cxx_std: 17
-            # openimageio_ver: release
+            openimageio_ver: release
             python_ver: "3.10"
             simd: "avx2,f16c"
             batched: b8_AVX2
@@ -344,7 +345,7 @@ jobs:
             setenvs: export OSL_CMAKE_FLAGS="-DSTOP_ON_WARNING=OFF -DEXTRA_CPP_ARGS=-fp-model=consistent"
                             OPENIMAGEIO_CMAKE_FLAGS=-DBUILD_FMT_VERSION=7.1.3
                             USE_OPENVDB=0 OPENCOLORIO_CXX=g++
-          - desc: icx/C++17 llvm14 py3.9 oiio2.3 avx2
+          - desc: icx/C++17 llvm14 py3.10 oiio-3.0 avx2
             nametag: linux-icx
             runner: ubuntu-latest
             container: aswftesting/ci-osl:2023-clang15
@@ -354,7 +355,7 @@ jobs:
             cxx_std: 17
             fmt_ver: 7.1.3
             opencolorio_ver: v2.3.2
-            openimageio_ver: main
+            openimageio_ver: v3.0.2.0
             python_ver: "3.10"
             pybind11_ver: v2.10.0
             simd: avx2,f16c
@@ -464,22 +465,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: Debug gcc7/C++17 llvm9 py3.7 oiio2.3 exr2.4 sse4 exr2.4
-            nametag: linux-debug-gcc7-llvm9
+          - desc: Debug gcc7/C++17 llvm11 py3.8 oiio2.5 exr3.1 sse4
+            nametag: linux-debug-gcc7-llvm11
             runner: ubuntu-20.04
             cxx_compiler: g++-9
             cxx_std: 17
             openexr_ver: v3.1.11
-            openimageio_ver: v2.4.13.0
+            openimageio_ver: v2.5.4.0
             pybind11_ver: v2.7.0
             python_ver: 3.8
             simd: sse4.2
             setenvs: export CMAKE_BUILD_TYPE=Debug
-                            LLVM_VERSION=9.0.0
+                            LLVM_VERSION=11.0.0 LLVM_DISTRO_NAME=ubuntu-20.04
                             PUGIXML_VERSION=v1.9
                             CTEST_TEST_TIMEOUT=240
-          - desc: gcc10/C++17 llvm10 oiio-2.5 avx2
-            nametag: linux-2021ish-gcc10-llvm10
+          - desc: gcc10/C++17 llvm11 oiio-2.5 avx2
+            nametag: linux-2021ish-gcc10-llvm11
             runner: ubuntu-20.04
             cxx_compiler: g++-10
             cxx_std: 17
@@ -489,10 +490,10 @@ jobs:
             pybind11_ver: v2.8.1
             python_ver: 3.8
             simd: avx2,f16c
-            setenvs: export LLVM_VERSION=10.0.0
+            setenvs: export LLVM_VERSION=11.0.0 LLVM_DISTRO_NAME=ubuntu-20.04
                             OPENIMAGEIO_CMAKE_FLAGS="-DBUILD_FMT_VERSION=7.0.1"
                             PUGIXML_VERSION=v1.10
-          - desc: latest releases gcc11/C++17 llvm17 exr3.2 py3.10 avx2 batch-b16avx512
+          - desc: latest releases gcc11/C++17 llvm17 oiio-3.0 exr3.2 py3.12 avx2 batch-b16avx512
             nametag: linux-latest-releases
             runner: ubuntu-24.04
             cc_compiler: gcc-13
@@ -501,7 +502,7 @@ jobs:
             fmt_ver: 11.0.2
             opencolorio_ver: v2.4.0
             openexr_ver: v3.3.0
-            openimageio_ver: main
+            openimageio_ver: release
             pybind11_ver: v2.13.5
             python_ver: "3.12"
             simd: avx2,f16c
@@ -512,7 +513,7 @@ jobs:
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.14
                             FREETYPE_VERSION=VER-2-13-3
-          - desc: bleeding edge gcc12/C++17 llvm17 oiio/ocio/exr/pybind-main py3.10 avx2 batch-b16avx512
+          - desc: bleeding edge gcc12/C++17 llvm17 oiio/ocio/exr/pybind-main py3.12 avx2 batch-b16avx512
             nametag: linux-bleeding-edge
             runner: ubuntu-24.04
             cc_compiler: gcc-13

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.19)
 
 set (OSL_VERSION "1.14.3.0")
 set (OSL_VERSION_OVERRIDE "" CACHE STRING

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,16 +19,18 @@ Dependencies
 OSL requires the following dependencies or tools.
 NEW or CHANGED dependencies since the last major release are **bold**.
 
-* Build system: [CMake](https://cmake.org/) **3.15 or newer** (tested through 3.30)
+* Build system: [CMake](https://cmake.org/) **3.19 or newer** (tested
+  through 3.31)
 
 * A suitable C++17 compiler to build OSL itself, which may be any of:
-   - **GCC 9.3** or newer (tested through gcc 12.1)
-   - **Clang 5** or newer (tested through clang 18)
+   - **GCC 9.3** or newer (tested through gcc 13.1)
+   - **Clang 5** or newer (tested through clang 19)
    - Microsoft Visual Studio 2017 or newer
    - Intel C++ compiler **icc version 19** or newer or LLVM-based icx compiler
      version 2022 or newer.
 
-* **[OpenImageIO](http://openimageio.org) 2.4 or newer** (tested through 2.5 and main)
+* **[OpenImageIO](http://openimageio.org) 2.5 or newer** (tested through 3.0
+  and main)
 
     OSL uses OIIO both for its texture mapping functionality as well as
     numerous utility classes.  If you are integrating OSL into an existing
@@ -47,8 +49,8 @@ NEW or CHANGED dependencies since the last major release are **bold**.
     $OpenImageIO_ROOT/lib to be in your LD_LIBRARY_PATH (or
     DYLD_LIBRARY_PATH on OS X).
 
-* [LLVM](http://www.llvm.org) 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, or 19,
-  including clang libraries.
+* [LLVM](http://www.llvm.org) 11, 12, 13, 14, 15, 16, 17, 18, or 19, including
+  clang libraries.
 
 * (optional) For GPU rendering on NVIDIA GPUs:
     * [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) 7.0 or higher.

--- a/src/build-scripts/build_cmake.bash
+++ b/src/build-scripts/build_cmake.bash
@@ -12,7 +12,7 @@ set -ex
 echo "Building cmake"
 uname
 
-CMAKE_VERSION=${CMAKE_VERSION:=3.18.5}
+CMAKE_VERSION=${CMAKE_VERSION:=3.31.3}
 LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 CMAKE_INSTALL_DIR=${CMAKE_INSTALL_DIR:=${LOCAL_DEPS_DIR}/cmake}
 
@@ -25,8 +25,8 @@ fi
 
 if [[ `uname` == "Linux" && `uname -m` == "aarch64" ]] ; then
     mkdir -p ${CMAKE_INSTALL_DIR} || true
-    curl --location https://anaconda.org/conda-forge/cmake/3.17.0/download/linux-aarch64/cmake-3.17.0-h28c56e5_0.tar.bz2 -o cmake-3.17.0-h28c56e5_0.tar.bz2
-    tar -xjf cmake-3.17.0-h28c56e5_0.tar.bz2 -C ${CMAKE_INSTALL_DIR}
+    curl --location "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-aarch64.sh" -o "cmake.sh"
+    sh cmake.sh --skip-license --prefix=${CMAKE_INSTALL_DIR}
     export PATH=${CMAKE_INSTALL_DIR}/bin:$PATH
 
     # In case we ever need to build from scratch:

--- a/src/build-scripts/build_llvm.bash
+++ b/src/build-scripts/build_llvm.bash
@@ -19,14 +19,7 @@ if [[ `uname` == "Linux" ]] ; then
     : ${LLVM_DISTRO_NAME:=ubuntu-18.04}
     LLVMTAR=clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-${LLVM_DISTRO_NAME}.tar.xz
     echo LLVMTAR = $LLVMTAR
-    if [[ "$LLVM_VERSION" == "9.0.0" ]] || [[ "$LLVM_VERSION" == "9.0.1" ]] ;
-    then
-        # old -- get rid of this when LLVM 10 is the newest we allow
-        curl --location http://releases.llvm.org/${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
-    else
-        # new
-        curl --location https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
-    fi
+    curl --location https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVMTAR} -o $LLVMTAR
     ls -l $LLVMTAR
     tar xf $LLVMTAR
     rm -f $LLVMTAR

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -48,7 +48,7 @@ set (OSL_USING_IMATH 3)
 
 # OpenImageIO
 checked_find_package (OpenImageIO REQUIRED
-                      VERSION_MIN 2.4
+                      VERSION_MIN 2.5
                       DEFINITIONS OIIO_HIDE_FORMAT=1)
 
 checked_find_package (pugixml REQUIRED
@@ -57,7 +57,7 @@ checked_find_package (pugixml REQUIRED
 
 # LLVM library setup
 checked_find_package (LLVM REQUIRED
-                      VERSION_MIN 9.0
+                      VERSION_MIN 11.0
                       VERSION_MAX 19.9
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES)
 # ensure include directory is added (in case of non-standard locations
@@ -70,15 +70,6 @@ add_compile_definitions (OSL_LLVM_VERSION=${OSL_LLVM_VERSION})
 add_compile_definitions (OSL_LLVM_FULL_VERSION="${LLVM_VERSION}")
 if (LLVM_NAMESPACE)
     add_compile_definitions (LLVM_NAMESPACE=${LLVM_NAMESPACE})
-endif ()
-if (APPLE AND LLVM_VERSION VERSION_EQUAL 10.0.1 AND EXISTS "/usr/local/Cellar/llvm")
-    message (WARNING
-             "${ColorYellow}If you are using LLVM 10.0.1 installed by Homebrew, "
-             "please note that a known bug in LLVM may produce a link error where "
-             "it says it can't find libxml2.tbd. If you encounter this, please "
-             "try upgrading to a newer LLVM: \n"
-             "    brew upgrade llvm \n"
-             "${ColorReset}\n")
 endif ()
 if (LLVM_VERSION VERSION_GREATER_EQUAL 15.0 AND CMAKE_COMPILER_IS_CLANG
     AND ANY_CLANG_VERSION_STRING VERSION_LESS 15.0)

--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -99,7 +99,7 @@ endif ()
 execute_process (COMMAND ${LLVM_CONFIG} --shared-mode
        OUTPUT_VARIABLE LLVM_SHARED_MODE
        OUTPUT_STRIP_TRAILING_WHITESPACE)
-if (LLVM_VERSION VERSION_GREATER_EQUAL 9.0 AND (LLVM_SHARED_MODE STREQUAL "shared"))
+if (LLVM_SHARED_MODE STREQUAL "shared")
     find_library ( _CLANG_CPP_LIBRARY
                    NAMES "clang-cpp"
                    PATHS ${LLVM_LIB_DIR}

--- a/src/liboslexec/llvm_passes.h
+++ b/src/liboslexec/llvm_passes.h
@@ -60,7 +60,6 @@ public:
         llvm::Type* llvm_type_bool  = llvm::Type::getInt1Ty(context);
         llvm::Type* llvm_type_int32 = llvm::Type::getInt32Ty(context);
 
-#if OSL_LLVM_VERSION >= 110
         m_llvm_mask_type = llvm::FixedVectorType::get(llvm_type_bool, WidthT);
         // NOTE:  OSL doesn't have any 16 bit data types, so 32bit version
         // of the mask promotion will always be correct here.  Should 16 bit
@@ -71,19 +70,13 @@ public:
         // livein.
         m_native_mask_type = llvm::FixedVectorType::get(llvm_type_int32,
                                                         WidthT);
-#    if OSL_LLVM_VERSION >= 112
+#if OSL_LLVM_VERSION >= 112
         m_wide_zero_initializer = llvm::ConstantDataVector::getSplat(
             WidthT, llvm::ConstantInt::get(context, llvm::APInt(32, 0)));
-#    else
+#else
         m_wide_zero_initializer = llvm::ConstantVector::getSplat(
             llvm::ElementCount(WidthT, false),
             llvm::ConstantInt::get(context, llvm::APInt(32, 0)));
-#    endif
-#else
-        m_llvm_mask_type   = llvm::VectorType::get(llvm_type_bool, WidthT);
-        m_native_mask_type = llvm::VectorType::get(llvm_type_int32, WidthT);
-        m_wide_zero_initializer = llvm::ConstantVector::getSplat(
-            WidthT, llvm::ConstantInt::get(context, llvm::APInt(32, 0)));
 #endif
     }
 

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -1896,6 +1896,10 @@ void
 LLVM_Util::setup_new_optimization_passes(int optlevel, bool target_host)
 {
 #ifdef OSL_LLVM_NEW_PASS_MANAGER
+#    if OSL_LLVM_VERSION <= 110
+#        error "New pass manager not supported in LLVM 11 and earlier"
+#    endif
+
     OSL_DEV_ONLY(std::cout << "setup_new_optimization_passes " << optlevel);
     OSL_ASSERT(m_new_pass_manager == nullptr);
 

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -13,8 +13,8 @@
 #include <OSL/oslconfig.h>
 #include <OSL/wide.h>
 
-#if OSL_LLVM_VERSION < 90
-#    error "LLVM minimum version required for OSL is 9.0"
+#if OSL_LLVM_VERSION < 110
+#    error "LLVM minimum version required for OSL is 11.0"
 #endif
 
 #include "llvm_passes.h"
@@ -29,12 +29,10 @@
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Intrinsics.h>
-#if OSL_LLVM_VERSION >= 100
-#    include <llvm/IR/IntrinsicsX86.h>
-#endif
-#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/IntrinsicsX86.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
@@ -1678,11 +1676,7 @@ LLVM_Util::make_jit_execengine(std::string* err, TargetISA requestedISA,
 inline uint64_t
 get_alignment(const llvm::StructLayout* layout)
 {
-#    if OSL_LLVM_VERSION < 100
-    return layout->getAlignment();
-#    else
     return layout->getAlignment().value();
-#    endif
 }
 #endif
 
@@ -1902,10 +1896,6 @@ void
 LLVM_Util::setup_new_optimization_passes(int optlevel, bool target_host)
 {
 #ifdef OSL_LLVM_NEW_PASS_MANAGER
-#    if OSL_LLVM_VERSION <= 110
-#        error "New pass manager not supported in LLVM 11 and earlier"
-#    endif
-
     OSL_DEV_ONLY(std::cout << "setup_new_optimization_passes " << optlevel);
     OSL_ASSERT(m_new_pass_manager == nullptr);
 
@@ -4217,11 +4207,7 @@ LLVM_Util::llvm_type(const TypeDesc& typedesc)
 llvm::VectorType*
 LLVM_Util::llvm_vector_type(llvm::Type* elementtype, unsigned numelements)
 {
-#if OSL_LLVM_VERSION >= 110
     return llvm::FixedVectorType::get(elementtype, numelements);
-#else
-    return llvm::VectorType::get(elementtype, numelements);
-#endif
 }
 
 
@@ -4319,14 +4305,7 @@ LLVM_Util::op_alloca(llvm::Type* llvmtype, int n, const std::string& name,
     llvm::AllocaInst* allocainst = builder().CreateAlloca(llvmtype, numalloc,
                                                           name);
     if (align > 0) {
-#if OSL_LLVM_VERSION >= 110
-        using AlignmentType = llvm::Align;
-#elif OSL_LLVM_VERSION >= 100
-        using AlignmentType = llvm::MaybeAlign;
-#else
-        using AlignmentType = int;
-#endif
-        allocainst->setAlignment(AlignmentType(align));
+        allocainst->setAlignment(llvm::Align(align));
     }
     OSL_ASSERT(previousIP.isSet());
     m_builder->restoreIP(previousIP);
@@ -4366,15 +4345,9 @@ LLVM_Util::call_function(llvm::Value* func, cspan<llvm::Value*> args)
         llvm::outs() << "\t" << *a << "\n";
 #endif
     //llvm_gen_debug_printf (std::string("start ") + std::string(name));
-#if OSL_LLVM_VERSION >= 110
     llvm::Value* r = builder().CreateCall(
         static_cast<llvm::Function*>(func)->getFunctionType(), func,
         llvm::ArrayRef<llvm::Value*>(args.data(), args.size()));
-#else
-    llvm::Value* r
-        = builder().CreateCall(func, llvm::ArrayRef<llvm::Value*>(args.data(),
-                                                                  args.size()));
-#endif
     //llvm_gen_debug_printf (std::string(" end  ") + std::string(name));
     return r;
 }
@@ -4448,12 +4421,7 @@ void
 LLVM_Util::op_memset(llvm::Value* ptr, int val, int len, int align)
 {
     builder().CreateMemSet(ptr, builder().getInt8((unsigned char)val),
-                           uint64_t(len),
-#if OSL_LLVM_VERSION >= 100
-                           llvm::MaybeAlign(align));
-#else
-                           unsigned(align));
-#endif
+                           uint64_t(len), llvm::MaybeAlign(align));
 }
 
 
@@ -4462,11 +4430,7 @@ void
 LLVM_Util::op_memset(llvm::Value* ptr, int val, llvm::Value* len, int align)
 {
     builder().CreateMemSet(ptr, builder().getInt8((unsigned char)val), len,
-#if OSL_LLVM_VERSION >= 100
                            llvm::MaybeAlign(align));
-#else
-                           unsigned(align));
-#endif
 }
 
 
@@ -4483,13 +4447,8 @@ void
 LLVM_Util::op_memcpy(llvm::Value* dst, int dstalign, llvm::Value* src,
                      int srcalign, int len)
 {
-#if OSL_LLVM_VERSION >= 100
     builder().CreateMemCpy(dst, llvm::MaybeAlign(dstalign), src,
                            llvm::MaybeAlign(srcalign), uint64_t(len));
-#else
-    builder().CreateMemCpy(dst, (unsigned)dstalign, src, (unsigned)srcalign,
-                           uint64_t(len));
-#endif
 }
 
 
@@ -4557,11 +4516,7 @@ LLVM_Util::op_linearize_4x_indices(llvm::Value* wide_index)
 std::array<llvm::Value*, 2>
 LLVM_Util::op_split_16x(llvm::Value* vector_val)
 {
-#if OSL_LLVM_VERSION >= 110
-    using index_t = int32_t;
-#else
-    using index_t = uint32_t;
-#endif
+    using index_t                       = int32_t;
     const index_t extractLanes0_to_7[]  = { 0, 1, 2, 3, 4, 5, 6, 7 };
     const index_t extractLanes8_to_15[] = { 8, 9, 10, 11, 12, 13, 14, 15 };
 
@@ -4578,11 +4533,7 @@ LLVM_Util::op_split_16x(llvm::Value* vector_val)
 std::array<llvm::Value*, 2>
 LLVM_Util::op_split_8x(llvm::Value* vector_val)
 {
-#if OSL_LLVM_VERSION >= 110
-    using index_t = int32_t;
-#else
-    using index_t = uint32_t;
-#endif
+    using index_t                      = int32_t;
     const index_t extractLanes0_to_3[] = { 0, 1, 2, 3 };
     const index_t extractLanes4_to_7[] = { 4, 5, 6, 7 };
 
@@ -4601,11 +4552,7 @@ LLVM_Util::op_quarter_16x(llvm::Value* vector_val)
 {
     OSL_ASSERT(m_vector_width == 16);
 
-#if OSL_LLVM_VERSION >= 110
-    using index_t = int32_t;
-#else
-    using index_t = uint32_t;
-#endif
+    using index_t                        = int32_t;
     const index_t extractLanes0_to_3[]   = { 0, 1, 2, 3 };
     const index_t extractLanes4_to_7[]   = { 4, 5, 6, 7 };
     const index_t extractLanes8_to_11[]  = { 8, 9, 10, 11 };
@@ -4631,11 +4578,7 @@ llvm::Value*
 LLVM_Util::op_combine_8x_vectors(llvm::Value* half_vec_1,
                                  llvm::Value* half_vec_2)
 {
-#if OSL_LLVM_VERSION >= 110
     using index_t = int32_t;
-#else
-    using index_t = uint32_t;
-#endif
     static constexpr index_t combineIndices[]
         = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
     return builder().CreateShuffleVector(half_vec_1, half_vec_2,
@@ -4646,11 +4589,7 @@ llvm::Value*
 LLVM_Util::op_combine_4x_vectors(llvm::Value* half_vec_1,
                                  llvm::Value* half_vec_2)
 {
-#if OSL_LLVM_VERSION >= 110
-    using index_t = int32_t;
-#else
-    using index_t = uint32_t;
-#endif
+    using index_t                             = int32_t;
     static constexpr index_t combineIndices[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
     return builder().CreateShuffleVector(half_vec_1, half_vec_2,
                                          toArrayRef(combineIndices));
@@ -6813,14 +6752,10 @@ LLVM_Util::ptx_compile_group(llvm::Module*, const std::string& name,
     target_machine->addPassesToEmitFile(mpm, assembly_stream,
                                         nullptr,  // FIXME: Correct?
                                         llvm::CodeGenFileType::AssemblyFile);
-#    elif OSL_LLVM_VERSION >= 100
-    target_machine->addPassesToEmitFile(mpm, assembly_stream,
-                                        nullptr,  // FIXME: Correct?
-                                        llvm::CGFT_AssemblyFile);
 #    else
     target_machine->addPassesToEmitFile(mpm, assembly_stream,
                                         nullptr,  // FIXME: Correct?
-                                        llvm::TargetMachine::CGFT_AssemblyFile);
+                                        llvm::CGFT_AssemblyFile);
 #    endif
 
     // Run the optimization passes on the module to generate the PTX

--- a/src/liboslexec/opmatrix.cpp
+++ b/src/liboslexec/opmatrix.cpp
@@ -16,6 +16,8 @@
 #include <OSL/fmt_util.h>
 #include <OSL/hashes.h>
 
+#include <OpenImageIO/Imath.h>
+
 #include <OpenImageIO/fmath.h>
 #include <OpenImageIO/simd.h>
 

--- a/src/shaders/CMakeLists.txt
+++ b/src/shaders/CMakeLists.txt
@@ -38,7 +38,7 @@ macro (oslc_compile)
     list (APPEND oslc_args "-I${CMAKE_SOURCE_DIR}/src/shaders")
     add_custom_command (OUTPUT ${osofile}
         COMMAND oslc ${oslc_args} "${oslfile}" -o "${osofile}"
-        MAIN_DEPENDENCY ${oslsrc}
+        MAIN_DEPENDENCY ${oslfile}
         DEPENDS ${_shader_DEPENDS} "${stdosl_header}" oslc
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "oslc ${oslsrc_we}")


### PR DESCRIPTION
Some last minute dependency adjustments before I cut a beta for OSL 1.14.

* Raise CMake minimum to 3.19 (from 3.15). This is still very conservative -- 4 years old, even more lax than our usual "3 years back" rule.

  Raising to 3.18 matches OIIO 3.0, and compared to 3.15, it adds Cuda support as well as the `--debug-find` flag.  Further raising to 3.19 -- which in 2025 seems prudent, even though it's beyond the version chosen by OIIO 6 months ago -- adds more helpful features, including presets, and Apple Silicon support.

* Raise OpenImageIO to 2.5 (from 2.4). The current release is 3.0, FYI.

* Bump LLVM minimum to 11.0 (from 9.0). This is a pretty conservative move, still gives several years of back support, but brings a little code simplification. I expect that next year's OSL will raise the LLVM minimum by several more versions.

