### PR TITLE
build: Support for CMake 4.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ OSL requires the following dependencies or tools.
 NEW or CHANGED dependencies since the last major release are **bold**.
 
 * Build system: [CMake](https://cmake.org/) **3.19 or newer** (tested
-  through 3.31)
+  through 4.0)
 
 * A suitable C++17 compiler to build OSL itself, which may be any of:
    - **GCC 9.3** or newer (tested through gcc 13.1)

--- a/src/build-scripts/build_opencolorio.bash
+++ b/src/build-scripts/build_opencolorio.bash
@@ -26,6 +26,11 @@ OPENCOLORIO_CMAKE_FLAGS+=" -DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_NUKE=OFF \
                        -DOCIO_BUILD_PYTHON=OFF -DOCIO_BUILD_PYGLUE=OFF \
                        -DOCIO_BUILD_JAVA=OFF \
                        -DBUILD_SHARED_LIBS=${OPENCOLORIO_BUILD_SHARED_LIBS:=ON}"
+
+# Fix yaml-cpp which breaks against cmake 4.0 because of too-old cmake min.
+# Remove when yaml-cpp is fixed to declare its own minimum high enough.
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 BASEDIR=`pwd`
 pwd
 echo "OpenColorIO install dir will be: ${OPENCOLORIO_INSTALL_DIR}"

--- a/src/build-scripts/build_pybind11.bash
+++ b/src/build-scripts/build_pybind11.bash
@@ -22,6 +22,10 @@ LOCAL_DEPS_DIR=${LOCAL_DEPS_DIR:=${PWD}/ext}
 PYBIND11_INSTALL_DIR=${PYBIND11_INSTALL_DIR:=${LOCAL_DEPS_DIR}/dist}
 #PYBIND11_BUILD_OPTS=${PYBIND11_BUILD_OPTS:=}
 
+# Fix for pybind11 breaking against cmake 4.0 because of too-old cmake min.
+# Remove when pybind11 is fixed to declare its own minimum high enough.
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 if [[ "${PYTHON_VERSION}" != "" ]] ; then
     PYBIND11_BUILD_OPTS+=" -DPYBIND11_PYTHON_VERSION=${PYTHON_VERSION}"
 fi

--- a/src/build-scripts/build_zlib.bash
+++ b/src/build-scripts/build_zlib.bash
@@ -21,6 +21,10 @@ ZLIB_BUILD_DIR=${ZLIB_BUILD_DIR:=${ZLIB_SRC_DIR}/build}
 ZLIB_INSTALL_DIR=${ZLIB_INSTALL_DIR:=${PWD}/ext/dist}
 #ZLIB_CONFIG_OPTS=${ZLIB_CONFIG_OPTS:=}
 
+# Fix zlib which breaks against cmake 4.0 because of too-old cmake min.
+# Remove when zlib is fixed to declare its own minimum high enough.
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 pwd
 echo "zlib install dir will be: ${ZLIB_INSTALL_DIR}"
 


### PR DESCRIPTION
The tricky part is that several dependencies break because of cmake 4.0 dropping support for strict compatbility with cmake < 3.5. Have to resort to some trickery with CMAKE_POLICY_VERSION_MINIMUM overriding what those packages declare via their own cmake_minimum_required(), and hope it works.

