### PR TITLE
Add compatibility with LLVM 20.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,8 +49,8 @@ NEW or CHANGED minimum dependencies since the last major release are **bold**.
     $OpenImageIO_ROOT/lib to be in your LD_LIBRARY_PATH (or
     DYLD_LIBRARY_PATH on OS X).
 
-* [LLVM](http://www.llvm.org) 11, 12, 13, 14, 15, 16, 17, 18, or 19, including
-  clang libraries. **LLVM 20 is not yet supported.**
+* [LLVM](http://www.llvm.org) 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, including
+  clang libraries.
 
 * (optional) For GPU rendering on NVIDIA GPUs:
     * [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) 7.0 or higher.

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -58,7 +58,7 @@ checked_find_package (pugixml REQUIRED
 # LLVM library setup
 checked_find_package (LLVM REQUIRED
                       VERSION_MIN 11.0
-                      VERSION_MAX 19.9
+                      VERSION_MAX 20.9
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES
                             LLVM_SHARED_MODE)
 # ensure include directory is added (in case of non-standard locations

--- a/src/include/OSL/platform.h
+++ b/src/include/OSL/platform.h
@@ -20,6 +20,7 @@
 
 #include <cstring>
 #include <memory>
+#include <cstdint>
 
 #include <OSL/oslversion.h>
 

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -3212,7 +3212,11 @@ LLVM_Util::loop_after_block() const
 llvm::Type*
 LLVM_Util::type_union(cspan<llvm::Type*> types)
 {
+#if OSL_LLVM_VERSION >= 200
+    llvm::DataLayout target(module()->getDataLayout());
+#else
     llvm::DataLayout target(module());
+#endif
     size_t max_size  = 0;
     size_t max_align = 1;
     for (auto t : types) {

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -3605,6 +3605,21 @@ LLVM_Util::native_to_llvm_mask(llvm::Value* native_mask)
     return llvm_mask;
 }
 
+
+
+inline llvm::Function*
+getIntrinsicDeclaration(llvm::Module* module, llvm::Intrinsic::ID id,
+                        llvm::ArrayRef<llvm::Type*> Tys = {})
+{
+#if OSL_LLVM_VERSION >= 200
+    return llvm::Intrinsic::getOrInsertDeclaration(module, id, Tys);
+#else
+    return llvm::Intrinsic::getDeclaration(module, id, Tys);
+#endif
+}
+
+
+
 llvm::Value*
 LLVM_Util::mask_as_int(llvm::Value* mask)
 {
@@ -3656,7 +3671,7 @@ LLVM_Util::mask_as_int(llvm::Value* mask)
                   builder().CreateBitCast(w8_int_masks[1], w8_float_type) }
             };
 
-            llvm::Function* func = llvm::Intrinsic::getDeclaration(
+            llvm::Function* func = getIntrinsicDeclaration(
                 module(), llvm::Intrinsic::x86_avx_movmsk_ps_256);
 
             llvm::Value* args[1] = { w8_float_masks[0] };
@@ -3687,7 +3702,7 @@ LLVM_Util::mask_as_int(llvm::Value* mask)
             llvm::Value* w8_float_mask = builder().CreateBitCast(wide_int_mask,
                                                                  w8_float_type);
 
-            llvm::Function* func = llvm::Intrinsic::getDeclaration(
+            llvm::Function* func = getIntrinsicDeclaration(
                 module(), llvm::Intrinsic::x86_avx_movmsk_ps_256);
 
             llvm::Value* args[1] = { w8_float_mask };
@@ -3715,8 +3730,9 @@ LLVM_Util::mask_as_int(llvm::Value* mask)
 
             // Now we will use the horizontal sign extraction intrinsic
             // to build a 32 bit mask value.
-            llvm::Function* func = llvm::Intrinsic::getDeclaration(
-                module(), llvm::Intrinsic::x86_sse_movmsk_ps);
+            llvm::Function* func
+                = getIntrinsicDeclaration(module(),
+                                          llvm::Intrinsic::x86_sse_movmsk_ps);
 
             llvm::Value* args[1] = { w4_float_mask };
             llvm::Value* int8_mask;
@@ -3753,8 +3769,9 @@ LLVM_Util::mask_as_int(llvm::Value* mask)
                   builder().CreateBitCast(w4_int_masks[3], w4_float_type) }
             };
 
-            llvm::Function* func = llvm::Intrinsic::getDeclaration(
-                module(), llvm::Intrinsic::x86_sse_movmsk_ps);
+            llvm::Function* func
+                = getIntrinsicDeclaration(module(),
+                                          llvm::Intrinsic::x86_sse_movmsk_ps);
 
             llvm::Value* args[1] = { w4_float_masks[0] };
             std::array<llvm::Value*, 4> int4_masks;
@@ -3793,8 +3810,9 @@ LLVM_Util::mask_as_int(llvm::Value* mask)
                   builder().CreateBitCast(w4_int_masks[1], w4_float_type) }
             };
 
-            llvm::Function* func = llvm::Intrinsic::getDeclaration(
-                module(), llvm::Intrinsic::x86_sse_movmsk_ps);
+            llvm::Function* func
+                = getIntrinsicDeclaration(module(),
+                                          llvm::Intrinsic::x86_sse_movmsk_ps);
 
             llvm::Value* args[1] = { w4_float_masks[0] };
             std::array<llvm::Value*, 2> int4_masks;
@@ -3825,8 +3843,9 @@ LLVM_Util::mask_as_int(llvm::Value* mask)
 
             // Now we will use the horizontal sign extraction intrinsic
             // to build a 32 bit mask value.
-            llvm::Function* func = llvm::Intrinsic::getDeclaration(
-                module(), llvm::Intrinsic::x86_sse_movmsk_ps);
+            llvm::Function* func
+                = getIntrinsicDeclaration(module(),
+                                          llvm::Intrinsic::x86_sse_movmsk_ps);
 
             llvm::Value* args[1]   = { w4_float_mask };
             llvm::Value* int4_mask = builder().CreateCall(func,
@@ -3884,8 +3903,9 @@ LLVM_Util::mask4_as_int8(llvm::Value* mask)
 
         // Now we will use the horizontal sign extraction intrinsic
         // to build a 32 bit mask value.
-        llvm::Function* func = llvm::Intrinsic::getDeclaration(
-            module(), llvm::Intrinsic::x86_sse_movmsk_ps);
+        llvm::Function* func
+            = getIntrinsicDeclaration(module(),
+                                      llvm::Intrinsic::x86_sse_movmsk_ps);
 
         llvm::Value* args[1] = { w4_float_mask };
         llvm::Value* int32   = builder().CreateCall(func, toArrayRef(args));
@@ -4056,10 +4076,10 @@ LLVM_Util::op_1st_active_lane_of(llvm::Value* mask)
     };
 
     // Count trailing zeros, least significant
-    llvm::Type* types[] = { intMaskType };
-    llvm::Function* func_cttz
-        = llvm::Intrinsic::getDeclaration(module(), llvm::Intrinsic::cttz,
-                                          toArrayRef(types));
+    llvm::Type* types[]       = { intMaskType };
+    llvm::Function* func_cttz = getIntrinsicDeclaration(module(),
+                                                        llvm::Intrinsic::cttz,
+                                                        toArrayRef(types));
 
     llvm::Value* args[2] = { int_mask, constant_bool(true) };
 
@@ -4655,13 +4675,13 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             switch (m_vector_width) {
             case 16:
                 int_mask              = mask_as_int16(current_mask());
-                func_avx512_gather_pi = llvm::Intrinsic::getDeclaration(
+                func_avx512_gather_pi = getIntrinsicDeclaration(
                     module(), llvm::Intrinsic::x86_avx512_gather_dpi_512);
                 break;
             case 8:
             case 4:
                 int_mask              = mask_as_int8(current_mask());
-                func_avx512_gather_pi = llvm::Intrinsic::getDeclaration(
+                func_avx512_gather_pi = getIntrinsicDeclaration(
                     module(), llvm::Intrinsic::x86_avx512_gather3siv8_si);
                 break;
             default: OSL_ASSERT(0 && "unsupported native bit mask width");
@@ -4675,9 +4695,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             return builder().CreateCall(func_avx512_gather_pi,
                                         toArrayRef(args));
         } else if (m_supports_avx2) {
-            llvm::Function* func_avx2_gather_pi
-                = llvm::Intrinsic::getDeclaration(
-                    module(), llvm::Intrinsic::x86_avx2_gather_d_d_256);
+            llvm::Function* func_avx2_gather_pi = getIntrinsicDeclaration(
+                module(), llvm::Intrinsic::x86_avx2_gather_d_d_256);
             OSL_ASSERT(func_avx2_gather_pi);
 
             llvm::Constant* avx2_unmasked_value = wide_constant(8, 0);
@@ -4733,13 +4752,13 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             switch (m_vector_width) {
             case 16:
                 int_mask              = mask_as_int16(current_mask());
-                func_avx512_gather_ps = llvm::Intrinsic::getDeclaration(
+                func_avx512_gather_ps = getIntrinsicDeclaration(
                     module(), llvm::Intrinsic::x86_avx512_gather_dps_512);
                 break;
             case 8:
             case 4:
                 int_mask              = mask_as_int8(current_mask());
-                func_avx512_gather_ps = llvm::Intrinsic::getDeclaration(
+                func_avx512_gather_ps = getIntrinsicDeclaration(
                     module(), llvm::Intrinsic::x86_avx512_gather3siv8_sf);
                 break;
             default: OSL_ASSERT(0 && "unsupported native bit mask width");
@@ -4755,9 +4774,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             return builder().CreateCall(func_avx512_gather_ps,
                                         toArrayRef(args));
         } else if (m_supports_avx2) {
-            llvm::Function* func_avx2_gather_ps
-                = llvm::Intrinsic::getDeclaration(
-                    module(), llvm::Intrinsic::x86_avx2_gather_d_ps_256);
+            llvm::Function* func_avx2_gather_ps = getIntrinsicDeclaration(
+                module(), llvm::Intrinsic::x86_avx2_gather_d_ps_256);
             OSL_ASSERT(func_avx2_gather_ps);
 
             llvm::Constant* avx2_unmasked_value = wide_constant(8, 0.0f);
@@ -4818,9 +4836,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             switch (m_vector_width) {
             case 16: {
                 // Gather 64bit integer, as that is binary compatible with 64bit pointers of ustring
-                llvm::Function* func_avx512_gather_dpq
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather_dpq_512);
+                llvm::Function* func_avx512_gather_dpq = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather_dpq_512);
                 OSL_ASSERT(func_avx512_gather_dpq);
 
                 // We can only gather 8 at a time, so need to split the work over 2 gathers
@@ -4847,9 +4864,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             }
             case 8: {
                 // Gather 64bit integer, as that is binary compatible with 64bit pointers of ustring
-                llvm::Function* func_avx512_gather_dpq
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather3siv4_di);
+                llvm::Function* func_avx512_gather_dpq = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather3siv4_di);
                 OSL_ASSERT(func_avx512_gather_dpq);
 
                 // We can only gather 4 at a time, so need to split the work over 2 gathers
@@ -4876,9 +4892,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             }
             case 4: {
                 // Gather 64bit integer, as that is binary compatible with 64bit pointers of ustring
-                llvm::Function* func_avx512_gather_dpq
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather3siv4_di);
+                llvm::Function* func_avx512_gather_dpq = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather3siv4_di);
                 OSL_ASSERT(func_avx512_gather_dpq);
 
                 auto w4_bit_masks   = current_mask();
@@ -4906,9 +4921,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
         if (m_supports_avx512f) {
             switch (m_vector_width) {
             case 16: {
-                llvm::Function* func_avx512_gather_ps
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather_dps_512);
+                llvm::Function* func_avx512_gather_ps = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather_dps_512);
                 OSL_ASSERT(func_avx512_gather_ps);
 
                 llvm::Value* unmasked_value = wide_constant(0.0f);
@@ -4920,9 +4934,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
                                             toArrayRef(args));
             }
             case 8: {
-                llvm::Function* func_avx512_gather_ps
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather3siv8_sf);
+                llvm::Function* func_avx512_gather_ps = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather3siv8_sf);
                 OSL_ASSERT(func_avx512_gather_ps);
 
                 llvm::Value* unmasked_value = wide_constant(0.0f);
@@ -4934,9 +4947,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
                                             toArrayRef(args));
             }
             case 4: {
-                llvm::Function* func_avx512_gather_ps
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather3siv8_sf);
+                llvm::Function* func_avx512_gather_ps = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather3siv8_sf);
                 OSL_ASSERT(func_avx512_gather_ps);
 
                 llvm::Value* unmasked_value = wide_constant(0.0f);
