### PR TITLE
Build fixes for OSL on Windows

### DIFF
--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -79,7 +79,7 @@ add_executable (testrender ${testrender_srcs})
 
 target_link_libraries (testrender
     PRIVATE
-        oslexec oslquery
+        oslexec oslquery oslcomp
         pugixml::pugixml
         Threads::Threads)
 

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
+set (LLVM_COMPILE_FLAGS ${LLVM_COMPILE_FLAGS} -std=c++${CMAKE_CXX_STANDARD})
+
 # The 'testshade' executable
 set ( testshade_srcs
       testshade.cpp


### PR DESCRIPTION
## Description

This changelist contains two fixes for OSL builds on the Windows platform, both of which were authored by Kai Rohmer at NVIDIA.

## Tests

With these fixes in place, OSL builds on Windows now include `testshade` and `testrender`, where these two applications would previously fail to build.

For visual validation, I'm attaching the latest MaterialX render comparisons between GLSL and OSL, where the OSL renders are using the codebase in OSL main plus these two fixes.

[MaterialXRenderTests_01_07_2025_GitHub.pdf](https://github.com/user-attachments/files/18351045/MaterialXRenderTests_01_07_2025_GitHub.pdf)

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
