### PR TITLE
deps: test against pybind11 3.0 and minor fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,13 +532,13 @@ jobs:
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 17
-            openimageio_ver: lg-buildpng
+            openimageio_ver: dev-3.0
             python_ver: "3.13"
             aclang: 14
             ctest_test_timeout: 120
             setenvs: export HOMEBREW_PREFIX=/usr/local
                             LLVMBREWVER="@17"
-                            OPENIMAGEIO_REPO=lgritz/OpenImageIO
+                            USE_OPENVDB=0
           - desc: MacOS-14-ARM llvm19 oiio-release
             runner: macos-14
             nametag: macos14-arm-p313

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,7 @@ jobs:
             opencolorio_ver: v2.4.2
             openexr_ver: v3.3.3
             openimageio_ver: release
-            pybind11_ver: v2.13.6
+            pybind11_ver: v3.0.0
             python_ver: "3.12"
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
@@ -460,7 +460,7 @@ jobs:
             opencolorio_ver: v2.2.1
             openexr_ver: v3.1.11
             openimageio_ver: release
-            pybind11_ver: v2.9.2
+            pybind11_ver: v2.13.6
             python_ver: "3.10"
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
@@ -532,22 +532,23 @@ jobs:
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 17
+            openimageio_ver: lg-buildpng
             python_ver: "3.13"
             aclang: 14
             ctest_test_timeout: 120
             setenvs: export HOMEBREW_PREFIX=/usr/local
-                            EXTRA_BREW_PACKAGES="openimageio"
                             LLVMBREWVER="@17"
+                            OPENIMAGEIO_REPO=lgritz/OpenImageIO
           - desc: MacOS-14-ARM llvm19 oiio-release
             runner: macos-14
             nametag: macos14-arm-p313
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 17
+            openimageio_ver: main
             python_ver: "3.13"
             aclang: 15
-            setenvs: export EXTRA_BREW_PACKAGES="openimageio"
-                            LLVMBREWVER="@19"
+            setenvs: export LLVMBREWVER="@19"
           - desc: MacOS-15-ARM aclang16/C++17/py3.13 llvm19 oiio-main
             runner: macos-15
             nametag: macos15-arm-py313

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,7 +70,7 @@ NEW or CHANGED minimum dependencies since the last major release are **bold**.
 * (optional) Python: If you are building the Python bindings or running the
   testsuite:
     * **Python >= 3.7** (tested through 3.13)
-    * **pybind11 >= 2.7** (tested through 2.13)
+    * **pybind11 >= 2.7** (tested through 3.0)
     * NumPy (tested through 2.2.4)
 * (optional) Qt5 >= 5.6 or Qt6 (tested Qt5 through 5.15 and Qt6 through 6.8).
   If not found at build time, the `osltoy` application will be disabled.

--- a/src/build-scripts/build_openimageio.bash
+++ b/src/build-scripts/build_openimageio.bash
@@ -22,7 +22,6 @@ OPENIMAGEIO_CXXFLAGS=${OPENIMAGEIO_CXXFLAGS:=""}
 BASEDIR=$PWD
 
 pwd
-echo "Building OpenImageIO ${OPENIMAGEIO_VERSION}"
 echo "OpenImageIO build dir will be: ${OPENIMAGEIO_BUILD_DIR}"
 echo "OpenImageIO install dir will be: ${OPENIMAGEIO_INSTALL_DIR}"
 echo "OpenImageIO Build type is ${OPENIMAGEIO_BUILD_TYPE}"
@@ -39,7 +38,7 @@ mkdir -p ${OPENIMAGEIO_BUILD_DIR} && true
 pushd $OPENIMAGEIO_SOURCE_DIR
 git fetch --all -p
 git checkout $OPENIMAGEIO_VERSION --force
-echo "Building OpenImageIO from commit" `git rev-parse --short HEAD`
+echo "Building OpenImageIO from ${OPENIMAGEIO_REPO} / ${OPENIMAGEIO_VERSION} @ commit" `git rev-parse --short HEAD`
 
 if [[ "$USE_SIMD" != "" ]] ; then
     OPENIMAGEIO_CMAKE_FLAGS+=" -DUSE_SIMD=$USE_SIMD"

--- a/src/liboslquery/py_osl.cpp
+++ b/src/liboslquery/py_osl.cpp
@@ -30,7 +30,6 @@ declare_oslqueryparam(py::module& m)
         .def_readwrite("varlenarray", &Parameter::varlenarray)
         .def_readwrite("isstruct", &Parameter::isstruct)
         .def_readwrite("isclosure", &Parameter::isclosure)
-        .def_readwrite("type", &Parameter::type)
         .def_property_readonly(
             "value",
             [](const Parameter& p) {


### PR DESCRIPTION
Add pybind11 3.0 to the CI test matrix.

Found a place where we defined a python method twice, fixed that.

Ran into some trouble where the Mac runners which used a pre-built OIIO supplied by Homebrew, and apparently compiled against pybind11 2.x.  I think maybe there are some corner cases where if you have two python modules that share types (TypeDesc and a few more, in this case), they should not be built with pre-3.0 and post-3.0 versions of pybind11?

The quick fix was to switch to having OSL CI on Mac just build an OIIO from scratch to ensure that it was using the same pybind11. But that identified yet another problem (which I also think is a runner issue) that required some minor adjustment to how OIIO auto-builds libpng.