@@ -4951,9 +4963,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             };
 
         } else if (m_supports_avx2) {
-            llvm::Function* func_avx2_gather_ps
-                = llvm::Intrinsic::getDeclaration(
-                    module(), llvm::Intrinsic::x86_avx2_gather_d_ps_256);
+            llvm::Function* func_avx2_gather_ps = getIntrinsicDeclaration(
+                module(), llvm::Intrinsic::x86_avx2_gather_d_ps_256);
             OSL_ASSERT(func_avx2_gather_ps);
 
             llvm::Constant* avx2_unmasked_value = wide_constant(8, 0.0f);
@@ -5018,9 +5029,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
         if (m_supports_avx512f) {
             switch (m_vector_width) {
             case 16: {
-                llvm::Function* func_avx512_gather_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather_dpi_512);
+                llvm::Function* func_avx512_gather_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather_dpi_512);
                 OSL_ASSERT(func_avx512_gather_pi);
 
                 llvm::Value* unmasked_value = wide_constant(0);
@@ -5032,9 +5042,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
                                             toArrayRef(args));
             }
             case 8: {
-                llvm::Function* func_avx512_gather_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather3siv8_si);
+                llvm::Function* func_avx512_gather_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather3siv8_si);
                 OSL_ASSERT(func_avx512_gather_pi);
 
                 llvm::Value* unmasked_value = wide_constant(0);
