### PR TITLE
deps: Adjust osltoy for Qt 6.8

### DIFF
--- a/src/osltoy/osltoyapp.cpp
+++ b/src/osltoy/osltoyapp.cpp
@@ -1298,8 +1298,13 @@ OSLToyMainWindow::make_param_adjustment_row(ParamRec* param,
     auto diddleCheckbox = new QCheckBox("  ");
     if (m_diddlers[param->name.string()])
         diddleCheckbox->setCheckState(Qt::Checked);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    connect(diddleCheckbox, &QCheckBox::checkStateChanged, this,
+            [=](Qt::CheckState state) { set_param_diddle(param, int(state)); });
+#else
     connect(diddleCheckbox, &QCheckBox::stateChanged, this,
             [=](int state) { set_param_diddle(param, state); });
+#endif
     layout->addWidget(diddleCheckbox, row, 0);
 
     std::string typetext(param->type.c_str());


### PR DESCRIPTION
Qt 6.8 deprecates QCheckBox::stateChanged().

