### PR TITLE
build: Fix various MacOS problems with GitHub and CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,17 +520,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: MacOS-13-Intel llvm17
+          - desc: MacOS-13-Intel llvm17 oiio-release
             runner: macos-13
             nametag: macos13-p313
-            cc_compiler: /usr/local/opt/llvm/bin/clang
-            cxx_compiler: /usr/local/opt/llvm/bin/clang++
+            cc_compiler: clang
+            cxx_compiler: clang++
             cxx_std: 17
             python_ver: "3.13"
             aclang: 14
-            setenvs: export DO_BREW_UPDATE=0 CTEST_TEST_TIMEOUT=120
+            ctest_test_timeout: 120
+            setenvs: export HOMEBREW_PREFIX=/usr/local
                             EXTRA_BREW_PACKAGES="openimageio"
-          - desc: MacOS-14-ARM llvm17
+                            LLVMBREWVER="@17"
+          - desc: MacOS-14-ARM llvm19 oiio-release
             runner: macos-14
             nametag: macos14-arm-p313
             cc_compiler: clang
@@ -538,9 +540,9 @@ jobs:
             cxx_std: 17
             python_ver: "3.13"
             aclang: 15
-            setenvs: export DO_BREW_UPDATE=0
-                            EXTRA_BREW_PACKAGES="openimageio"
-          - desc: MacOS-15-ARM aclang16/C++17/py3.13
+            setenvs: export EXTRA_BREW_PACKAGES="openimageio"
+                            LLVMBREWVER="@19"
+          - desc: MacOS-15-ARM aclang16/C++17/py3.13 llvm19 oiio-main
             runner: macos-15
             nametag: macos15-arm-py313
             cc_compiler: clang
@@ -548,6 +550,7 @@ jobs:
             cxx_std: 17
             python_ver: "3.13"
             openimageio_ver: main
+            setenvs: export LLVMBREWVER="@19"
 
 
   windows:

--- a/src/build-scripts/install_homebrew_deps.bash
+++ b/src/build-scripts/install_homebrew_deps.bash
@@ -28,14 +28,18 @@ echo ""
 echo "Before my brew installs:"
 brew list --versions
 
-brew install --display-times -q gcc ccache cmake ninja || true
+if [[ "${BREW_UNLINK_PACKAGES}" != "" ]] ; then
+    brew unlink ${BREW_UNLINK_PACKAGES} || true
+fi
+
+
+if [[ "${DO_BREW_CMAKE_INSTALL:=1}" != "0" ]] ; then
+    brew install --display-times -q cmake || true
+fi
+brew install --display-times -q gcc ccache ninja || true
 brew link --overwrite gcc
 brew install --display-times -q python@${PYTHON_VERSION} || true
-# brew unlink python@3.8 || true
-# brew unlink python@3.9 || true
-brew unlink python@3.10 || true
 brew link --overwrite --force python@${PYTHON_VERSION} || true
-#brew upgrade --display-times -q cmake || true
 brew install --display-times -q imath openexr opencolorio || true
 #brew install --display-times -q freetype
 brew install --display-times -q partio pugixml || true

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -87,8 +87,9 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 16.0)
     if (CMAKE_COMPILER_IS_GNUCC AND (GCC_VERSION VERSION_LESS 7.0))
         message (WARNING "${ColorYellow}LLVM 16+ requires gcc 7.0 or higher.${ColorReset}\n")
     endif ()
-    if (CMAKE_COMPILER_IS_CLANG AND (CLANG_VERSION_STRING VERSION_LESS 5.0
-                                     OR APPLE_CLANG_VERSION_STRING VERSION_LESS 5.0))
+    if (CMAKE_COMPILER_IS_CLANG
+        AND NOT (CLANG_VERSION_STRING VERSION_GREATER_EQUAL 5.0
+                 OR APPLECLANG_VERSION_STRING VERSION_GREATER_EQUAL 5.0))
         message (WARNING "${ColorYellow}LLVM 16+ requires clang 5.0 or higher.${ColorReset}\n")
     endif ()
 endif ()

--- a/src/cmake/llvm_macros.cmake
+++ b/src/cmake/llvm_macros.cmake
@@ -60,7 +60,9 @@ function ( EMBED_LLVM_BITCODE_IN_CPP src_list suffix output_name list_to_append_
         endif ()
 
         if (APPLE)
-            list (APPEND LLVM_COMPILE_FLAGS -isysroot ${CMAKE_OSX_SYSROOT})
+            if (CMAKE_OSX_SYSROOT)
+                list (APPEND LLVM_COMPILE_FLAGS -isysroot ${CMAKE_OSX_SYSROOT})
+            endif ()
             if (CMAKE_OSX_DEPLOYMENT_TARGET)
                 list (APPEND LLVM_COMPILE_FLAGS -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET})
             endif ()


### PR DESCRIPTION
The combination of cmake 4.0, changing homebrew default package versions, and slight changes rolled out to the GitHub Actions runner images conspired to break our CI for 2 of 3 Mac variants. Fixes:

* Apple: only add the -isysroot to the bitcode-generating clang++ command if CMAKE_OSX_SYSROOT is defined. Plot twist -- this is no longer set by cmake  starting with cmake 4.0!

* Fix incorrect warning message for apple clang vs newish llvm in externalpackages.cmake.

* Remove homebrew unlinking of python@3.10 that warned in install_homebrew_deps.bash. On the GHA runners, it was giving us warnings because we were asking this package to be unlinked but it wasn't installed.  For future needs, add an env variable based way to unlink individual packges.