@@ -5046,9 +5055,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
                                             toArrayRef(args));
             }
             case 4: {
-                llvm::Function* func_avx512_gather_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather3siv8_si);
+                llvm::Function* func_avx512_gather_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather3siv8_si);
                 OSL_ASSERT(func_avx512_gather_pi);
 
                 llvm::Value* unmasked_value = wide_constant(0);
@@ -5064,9 +5072,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
         } else if (m_supports_avx2) {
             switch (m_vector_width) {
             case 16: {
-                llvm::Function* func_avx2_gather_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx2_gather_d_d_256);
+                llvm::Function* func_avx2_gather_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx2_gather_d_d_256);
                 OSL_ASSERT(func_avx2_gather_pi);
 
                 llvm::Constant* avx2_unmasked_value = wide_constant(8, 0);
@@ -5089,9 +5096,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
                 return op_combine_8x_vectors(gather1, gather2);
             }
             case 8: {
-                llvm::Function* func_avx2_gather_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx2_gather_d_d_256);
+                llvm::Function* func_avx2_gather_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx2_gather_d_d_256);
                 OSL_ASSERT(func_avx2_gather_pi);
 
                 llvm::Constant* avx2_unmasked_value = wide_constant(8, 0);
@@ -5109,9 +5115,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
                 return gather_result;
             }
             case 4: {
-                llvm::Function* func_avx2_gather_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx2_gather_d_d_256);
+                llvm::Function* func_avx2_gather_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx2_gather_d_d_256);
                 OSL_ASSERT(func_avx2_gather_pi);
 
                 llvm::Constant* avx2_unmasked_value = wide_constant(8, 0);
