### PR TITLE
ci: improve clang-format check

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -58,6 +58,8 @@ on:
         type: string
       build_docs:
         type: string
+      clang_format:
+        type: string
       generator:
         type: string
       ctest_args:
@@ -162,6 +164,10 @@ jobs:
         if: inputs.skip_tests != '1'
         shell: bash
         run: src/build-scripts/ci-test.bash
+      - name: clang-format
+        if: inputs.clang_format == '1'
+        shell: bash
+        run: src/build-scripts/run-clang-format.bash
       - name: Code coverage
         if: inputs.coverage == '1'
         run: src/build-scripts/ci-coverage.bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,7 @@ jobs:
       coverage: ${{ matrix.coverage || 0 }}
       sonar: ${{ matrix.sonar || 0 }}
       llvm_action_ver: ${{ matrix.llvm_action_ver }}
+      clang_format: ${{ matrix.clang_format }}
     strategy:
       fail-fast: false
       matrix:
@@ -467,22 +468,20 @@ jobs:
             # the console output).
           - desc: "clang-format"
             nametag: clang-format
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             cxx_std: 17
             extra_artifacts: "src/*.*"
-            opencolorio_ver: v2.4.0
-            openexr_ver: v3.1.11
-            openimageio_ver: release
             python_ver: "3.10"
-            simd: avx2,f16c
-            batched: b8_AVX2
+            pybind11_ver: "0"
+            skip_build: 1
             skip_tests: 1
-            setenvs: export BUILDTARGET=clang-format
-                            LLVM_VERSION=17.0.6
-                            LLVM_DISTRO_NAME=ubuntu-22.04
-                            OPENIMAGEIO_CMAKE_FLAGS=-DUSE_PYTHON=0
-                            USE_PYTHON=0
-                            QT_VERSION=0
+            clang_format: 1
+            setenvs: export OPENIMAGEIO_CMAKE_FLAGS=-DUSE_PYTHON=0
+                            USE_PYTHON=0 QT_VERSION=0 PUGIXML_VERSION=0
+                            SKIP_APT_GET_UPDATE=0
+                            SKIP_SYSTEM_DEPS_INSTALL=1
+                            EXTRA_DEP_PACKAGES="clang-format-17"
+                            CLANG_FORMAT_EXE=clang-format-17
 
 
   macos:

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -84,13 +84,15 @@ else
         time sudo apt-get update
     fi
 
-    time sudo apt-get -q install -y \
-        git cmake ninja-build ccache g++ \
-        libboost-dev libboost-thread-dev libboost-filesystem-dev \
-        libtiff-dev libgif-dev libpng-dev \
-        flex bison libbison-dev \
-        libpugixml-dev \
-        libopencolorio-dev
+    if [[ "${SKIP_SYSTEM_DEPS_INSTALL}" != "1" ]] ; then
+        time sudo apt-get -q install -y \
+            git cmake ccache ninja-build g++ \
+            libboost-dev libboost-thread-dev libboost-filesystem-dev \
+            libtiff-dev libgif-dev libpng-dev \
+            flex bison libbison-dev \
+            libpugixml-dev \
+            libopencolorio-dev
+    fi
 
     if [[ "${QT_VERSION:-5}" == "5" ]] ; then
         time sudo apt-get -q install -y qt5-default || /bin/true
@@ -101,7 +103,9 @@ else
         time sudo apt-get -q install -y ${EXTRA_DEP_PACKAGES}
     fi
 
-    time sudo apt-get -q install -y python3-numpy
+    if [[ "${USE_PYTHON}" != "0" ]] ; then
+        time sudo apt-get -q install -y python3-numpy
+    fi
     if [[ "${PIP_INSTALLS}" != "" ]] ; then
         time pip3 install ${PIP_INSTALLS}
     fi
@@ -167,16 +171,18 @@ fi
 # Packages we need to build from scratch.
 #
 
-source src/build-scripts/build_pybind11.bash
+if [[ "$PYBIND11_VERSION" != "0" ]] ; then
+    source src/build-scripts/build_pybind11.bash
+fi
 
 if [[ "$OPENEXR_VERSION" != "" ]] ; then
     source src/build-scripts/build_openexr.bash
 fi
 
-# if [[ "$PUGIXML_VERSION" != "" ]] ; then
+if [[ "$PUGIXML_VERSION" != "0" ]] ; then
     source src/build-scripts/build_pugixml.bash
     export MY_CMAKE_FLAGS+=" -DUSE_EXTERNAL_PUGIXML=1 "
-# fi
+fi
 
 if [[ "$OPENCOLORIO_VERSION" != "" ]] ; then
     source src/build-scripts/build_opencolorio.bash

--- a/src/build-scripts/run-clang-format.bash
+++ b/src/build-scripts/run-clang-format.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright Contributors to the Open Shading Language project.
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+# Important: set -ex causes this whole script to terminate with error if
+# any command in it fails. This is crucial for CI tests.
+set -ex
+
+CLANG_FORMAT_EXE=${CLANG_FORMAT_EXE:="clang-format"}
+echo "Running " `which clang-format` " version " `${CLANG_FORMAT_EXE} --version`
+
+files=`find ./{src,testsuite} \( -name '*.h' -o -name '*.cpp' -o -name '*.cu' \) -print \
+       | grep -Ev 'testsuite/.*\.h|src/shaders'`
+
+
+${CLANG_FORMAT_EXE}  -i -style=file $files
+git diff --color
+THEDIFF=`git diff`
+if [[ "$THEDIFF" != "" ]] ; then
+    echo "git diff was not empty. Failing clang-format check."
+    exit 1
+fi

