### PR TITLE
build: Use macOS sysroot, arch, minversion for generating bitcode

### DIFF
--- a/src/cmake/llvm_macros.cmake
+++ b/src/cmake/llvm_macros.cmake
@@ -54,20 +54,15 @@ function ( EMBED_LLVM_BITCODE_IN_CPP src_list suffix output_name list_to_append_
                     NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_ENVIRONMENT_PATH)
         endif ()
 
-
-        # Fix specific problem I had on new Apple systems (e.g. Mavericks) with
-        # LLVM/libc++ installed -- for some reason, LLVM 3.4 wasn't finding it,
-        # so in that specific case, append another -I to point it in the right
-        # direction.
-        #if (APPLE AND ${LLVM_BC_GENERATOR} MATCHES ".*clang.*")
-        #    exec_program ( "${LLVM_BC_GENERATOR}" ARGS --version OUTPUT_VARIABLE MY_CLANG_VERSION )
-        #    string (REGEX REPLACE "clang version ([0-9][.][0-9]+).*" "\\1" MY_CLANG_VERSION "${MY_CLANG_VERSION}")
-        #    if ((${MY_CLANG_VERSION} VERSION_GREATER "3.3")
-        #          AND (EXISTS "/usr/lib/libc++.dylib")
-        #          AND (EXISTS "/Library/Developer/CommandLineTools/usr/lib/c++/v1"))
-        #        set (LLVM_COMPILE_FLAGS ${LLVM_COMPILE_FLAGS} "-I/Library/Developer/CommandLineTools/usr/lib/c++/v1")
-        #    endif ()
-        #endif ()
+        if (APPLE)
+            list (APPEND LLVM_COMPILE_FLAGS -isysroot ${CMAKE_OSX_SYSROOT})
+            if (CMAKE_OSX_DEPLOYMENT_TARGET)
+                list (APPEND LLVM_COMPILE_FLAGS -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET})
+            endif ()
+            if (CMAKE_OSX_ARCHITECTURES)
+                list (APPEND LLVM_COMPILE_FLAGS -arch ${CMAKE_OSX_ARCHITECTURES})
+            endif ()
+        endif ()
 
         list (TRANSFORM include_dirs PREPEND -I
             OUTPUT_VARIABLE ALL_INCLUDE_DIRS)


### PR DESCRIPTION
## Description

To solve a problem finding system headers when building with command line tools instead of Xcode. Replaces some commented out code, as this should be a more general solution to the same problem.

Adding arch and minversion for completeness, not because of a particular known problem, but better to be sure everything matches up.

## Tests

N/A

## Checklist:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.