### PR TITLE
Include entry layer name in PTX cache key

### DIFF
--- a/src/liboslexec/instance.cpp
+++ b/src/liboslexec/instance.cpp
@@ -857,10 +857,14 @@ ShaderGroup::generate_optix_cache_key(string_view code)
     safegroup = Strutil::replace(name(), "/", "_", true);
     safegroup = Strutil::replace(safegroup, ":", "_", true);
 
-    // Cache key includes the groupname in addition to the serialized IR.
-    // This is because the groupname makes its way into the ptx's direct callable name,
-    // but isn't included in the serialization.
-    std::string cache_key = fmtformat("cache-osl-ptx-{}-{}", safegroup, ir_key);
+    ShaderInstance* inst = layer(nlayers() - 1);
+    ustring layername    = inst->layername();
+
+    // Cache key includes group and entry layer names in addition to the serialized IR.
+    // This is because the group and layer names make their way into the ptx's
+    // direct callable name, but isn't included in the serialization.
+    std::string cache_key = fmtformat("cache-osl-ptx-{}-{}-{}", safegroup,
+                                      layername, ir_key);
 
     m_optix_cache_key = cache_key;
 }


### PR DESCRIPTION
## Description

The ptx cache key introduced in #1938 didn't include a shader's entry layer name in its cache key. The direct callable function generated during llvm construction includes this layer name, so we could get false positive cache hits when two identical networks with matching group names had different entry layer names. The end result is an optix compilation error. This PR extends the cache key to handle this scenario.

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
