### PR TITLE
build: Link batched libraries with liboslexec

### DIFF
--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -521,6 +521,7 @@ foreach(batched_target ${BATCHED_TARGET_LIST})
     target_link_libraries (${batched_target_lib}
         PUBLIC
             OpenImageIO::OpenImageIO
+            ${local_lib}
         )
     if (partio_FOUND)
         target_link_libraries(${batched_target_lib} PRIVATE partio::partio ZLIB::ZLIB)


### PR DESCRIPTION
The batched libraries seem to require at least one symbol provided by liboslexec : `OSL::v1_14::Strings::null`. If this is not available, then attempts to do batch shading result in the following error at runtime :

```
ERROR: /home/john/dev/build/gaffer-1.6/lib/lib_b16_AVX512_noFMA_oslexec.so could not be loaded with error "/home/john/dev/build/gaffer-1.6/lib/lib_b16_AVX512_noFMA_oslexec.so: undefined symbol: _ZN3OSL5v1_147Strings4nullE"
LLVM_Util::call_function(osl_b16_AVX512_noFMA_allocate_weighted_closure_component_masked, args), requested function name doesn't exist in the current module!
/home/john/dev/gafferDependencies/OpenShadingLanguage/working/OpenShadingLanguage-1.14.5.1/src/liboslexec/llvm_util.cpp:4370: call_function: Assertion 'func' failed.
```

This came up in Gaffer, where we have a plugin that uses `liboslexec` to do geometry and image processing. Why does Gaffer require this fix but other clients such as `testshade` don't? My theory is that this is because `testshade` is an application, and since it links to `liboslexec` itself, the symbols are available to the batched library when it is opened. Whereas Gaffer does not link to `liboslexec`, but loads a plugin which does, meaning that `liboslexec` symbols do not become generally available. Using LD_PRELOAD to load `liboslexec` upfront also works, and I suspect loading the plugin with `DYLD_GLOBAL` probably would too, but both are more drastic than fixing the linking at source.

I don't know too much about how the batched libraries are loaded, so if there are better solutions I'm all ears.
