### PR TITLE
testing: for CI only, trim PWD from the oslc -M output

### DIFF
--- a/src/liboslcomp/oslcomp.cpp
+++ b/src/liboslcomp/oslcomp.cpp
@@ -590,7 +590,7 @@ OSLCompilerImpl::write_dependency_file(string_view filename)
                          : OIIO::Filesystem::fopen(m_deps_filename, "w"));
     if (depfile) {
         OSL::print(depfile, "{}: {}", target, filename);
-        for (const auto& dep : m_file_dependencies) {
+        for (ustring dep : m_file_dependencies) {
             if (OIIO::Strutil::ends_with(dep, "stdosl.h")
                 && !m_generate_system_deps)
                 continue;  // skip system headers if so instructed
@@ -598,6 +598,16 @@ OSLCompilerImpl::write_dependency_file(string_view filename)
                 continue;  // skip pseudo files
             if (dep == filename)
                 continue;  // skip this file, since we already put it first
+#if defined(_WIN32) && defined(OSL_CI)
+            // Special behavior for CI on Windows: remove the directory paths
+            // for the dependencies, or else it won't match the reference
+            // output.
+            using OIIO::Strutil::replace;
+            std::string cwd = replace(OIIO::Filesystem::current_path() + "/",
+                                      "/", "\\", true);
+            auto d          = replace(dep, "\\\\", "\\", true);
+            dep             = ustring(replace(d, cwd, ""));
+#endif
             OSL::print(depfile, " \\\n  {}", dep);
         }
         OSL::print(depfile, "\n");


### PR DESCRIPTION
I think this stems from libclang (doing the C preprocessing step for us) giving us relative paths on all platforms but Windows, where it gives absolute paths -- with backslaches and C:\ and all.

I'm going to be conservative and not switch to relative paths accross the board on Windows, but for now just restrict it to the builds we do for CI, in order to make the related tests pass for Windows on our CI (where we obviously don't want to have the reference output need to bake in absolute paths of the place they may happen to execute on the GHA runners).
