### PR TITLE
build: Get OptiX headers from new improved location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,8 @@ jobs:
             pybind11_ver: v2.10.0
             simd: avx2,f16c
             skip_tests: 1
-            setenvs: export OSL_CMAKE_FLAGS="-DOSL_USE_OPTIX=1" OPTIX_VERSION=7.0
+            setenvs: export OSL_CMAKE_FLAGS="-DOSL_USE_OPTIX=1"
+                            OPTIX_VERSION=7.0.0
                             OPENIMAGEIO_CMAKE_FLAGS=-DBUILD_FMT_VERSION=9.1.0
           - desc: VP2024 gcc11/C++17 llvm17 py3.11 boost1.82 oiio-rel avx2
             nametag: linux-vfx2024

--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -148,21 +148,10 @@ cmake --version
 
 
 if [[ "$OPTIX_VERSION" != "" ]] ; then
-    echo "Requested OPTIX_VERSION = '${OPTIX_VERSION}'"
-    mkdir -p $LOCAL_DEPS_DIR/dist/include/internal
-    OPTIXLOC=https://developer.download.nvidia.com/redist/optix/v${OPTIX_VERSION}
-    for f in optix.h optix_device.h optix_function_table.h \
-             optix_function_table_definition.h optix_host.h \
-             optix_stack_size.h optix_stubs.h optix_types.h optix_7_device.h \
-             optix_7_host.h optix_7_types.h \
-             internal/optix_7_device_impl.h \
-             internal/optix_7_device_impl_exception.h \
-             internal/optix_7_device_impl_transformations.h
-        do
-        curl --retry 100 -m 120 --connect-timeout 30 \
-            $OPTIXLOC/include/$f > $LOCAL_DEPS_DIR/dist/include/$f
-    done
-    export OptiX_ROOT=$LOCAL_DEPS_DIR/dist
+    OPTIXREPO=${OPTIXREPO:=https://github.com/NVIDIA/optix-dev}
+    echo "Requested OPTIX_VERSION = '${OPTIX_VERSION}' from ${OPTIXREPO}"
+    export OptiX_ROOT=$LOCAL_DEPS_DIR/dist/optix-dev
+    git clone -b v${OPTIX_VERSION} ${OPTIXREPO} ${OptiX_ROOT}
 fi
 
 


### PR DESCRIPTION
NVIDIA recently set up a GitHub repo with the OptiX headers (with version tags!), which is much better than the unreliable semi-secret location we used to use.
