### PR TITLE
Docs: Fix typo in Arrays

### DIFF
--- a/src/doc/datatypes.md
+++ b/src/doc/datatypes.md
@@ -558,6 +558,8 @@ are 1D and statically sized, using the usual syntax for C-like languages:
     float c[3] = { 0.1, 0.2, 3.14 };   // Initialize the array
 
     float f = c[1];                    // Access one element
+
+    float d[10][3];                    // Invalid, multi-dimensional arrays not supported
 ```
 
 The built-in function `arraylength()` returns the number of elements in an

--- a/src/doc/syntax.md
+++ b/src/doc/syntax.md
@@ -88,9 +88,9 @@ Some examples of variable declarations are
 
 Arrays are also supported, declared as follows:
 
-> *type variablename* `[` *arraylen* `}`
+> *type variablename* `[` *arraylen* `]`
 >
-> *type variablename* `[` *arraylen* `}` `=` `{` *init0 `,` *init1* ... `}`
+> *type variablename* `[` *arraylen* `]` `=` `{` *init0 `,` *init1* ... `}`
 
 Array variables in OSL must have a constant length (though function parameters
 and shader parameters may have undetermined length).  Some examples of array


### PR DESCRIPTION
## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

Resolves #1921

However, it could also be helpful to add in syntax.md (https://open-shading-language.readthedocs.io/en/latest/syntax.html#arrays) that only 1D arrays are supported. The fix so far only mentions this in datatypes.md (https://open-shading-language.readthedocs.io/en/latest/datatypes.html#arrays). Any suggestions?

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

Documentation built locally with sphinx, to ensure the changes worked.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
