### PR TITLE
build: Remove unused symbol that was removed from OIIO main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             old_node: 1
             cxx_std: 17
             opencolorio_ver: v2.2.1
-            openimageio_ver: v3.0.2.0
+            openimageio_ver: v3.0.6.1
             python_ver: 3.9
             pybind11_ver: v2.7.0
             simd: avx2,f16c
@@ -371,7 +371,7 @@ jobs:
             cxx_std: 17
             fmt_ver: 7.1.3
             opencolorio_ver: v2.3.2
-            openimageio_ver: v3.0.2.0
+            openimageio_ver: v3.0.6.1
             python_ver: "3.10"
             pybind11_ver: v2.10.0
             simd: avx2,f16c

--- a/src/liboslexec/shadingsys.cpp
+++ b/src/liboslexec/shadingsys.cpp
@@ -1568,7 +1568,6 @@ osl_simd_caps()
     if (OIIO_AVX512DQ_ENABLED)   caps.emplace_back ("avx512dq");
     if (OIIO_AVX512IFMA_ENABLED) caps.emplace_back ("avx512ifma");
     if (OIIO_AVX512PF_ENABLED)   caps.emplace_back ("avx512pf");
-    if (OIIO_AVX512ER_ENABLED)   caps.emplace_back ("avx512er");
     if (OIIO_AVX512CD_ENABLED)   caps.emplace_back ("avx512cd");
     if (OIIO_AVX512BW_ENABLED)   caps.emplace_back ("avx512bw");
     if (OIIO_AVX512VL_ENABLED)   caps.emplace_back ("avx512vl");


### PR DESCRIPTION
This symbol was for an architecture that never shipped mainstream, we don't need to look for it.
