### PR TITLE
build: Unbreak CI on Mac by not letting it install llvm 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,7 +528,7 @@ jobs:
             cxx_std: 17
             python_ver: "3.13"
             aclang: 14
-            setenvs: export DO_BREW_UPDATE=1 CTEST_TEST_TIMEOUT=120
+            setenvs: export DO_BREW_UPDATE=0 CTEST_TEST_TIMEOUT=120
                             EXTRA_BREW_PACKAGES="openimageio"
           - desc: MacOS-14-ARM llvm17
             runner: macos-14
@@ -538,7 +538,7 @@ jobs:
             cxx_std: 17
             python_ver: "3.13"
             aclang: 15
-            setenvs: export DO_BREW_UPDATE=1
+            setenvs: export DO_BREW_UPDATE=0
                             EXTRA_BREW_PACKAGES="openimageio"
           - desc: MacOS-15-ARM aclang16/C++17/py3.13
             runner: macos-15

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -69,6 +69,9 @@ ls ${HOMEBREW_PREFIX}/lib/python${PYTHON_VERSION}
 # export PATH=${HOMEBREW_PREFIX}/opt/llvm${LLVMBREWVER}/bin:$PATH
 export LLVM_DIRECTORY=${HOMEBREW_PREFIX}/opt/llvm${LLVMBREWVER}
 export LLVM_ROOT=${HOMEBREW_PREFIX}/opt/llvm${LLVMBREWVER}
+export PATH=$LLVM_ROOT/bin:$PATH
+echo LLVM_ROOT=${LLVM_ROOT}
+# ls $LLVM_ROOT
 export PATH=${HOMEBREW_PREFIX}/opt/flex/bin:${HOMEBREW_PREFIX}/opt/bison/bin:$PATH
 
 # Save the env for use by other stages


### PR DESCRIPTION
We're not LLVM 20 compatible yet, we'll deal with that separately and not under the time pressure of a major releases that's overdue.

