### PR TITLE
build: Fix libclang link order

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -44,6 +44,8 @@ on:
         type: string
       python_ver:
         type: string
+      llvm_action_ver:
+        type: string
       setenvs:
         type: string
       simd:
@@ -125,6 +127,11 @@ jobs:
         run: |
             ${{inputs.setenvs}}
             src/build-scripts/ci-startup.bash
+      - name: Install LLVM and Clang
+        if: inputs.llvm_action_ver != ''
+        uses: KyleMayes/install-llvm-action@e0a8dc9cb8a22e8a7696e8a91a4e9581bec13181 # v2.0.5
+        with:
+          version: ${{ inputs.llvm_action_ver }}
       - name: Dependencies
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,7 @@ jobs:
       ctest_test_timeout: ${{ matrix.ctest_test_timeout || '800' }}
       coverage: ${{ matrix.coverage || 0 }}
       sonar: ${{ matrix.sonar || 0 }}
+      llvm_action_ver: ${{ matrix.llvm_action_ver }}
     strategy:
       fail-fast: false
       matrix:
@@ -438,11 +439,10 @@ jobs:
             openimageio_ver: main
             pybind11_ver: master
             python_ver: "3.12"
+            llvm_action_ver: "18.1.7"
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
-            setenvs: export LLVM_VERSION=17.0.6
-                            LLVM_DISTRO_NAME=ubuntu-22.04
-                            PUGIXML_VERSION=master
+            setenvs: export PUGIXML_VERSION=master
           - desc: clang14/C++17 llvm14 py3.10 avx2 batch-b16avx512
             nametag: linux-latest-releases-clang
             runner: ubuntu-22.04

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -132,7 +132,9 @@ else
         set +e; source /opt/intel/oneapi/setvars.sh --config oneapi_2022.1.0.cfg; set -e
     fi
 
-    source src/build-scripts/build_llvm.bash
+    if [[ "$LLVM_VERSION" != "" ]] ; then
+        source src/build-scripts/build_llvm.bash
+    fi
 fi
 
 if [[ "$CMAKE_VERSION" != "" ]] ; then

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -59,7 +59,8 @@ checked_find_package (pugixml REQUIRED
 checked_find_package (LLVM REQUIRED
                       VERSION_MIN 11.0
                       VERSION_MAX 19.9
-                      PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES)
+                      PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES
+                            LLVM_SHARED_MODE)
 # ensure include directory is added (in case of non-standard locations
 include_directories (BEFORE SYSTEM "${LLVM_INCLUDES}")
 link_directories ("${LLVM_LIB_DIR}")

--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -115,8 +115,8 @@ endif ()
 
 foreach (COMPONENT clangFrontend clangDriver clangSerialization
                    clangParse clangSema clangAnalysis clangAST
-                   clangASTMatchers clangBasic clangEdit clangLex
-                   clangSupport clangAPINotes)
+                   clangASTMatchers clangEdit clangLex
+                   clangSupport clangAPINotes clangBasic)
     find_library ( _CLANG_${COMPONENT}_LIBRARY
                   NAMES ${COMPONENT}
                   PATHS ${LLVM_LIB_DIR}


### PR DESCRIPTION
Apparently, in LLVM 18, some things shifted between libraries and that requires a slightly different link order. But only on Linux, or maybe only with static libraries, so even though our Mac and Windows CI tests have used LLVM 18, it wasn't symptomatic there.

We didn't discover this earlier because we didn't actually test against LLVM 18 on any of the Linux CI runs. So we add that.

Also, to alleviate the pain in adjusting LLVM versions and often needing to modify our build_llvm.bash script, I'm trying out a GHA marketplace action KyleMayes/install-llvm-action, and it works well and saved me time, so we may switch to that for other cases over time as well.

