### PR TITLE
build: Simplify FindOptiX.cmake a bit now that OptiX 7 is the minimum

### DIFF
--- a/src/cmake/modules/FindOptiX.cmake
+++ b/src/cmake/modules/FindOptiX.cmake
@@ -33,25 +33,6 @@ find_path (OPTIX_INCLUDE_DIR
     HINTS ${OPTIXHOME}/include
     PATH_SUFFIXES include )
 
-# Macro adapted from https://github.com/nvpro-samples/optix_advanced_samples
-macro(OPTIX_find_api_library name version)
-    find_library(${name}_LIBRARY
-        NAMES ${name}.${version} ${name}
-        PATHS "${OPTIXHOME}/lib64"
-        NO_DEFAULT_PATH
-        )
-    find_library(${name}_LIBRARY
-        NAMES ${name}.${version} ${name}
-        )
-    if (${name}_LIBRARY STREQUAL "${name}_LIBRARY-NOTFOUND")
-        if (WIN32)
-            set (${name}_LIBRARY "${OPTIXHOME}/lib64/${name}.${version}.lib")
-        else ()
-            set (${name}_LIBRARY "${OPTIXHOME}/lib64/lib${name}.so")
-        endif ()
-    endif()
-endmacro()
-
 if (OPTIX_INCLUDE_DIR)
     # Pull out the API version from optix.h
     file(STRINGS ${OPTIX_INCLUDE_DIR}/optix.h OPTIX_VERSION_LINE LIMIT_COUNT 1 REGEX "define OPTIX_VERSION")

--- a/src/cmake/modules/FindOptiX.cmake
+++ b/src/cmake/modules/FindOptiX.cmake
@@ -62,14 +62,6 @@ if (OPTIX_INCLUDE_DIR)
     set(OPTIX_VERSION "${OPTIX_VERSION_MAJOR}.${OPTIX_VERSION_MINOR}.${OPTIX_VERSION_MICRO}")
 endif ()
 
-# OptiX 7 doesn't link to any libraries
-if (OPTIX_VERSION VERSION_LESS 7)
-    OPTIX_find_api_library(optix ${OPTIX_VERSION})
-    OPTIX_find_api_library(optixu ${OPTIX_VERSION})
-    OPTIX_find_api_library(optix_prime ${OPTIX_VERSION})
-    set (OPTIX_LIBRARIES ${optix_LIBRARY})
-endif ()
-
 mark_as_advanced (
     OPTIX_INCLUDE_DIR
     OPTIX_LIBRARIES
@@ -79,19 +71,11 @@ mark_as_advanced (
 include (FindPackageHandleStandardArgs)
 
 
-if (${OPTIX_VERSION_MAJOR} LESS 7)
-    find_package_handle_standard_args (OptiX
-        FOUND_VAR     OPTIX_FOUND
-        REQUIRED_VARS OPTIX_INCLUDE_DIR OPTIX_LIBRARIES OPTIX_VERSION
-        VERSION_VAR   OPTIX_VERSION
-        )
-else ()
-    find_package_handle_standard_args (OptiX
-        FOUND_VAR     OPTIX_FOUND
-        REQUIRED_VARS OPTIX_INCLUDE_DIR OPTIX_VERSION
-        VERSION_VAR   OPTIX_VERSION
-        )
-endif()
+find_package_handle_standard_args (OptiX
+    FOUND_VAR     OPTIX_FOUND
+    REQUIRED_VARS OPTIX_INCLUDE_DIR OPTIX_VERSION
+    VERSION_VAR   OPTIX_VERSION
+    )
 
 if (OPTIX_FOUND)
     set (OPTIX_INCLUDES ${OPTIX_INCLUDE_DIR})


### PR DESCRIPTION
There was still some logic that was only needed during the period that we supported both OptiX 6 and 7+.

