### PR TITLE
Docs: Fix typo in the name of the argument "maxdist" of `trace`

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -5922,7 +5922,7 @@ a unit length (see Section~\ref{sec:stdlib:geom}) dir vector.
 \apiend
 \vspace{-16pt}
 
-\apiitem{"mindist", <float>}
+\apiitem{"maxdist", <float>}
 \vspace{12pt}
 The maximum hit distance (default: infinite).
 \apiend

--- a/src/doc/stdlib.md
+++ b/src/doc/stdlib.md
@@ -2190,7 +2190,7 @@ them will be removed entirely in OSL 2.0.
         shaders should pass a unit length (see Section [](#sec-stdlib-geom))
         dir vector.
 
-    `"mindist",` *`float`*
+    `"maxdist",` *`float`*
       : The maximum hit distance (default: infinite).
 
     `"shade",` *`int`*


### PR DESCRIPTION
## Description

Sorry, I was the one who committed the typo in the first place!

## Tests
N/A

## Checklist:
- [ x ] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ x ] I have updated the documentation, if applicable.
- [ x ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ x ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
