### PR TITLE
Draft: remap implementation in std library

### DIFF
--- a/src/doc/languagespec.tex
+++ b/src/doc/languagespec.tex
@@ -3122,6 +3122,12 @@ The {\cf mix} function returns a linear blending :
 $ x*(1-\alpha) + y*(\alpha) $
 \apiend
 
+\apiitem{\emph{type} {\ce remap} (\emph{type} value, \emph{type} minIn, \emph{type} maxIn, \emph{type} minOut, \emph{type} maxOut) \\
+\emph{type} {\ce remap} (\emph{type} value, \emph{type} minIn, \emph{type} maxIn, \emph{float} minOut, \emph{float} maxOut)}
+\indexapi{remap()}
+The {\cf remap} function takes the {\cf value} in range {\cf (minIn, minOut)} and shifts it to corresponding value in range {\cf (maxIn, maxOut)}.
+\apiend
+
 \apiitem{\emph{type} {\ce select} (\emph{type} x, \emph{type} y, \emph{type} cond) \\
 \emph{type} {\ce select} (\emph{type} x, \emph{type} y, float cond) \\
 \emph{type} {\ce select} (\emph{type} x, \emph{type} y, int cond)}

--- a/src/shaders/stdosl.h
+++ b/src/shaders/stdosl.h
@@ -184,6 +184,22 @@ int isfinite (float x) BUILTIN;
 float erf (float x) BUILTIN;
 float erfc (float x) BUILTIN;
 
+// Currently, only implemented for 'vector' and 'float' types.
+#if 0
+// normal remap(normal x, normal minIn, normal maxIn, normal minOut, normal maxOut) { return 1; }
+vector remap(vector x, vector minIn, vector maxIn, float minOut, float maxOut) { return minOut + (x - minIn) * (maxOut - minOut) / (maxIn - minIn); }
+vector remap(vector x, vector minIn, vector maxIn, vector minOut, vector maxOut) { return minOut + (x - minIn) * (maxOut - minOut) / (maxIn - minIn); }
+// point remap(point x, point minIn, point maxIn, point minOut, point maxOut) { return 1; }
+// color remap(color x, color minIn, color maxIn, color minOut, color maxOut) { return 1; }
+float remap(float x, float minIn, float maxIn, float minOut, float maxOut) { return minOut + (x - minIn) * (maxOut - minOut) / (maxIn - minIn); }
+#else
+vector remap (vector x, vector minIn, vector maxIn, float minOut, float maxOut) BUILTIN;
+vector remap (vector x, vector minIn, vector maxIn, vector minOut, vector maxOut) BUILTIN;
+float  remap (float x, float minIn, float maxIn, float minOut, float maxOut) BUILTIN;
+#endif
+closure color remap (closure x, closure minIn, closure maxIn, float minOut, float maxOut) { return minOut + (x - minIn) * (maxOut - minOut) / (maxIn - minIn); }
+closure color remap (closure x, closure minIn, closure maxIn, closure minOut, closure maxOut) { return minOut + (x - minIn) * (maxOut - minOut) / (maxIn - minIn); }
+
 // Vector functions
 
 vector cross (vector a, vector b) BUILTIN;


### PR DESCRIPTION
## Description

Work in progress PR. Aims to resolve #1899 

Some questions I have regarding implementing it are:
- To be added to the std lib, do I need to write for all types (normal, point, color)? Currently only have float and vectors types written.
- In case the combination of mix/unmix is used to implement remap (which I've seen is elsewhere, at least in many gamedev tutorials where remap is a lerp(inverseLerp()) call), does a separate unmix method need to be added to OSL or is there a easier way to complete it?
- From the documentation of efit in VEX [https://www.sidefx.com/docs/houdini/vex/functions/efit.html](https://www.sidefx.com/docs/houdini/vex/functions/efit.html), there's also a method signature which takes in 2 floats as the bounds for the 'new' range, while taking vectors for all other values. Should this also be added to the std library (or documentation)?

Thanks!

## Tests

Haven't added any tests currently, will add more once the method is complete. To my understanding the tests would be in 
/testsuite/remap-reg folder?


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