--- a/testsuite/example-batched-deformer/oslbatcheddeformer.cpp
+++ b/testsuite/example-batched-deformer/oslbatcheddeformer.cpp
@@ -128,10 +128,7 @@ class MyBatchedRendererServices final
     {
         return false;
     }
-    bool is_overridden_get_matrix_WmWsWf() const override
-    {
-        return false;
-    }
+    bool is_overridden_get_matrix_WmWsWf() const override { return false; }
     bool is_overridden_get_inverse_matrix_WmsWf() const override
     {
         return false;
@@ -140,30 +137,12 @@ class MyBatchedRendererServices final
     {
         return false;
     }
-    bool is_overridden_texture() const override
-    {
-        return false;
-    }
-    bool is_overridden_texture3d() const override
-    {
-        return false;
-    }
-    bool is_overridden_environment() const override
-    {
-        return false;
-    }
-    bool is_overridden_pointcloud_search() const override
-    {
-        return false;
-    }
-    bool is_overridden_pointcloud_get() const override
-    {
-        return false;
-    }
-    bool is_overridden_pointcloud_write() const override
-    {
-        return false;
-    }
+    bool is_overridden_texture() const override { return false; }
+    bool is_overridden_texture3d() const override { return false; }
+    bool is_overridden_environment() const override { return false; }
+    bool is_overridden_pointcloud_search() const override { return false; }
+    bool is_overridden_pointcloud_get() const override { return false; }
+    bool is_overridden_pointcloud_write() const override { return false; }
 };
 
 // RendererServices is the interface through which OSL requests things back
@@ -243,8 +222,9 @@ main(int argc, char* argv[])
         std::cout
             << "Error:  Hardware doesn't support 4, 8 or 16 wide SIMD or the OSL has not been configured and built with a proper USE_BATCHED."
             << std::endl;
-        std::cout << "Error:  e.g.:  USE_BATCHED=b4_SSE2,b8_AVX2,b8_AVX512,b16_AVX512"
-                  << std::endl;
+        std::cout
+            << "Error:  e.g.:  USE_BATCHED=b4_SSE2,b8_AVX2,b8_AVX512,b16_AVX512"
+            << std::endl;
         return -1;
     }
 
@@ -439,8 +419,7 @@ main(int argc, char* argv[])
 
     if (batch_width == 16) {
         batched_shadepoints(std::integral_constant<int, 16> {});
-    }
-    else if (batch_width == 8) {
+    } else if (batch_width == 8) {
         batched_shadepoints(std::integral_constant<int, 8> {});
     } else {
         batched_shadepoints(std::integral_constant<int, 4> {});

--- a/testsuite/example-cuda/rend_lib.cu
+++ b/testsuite/example-cuda/rend_lib.cu
@@ -230,8 +230,8 @@ osl_bind_interpolated_param(void* sg_, OSL::ustring_pod name, long long type,
     char status = *userdata_initialized;
     if (status == 0) {
         bool ok               = rend_get_userdata(HDSTR(name), userdata_data,
-                                    symbol_data_size, (*(OSL::TypeDesc*)&type),
-                                    userdata_index);
+                                                  symbol_data_size, (*(OSL::TypeDesc*)&type),
+                                                  userdata_index);
         *userdata_initialized = status = 1 + ok;
     }
     if (status == 2) {

--- a/testsuite/example-deformer/osldeformer.cpp
+++ b/testsuite/example-deformer/osldeformer.cpp
@@ -118,7 +118,7 @@ public:
 //Not recommended for production renderer but fine for osldeformer
 std::atomic<uint32_t> next_thread_index { 0 };
 constexpr uint32_t uninitialized_thread_index = -1;
-thread_local uint32_t this_threads_index = uninitialized_thread_index;
+thread_local uint32_t this_threads_index      = uninitialized_thread_index;
 
 
 int
@@ -290,14 +290,13 @@ main(int argc, char* argv[])
         // Run the shader (will automagically optimize and JIT the first
         // time it executes).
 
-        if(this_threads_index == uninitialized_thread_index) {
-                
-                this_threads_index = next_thread_index.fetch_add(1u);
-            }
-            int thread_index = this_threads_index;
+        if (this_threads_index == uninitialized_thread_index) {
+            this_threads_index = next_thread_index.fetch_add(1u);
+        }
+        int thread_index = this_threads_index;
 
-        shadsys->execute(*ctx, *mygroup.get(), thread_index, /*shade point index= */ i,
-                         shaderglobals,
+        shadsys->execute(*ctx, *mygroup.get(), thread_index,
+                         /*shade point index= */ i, shaderglobals,
                          /*userdata arena start=*/&userdata,
                          /*output arena start=*/&Pout);
 


### PR DESCRIPTION
Make a new run-clang-format.bash utility to issue the commands for the right files. No "build" is required, and the only dependencies we need are the minimum it takes to run clang-format itself.

These changes reduce the approximate total elapsed time of a CI clang-format job from 8:00+ to under 0:30.

In the process, this catches a couple files in testsuite that were never going through the clang-format test, so fix that now.


