### PR TITLE
update include directives for OpenImageIO_ROOT

### DIFF
--- a/src/liboslcomp/CMakeLists.txt
+++ b/src/liboslcomp/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries (${local_lib}
         ${CMAKE_DL_LIBS}
         ${CLANG_LIBRARIES} ${LLVM_LIBRARIES} ${LLVM_LDFLAGS}
         ${LLVM_SYSTEM_LIBRARIES})
+target_include_directories (${local_lib}  BEFORE PRIVATE ${OpenImageIO_INCLUDES})
 
 # link with (system) library to prevent missing symbols inside clangDriver.lib
 if (MSVC)

--- a/src/liboslexec/CMakeLists.txt
+++ b/src/liboslexec/CMakeLists.txt
@@ -539,6 +539,9 @@ target_include_directories (${local_lib}
         "${CMAKE_SOURCE_DIR}/src/liboslcomp"
         ${ROBINMAP_INCLUDES}
     )
+
+target_include_directories (${local_lib}  BEFORE PRIVATE ${OpenImageIO_INCLUDES})
+
 target_compile_definitions (${local_lib}
     PRIVATE
         OSL_EXPORTS
@@ -607,16 +610,19 @@ install_targets (${local_lib})
 if (OSL_BUILD_TESTS AND BUILD_TESTING)
     add_executable (accum_test accum_test.cpp)
     target_link_libraries (accum_test PRIVATE oslexec ${CMAKE_DL_LIBS})
+    target_include_directories (accum_test  BEFORE PRIVATE ${OpenImageIO_INCLUDES})
     set_target_properties (accum_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_accum ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/accum_test)
 
     add_executable (dual_test dual_test.cpp)
     target_link_libraries (dual_test PRIVATE OpenImageIO::OpenImageIO Imath::Imath ${CMAKE_DL_LIBS})
+    target_include_directories (dual_test  BEFORE PRIVATE ${OpenImageIO_INCLUDES})
     set_target_properties (dual_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_dual ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dual_test)
 
     add_executable (llvmutil_test llvmutil_test.cpp)
     target_link_libraries (llvmutil_test PRIVATE oslexec ${CMAKE_DL_LIBS})
+    target_include_directories (llvmutil_test  BEFORE PRIVATE ${OpenImageIO_INCLUDES})
     set_target_properties (llvmutil_test PROPERTIES FOLDER "Unit Tests")
     add_test (unit_llvmutil ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/llvmutil_test)
 endif ()

--- a/src/liboslnoise/CMakeLists.txt
+++ b/src/liboslnoise/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories (${local_lib}
         ${CMAKE_INSTALL_FULL_INCLUDEDIR}
     PRIVATE
         ../liboslexec)
+target_include_directories (${local_lib}  BEFORE PRIVATE ${OpenImageIO_INCLUDES})
 target_link_libraries (${local_lib}
     PUBLIC
         OpenImageIO::OpenImageIO
@@ -45,6 +46,7 @@ install_targets (${local_lib})
 if (OSL_BUILD_TESTS AND BUILD_TESTING)
     add_executable (oslnoise_test oslnoise_test.cpp)
     set_target_properties (oslnoise_test PROPERTIES FOLDER "Unit Tests")
+    target_include_directories (oslnoise_test BEFORE PRIVATE ${OpenImageIO_INCLUDES})
     target_link_libraries (oslnoise_test PRIVATE oslnoise)
     add_test (unit_oslnoise ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/oslnoise_test)
 endif()

--- a/src/liboslquery/CMakeLists.txt
+++ b/src/liboslquery/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries (${local_lib}
     PUBLIC
         OpenImageIO::OpenImageIO_Util
     )
+target_include_directories (${local_lib}  BEFORE PRIVATE ${OpenImageIO_INCLUDES})
 
 target_compile_features (${local_lib}
                          INTERFACE cxx_std_${DOWNSTREAM_CXX_STANDARD})

--- a/src/oslc/CMakeLists.txt
+++ b/src/oslc/CMakeLists.txt
@@ -12,5 +12,6 @@ if (NOT BUILD_SHARED_LIBS)
 endif ()
 
 add_executable ( oslc ${oslc_srcs} )
+target_include_directories ( oslc  BEFORE PRIVATE ${OpenImageIO_INCLUDES})
 target_link_libraries ( oslc PRIVATE oslcomp ${CMAKE_DL_LIBS})
 install_targets (oslc)

--- a/src/oslinfo/CMakeLists.txt
+++ b/src/oslinfo/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set ( oslinfo_srcs oslinfo.cpp )
 add_executable ( oslinfo ${oslinfo_srcs} )
+target_include_directories (oslinfo BEFORE PRIVATE ${OpenImageIO_INCLUDES})
 target_link_libraries (oslinfo
                        PRIVATE oslquery)
 install_targets (oslinfo)

--- a/src/osltoy/CMakeLists.txt
+++ b/src/osltoy/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 set (osltoy_srcs
      osltoymain.cpp osltoyapp.cpp codeeditor.cpp osltoyrenderer.cpp)
 add_executable (osltoy ${osltoy_srcs})
+target_include_directories (osltoy BEFORE PRIVATE ${OpenImageIO_INCLUDES})
 set_target_properties (osltoy PROPERTIES FOLDER "Tools")
 target_link_libraries (osltoy
     PRIVATE

--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -77,6 +77,8 @@ endif ()
 
 add_executable (testrender ${testrender_srcs})
 
+target_include_directories (testrender BEFORE PRIVATE ${OpenImageIO_INCLUDES})
+
 target_link_libraries (testrender
     PRIVATE
         oslexec oslquery oslcomp BSDL

--- a/src/testshade/CMakeLists.txt
+++ b/src/testshade/CMakeLists.txt
@@ -77,6 +77,8 @@ EMBED_LLVM_BITCODE_IN_CPP ( "${rs_srcs}" "_host" "testshade_llvm_compiled_rs" te
 
 add_executable ( testshade ${testshade_srcs} testshademain.cpp )
 
+target_include_directories (testshade BEFORE PRIVATE ${OpenImageIO_INCLUDES})
+
 target_link_libraries (testshade
                        PRIVATE
                            oslexec oslquery oslcomp)
@@ -107,12 +109,14 @@ if (NOT CODECOV)
     target_link_libraries (libtestshade
                            PRIVATE
                                oslexec oslquery oslcomp)
+    target_include_directories (libtestshade BEFORE PRIVATE ${OpenImageIO_INCLUDES})
     set_target_properties (libtestshade PROPERTIES PREFIX "")
 
     install_targets ( libtestshade )
 
     # The 'testshade_dso' executable
     add_executable ( testshade_dso testshade_dso.cpp )
+    target_include_directories (testshade_dso BEFORE PRIVATE ${OpenImageIO_INCLUDES})
     target_link_libraries (testshade_dso
                            PRIVATE
                                OpenImageIO::OpenImageIO


### PR DESCRIPTION

## Description

Adds directives to prioritize the includes from $OpenImageIO_ROOT in case there is an older (or newer!) system install of OpenImageIO.  Without this, OSL might use the includes in /usr/include/OpenImageIO yet link to the libraries in OpenImageIO_ROOT thus producing namespace clashes.

## Tests

tests pass excdept for '987 - render-microfacet.opt', but I get the same failure for main.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format v17 before submitting, I definitely will look at
  the CI test that runs clang-format and fix anything that it highlights as
  being nonconforming.
