### PR TITLE
fix: Link error on Windows due to shared symbols

### DIFF
--- a/src/liboslcomp/symtab.cpp
+++ b/src/liboslcomp/symtab.cpp
@@ -5,7 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "oslcomp_pvt.h"
+#include "osl_pvt.h"
+#include "symtab.h"
 
 #include <OpenImageIO/strutil.h>
 namespace Strutil = OIIO::Strutil;

--- a/src/liboslexec/batched_llvm_instance.cpp
+++ b/src/liboslexec/batched_llvm_instance.cpp
@@ -27,7 +27,6 @@
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/DerivedTypes.h>
 
-#include "../liboslcomp/oslcomp_pvt.h"
 #include "batched_backendllvm.h"
 #include "oslexec_pvt.h"
 

--- a/src/liboslexec/llvm_instance.cpp
+++ b/src/liboslexec/llvm_instance.cpp
@@ -18,7 +18,6 @@
 #include <OpenImageIO/sysutil.h>
 #include <OpenImageIO/timer.h>
 
-#include "../liboslcomp/oslcomp_pvt.h"
 #include "oslexec_pvt.h"
 #include "backendllvm.h"
 

--- a/src/liboslexec/master.cpp
+++ b/src/liboslexec/master.cpp
@@ -11,7 +11,6 @@
 #include <OpenImageIO/strutil.h>
 #include <OpenImageIO/thread.h>
 
-#include "../liboslcomp/oslcomp_pvt.h"
 #include "oslexec_pvt.h"
 
 

--- a/src/liboslexec/runtimeoptimize.cpp
+++ b/src/liboslexec/runtimeoptimize.cpp
@@ -10,7 +10,6 @@
 #include <OpenImageIO/thread.h>
 #include <OpenImageIO/timer.h>
 
-#include "../liboslcomp/oslcomp_pvt.h"
 #include "batched_analysis.h"
 #include "oslexec_pvt.h"
 #include "runtimeoptimize.h"


### PR DESCRIPTION
## Description

After reduction of shared dependencies in #1890, there is an unresolved OSLCompiler constructor symbol when linking liboslexec. Avoid including the oslcomp_pvt.h header that causes this.

## Tests

N/A

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