@@ -5141,9 +5146,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             case 16: {
                 // Gather 64bit integer, as that is binary compatible with
                 // 64bit pointers of ustring
-                llvm::Function* func_avx512_gather_dpq
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather_dpq_512);
+                llvm::Function* func_avx512_gather_dpq = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather_dpq_512);
                 OSL_ASSERT(func_avx512_gather_dpq);
 
                 // We can only gather 8 at a time, so need to split the work
@@ -5173,9 +5177,8 @@ LLVM_Util::op_gather(llvm::Type* src_type, llvm::Value* src_ptr,
             case 8:
             case 4: {
                 // Gather 64bit integer, as that is binary compatible with 64bit pointers of ustring
-                llvm::Function* func_avx512_gather_dpq
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_gather3siv4_di);
+                llvm::Function* func_avx512_gather_dpq = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_gather3siv4_di);
                 OSL_ASSERT(func_avx512_gather_dpq);
 
                 // TODO: we technically could gather all 8 if we let a
@@ -5301,13 +5304,13 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
             switch (m_vector_width) {
             case 16:
                 int_mask               = mask_as_int16(current_mask());
-                func_avx512_scatter_ps = llvm::Intrinsic::getDeclaration(
+                func_avx512_scatter_ps = getIntrinsicDeclaration(
                     module(), llvm::Intrinsic::x86_avx512_scatter_dps_512);
                 break;
             case 8:
             case 4:
                 int_mask               = mask_as_int8(current_mask());
-                func_avx512_scatter_ps = llvm::Intrinsic::getDeclaration(
+                func_avx512_scatter_ps = getIntrinsicDeclaration(
                     module(), llvm::Intrinsic::x86_avx512_scattersiv8_sf);
                 break;
             default:
@@ -5334,13 +5337,13 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
             switch (m_vector_width) {
             case 16:
                 int_mask               = mask_as_int16(current_mask());
-                func_avx512_scatter_pi = llvm::Intrinsic::getDeclaration(
+                func_avx512_scatter_pi = getIntrinsicDeclaration(
                     module(), llvm::Intrinsic::x86_avx512_scatter_dpi_512);
                 break;
             case 8:
             case 4:
                 int_mask               = mask_as_int8(current_mask());
-                func_avx512_scatter_pi = llvm::Intrinsic::getDeclaration(
+                func_avx512_scatter_pi = getIntrinsicDeclaration(
                     module(), llvm::Intrinsic::x86_avx512_scattersiv8_si);
                 break;
             default:
@@ -5366,7 +5369,7 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                 llvm::Value* linear_indices = wide_index;
 
                 llvm::Function* func_avx512_scatter_dpq
-                    = llvm::Intrinsic::getDeclaration(
+                    = getIntrinsicDeclaration(
                         module(), llvm::Intrinsic::x86_avx512_scatter_dpq_512);
                 OSL_ASSERT(func_avx512_scatter_dpq);
 
@@ -5398,7 +5401,7 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                 llvm::Value* linear_indices = wide_index;
 
                 llvm::Function* func_avx512_scatter_dpq
-                    = llvm::Intrinsic::getDeclaration(
+                    = getIntrinsicDeclaration(
                         module(), llvm::Intrinsic::x86_avx512_scatter_dpq_512);
                 OSL_ASSERT(func_avx512_scatter_dpq);
 
@@ -5417,7 +5420,7 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                 llvm::Value* linear_indices = wide_index;
 
                 llvm::Function* func_avx512_scatter_dpq
-                    = llvm::Intrinsic::getDeclaration(
+                    = getIntrinsicDeclaration(
                         module(), llvm::Intrinsic::x86_avx512_scatter_dpq_512);
                 OSL_ASSERT(func_avx512_scatter_dpq);
 
@@ -5446,9 +5449,8 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
         if (m_supports_avx512f) {
             switch (m_vector_width) {
             case 16: {
-                llvm::Function* func_avx512_scatter_ps
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_scatter_dps_512);
+                llvm::Function* func_avx512_scatter_ps = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_scatter_dps_512);
                 OSL_ASSERT(func_avx512_scatter_ps);
 
                 llvm::Value* args[] = { void_ptr(src_ptr),
@@ -5459,9 +5461,8 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                 return;
             }
             case 8: {
-                llvm::Function* func_avx512_scatter_ps
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_scattersiv8_sf);
+                llvm::Function* func_avx512_scatter_ps = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_scattersiv8_sf);
                 OSL_ASSERT(func_avx512_scatter_ps);
 
                 llvm::Value* args[] = { void_ptr(src_ptr),
@@ -5472,9 +5473,8 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                 return;
             }
             case 4: {
-                llvm::Function* func_avx512_scatter_ps
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_scattersiv8_sf);
+                llvm::Function* func_avx512_scatter_ps = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_scattersiv8_sf);
                 OSL_ASSERT(func_avx512_scatter_ps);
 
                 llvm::Value* args[] = { void_ptr(src_ptr),
@@ -5502,9 +5502,8 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
         if (m_supports_avx512f) {
             switch (m_vector_width) {
             case 16: {
-                llvm::Function* func_avx512_scatter_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_scatter_dpi_512);
+                llvm::Function* func_avx512_scatter_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_scatter_dpi_512);
                 OSL_ASSERT(func_avx512_scatter_pi);
 
                 llvm::Value* args[] = { void_ptr(src_ptr),
@@ -5515,9 +5514,8 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                 return;
             }
             case 8: {
-                llvm::Function* func_avx512_scatter_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_scattersiv8_si);
+                llvm::Function* func_avx512_scatter_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_scattersiv8_si);
                 OSL_ASSERT(func_avx512_scatter_pi);
 
                 llvm::Value* args[] = { void_ptr(src_ptr),
@@ -5528,9 +5526,8 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                 return;
             }
             case 4: {
-                llvm::Function* func_avx512_scatter_pi
-                    = llvm::Intrinsic::getDeclaration(
-                        module(), llvm::Intrinsic::x86_avx512_scattersiv8_si);
+                llvm::Function* func_avx512_scatter_pi = getIntrinsicDeclaration(
+                    module(), llvm::Intrinsic::x86_avx512_scattersiv8_si);
                 OSL_ASSERT(func_avx512_scatter_pi);
 
                 llvm::Value* args[] = { void_ptr(src_ptr),
@@ -5561,7 +5558,7 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                     wide_index);
 
                 llvm::Function* func_avx512_scatter_dpq
-                    = llvm::Intrinsic::getDeclaration(
+                    = getIntrinsicDeclaration(
                         module(), llvm::Intrinsic::x86_avx512_scatter_dpq_512);
                 OSL_ASSERT(func_avx512_scatter_dpq);
 
@@ -5594,7 +5591,7 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                     wide_index);
 
                 llvm::Function* func_avx512_scatter_dpq
-                    = llvm::Intrinsic::getDeclaration(
+                    = getIntrinsicDeclaration(
                         module(), llvm::Intrinsic::x86_avx512_scatter_dpq_512);
                 OSL_ASSERT(func_avx512_scatter_dpq);
 
@@ -5614,7 +5611,7 @@ LLVM_Util::op_scatter(llvm::Value* wide_val, llvm::Type* src_type,
                     wide_index);
 
                 llvm::Function* func_avx512_scatter_dpq
-                    = llvm::Intrinsic::getDeclaration(
+                    = getIntrinsicDeclaration(
                         module(), llvm::Intrinsic::x86_avx512_scatter_dpq_512);
                 OSL_ASSERT(func_avx512_scatter_dpq);
 
@@ -6541,7 +6538,7 @@ LLVM_Util::op_zero_if(llvm::Value* cond, llvm::Value* v)
             // inexpensive (0.5 clock) instruction rather than let something more expensive
             // be duplicated.
             // We can use a ternery log operation with a mask set to reproduce the 1st argument.
-            llvm::Function* func = llvm::Intrinsic::getDeclaration(
+            llvm::Function* func = getIntrinsicDeclaration(
                 module(), (m_vector_width == 16)
                               ? llvm::Intrinsic::x86_avx512_pternlog_d_512
                               : llvm::Intrinsic::x86_avx512_pternlog_d_256);
@@ -6672,8 +6669,7 @@ LLVM_Util::op_fabs(llvm::Value* v)
     llvm::Type* types[] = { v->getType() };
 
     llvm::Function* func
-        = llvm::Intrinsic::getDeclaration(module(), llvm::Intrinsic::fabs,
-                                          types);
+        = getIntrinsicDeclaration(module(), llvm::Intrinsic::fabs, types);
 
     llvm::Value* fabs_call = builder().CreateCall(func, { v });
     return fabs_call;
@@ -6687,7 +6683,7 @@ LLVM_Util::op_is_not_finite(llvm::Value* v)
 
     if (m_supports_avx512f && v->getType() == type_wide_float()) {
         OSL_ASSERT((m_vector_width == 8) || (m_vector_width == 16));
-        llvm::Value* func = llvm::Intrinsic::getDeclaration(
+        llvm::Value* func = getIntrinsicDeclaration(
             module(), (v->getType() == type_wide_float())
                           ? ((m_vector_width == 16)
                                  ? llvm::Intrinsic::x86_avx512_fpclass_ps_512


### PR DESCRIPTION
## Description

This adds LLVM 20 compatibility. The changes are thankfully quite concise. 

Fixes #1963.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
