### PR TITLE
build: Test C++20 and gcc14 + fixes needed

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -134,7 +134,7 @@ jobs:
           restore-keys: ${{inputs.nametag}}
       - name: Install LLVM and Clang
         if: inputs.llvm_action_ver != ''
-        uses: KyleMayes/install-llvm-action@6ba6e2cd3813def9879be378609d87cb3ef3bac3 # v2.0.6
+        uses: KyleMayes/install-llvm-action@a7a1a882e2d06ebe05d5bb97c3e1f8c984ae96fc # v2.0.7
         with:
           version: ${{ inputs.llvm_action_ver }}
       - name: Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,20 +426,19 @@ jobs:
             openimageio_ver: release
             pybind11_ver: v3.0.0
             python_ver: "3.12"
+            llvm_action_ver: "18.1.7"
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
-            setenvs: export LLVM_VERSION=17.0.6
-                            LLVM_DISTRO_NAME=ubuntu-22.04
-                            LIBTIFF_VERSION=v4.7.0
+            setenvs: export LIBTIFF_VERSION=v4.7.0
                             PTEX_VERSION=v2.4.3
                             PUGIXML_VERSION=v1.15
                             FREETYPE_VERSION=VER-2-13-3
-          - desc: bleeding edge gcc13/C++17 llvm17 oiio/ocio/exr/pybind-main py3.12 avx2 batch-b16avx512
+          - desc: bleeding edge gcc14/C++17 llvm17 oiio/ocio/exr/pybind-main py3.12 avx2 batch-b16avx512
             nametag: linux-bleeding-edge
             runner: ubuntu-24.04
-            cc_compiler: gcc-13
-            cxx_compiler: g++-13
-            cxx_std: 17
+            cc_compiler: gcc-14
+            cxx_compiler: g++-14
+            cxx_std: 20
             fmt_ver: master
             opencolorio_ver: main
             openexr_ver: main

--- a/src/include/OSL/oslconfig.h.in
+++ b/src/include/OSL/oslconfig.h.in
@@ -123,7 +123,11 @@ template<typename Str, typename... Args>
 OSL_NODISCARD inline std::string
 fmtformat(const Str& fmt, Args&&... args)
 {
+#if OSL_CPLUSPLUS_VERSION >= 20 || FMT_VERSION >= 100000
+    return ::fmt::vformat(fmt, ::fmt::make_format_args(args...));
+#else
     return OIIO::Strutil::fmt::format(fmt, std::forward<Args>(args)...);
+#endif
 }
 
 // TODO: notice the fmt argument is not templatised, this is because
@@ -132,13 +136,18 @@ fmtformat(const Str& fmt, Args&&... args)
 // OIIO should fix this if possible.
 template<typename OutIt, typename... Args>
 OSL_NODISCARD inline auto
-fmtformat_to_n(OutIt &out, size_t n, const string_view& fmt, Args&&... args)
+fmtformat_to_n(OutIt& out, size_t n, string_view fmt, Args&&... args)
 {
     // DOES NOT EXIST AS PUBLIC API
     //return OIIO::Strutil::fmt::format_to_n(out, n, fmt, std::forward<Args>(args)...);
     // So call directly into underlying fmt library OIIO is using
     // TODO:  Add format_to_n as a public API in OIIO
+#if OSL_CPLUSPLUS_VERSION >= 20 || FMT_VERSION >= 100000
+    std::string str = fmtformat(fmt, std::forward<Args>(args)...);
+    return ::fmt::format_to_n(out, n, "{}", str);
+#else
     return ::fmt::format_to_n(out, n, ::fmt::string_view{fmt.begin(), fmt.length()}, std::forward<Args>(args)...);
+#endif
 }
 
 

--- a/src/liboslcomp/oslcomp_pvt.h
+++ b/src/liboslcomp/oslcomp_pvt.h
@@ -365,7 +365,8 @@ private:
     template<typename... Args>
     inline void osofmt(const char* fmt, Args&&... args) const
     {
-        fmt::print(*m_osofile, fmt, std::forward<Args>(args)...);
+        *m_osofile << OIIO::Strutil::fmt::format(fmt,
+                                                 std::forward<Args>(args)...);
     }
 
     void track_variable_lifetimes()

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -17,6 +17,11 @@
 #    error "LLVM minimum version required for OSL is 11.0"
 #endif
 
+OSL_PRAGMA_WARNING_PUSH
+#if OSL_GNUC_VERSION >= 140000
+OSL_GCC_PRAGMA(GCC diagnostic ignored "-Wmaybe-uninitialized")
+#endif
+
 #include "llvm_passes.h"
 
 #include <llvm/InitializePasses.h>
@@ -127,6 +132,8 @@
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/SymbolRewriter.h>
+
+OSL_PRAGMA_WARNING_POP
 
 OSL_NAMESPACE_BEGIN
 


### PR DESCRIPTION
We weren't testing against gcc-14 nor against C++20 in our CI test matrix.  Add them.

The fixes required were:

* Had to suppress some warnings gcc-14 complains about in LLVM's headers.

* There were some tricky interactions between C++20 and fmtlib, which is because when being compiled with C++ >= 20, fmt switches to a bunch of tricky runtime checking that has different needs for constexpr and consteval. I had to rearrange some things a bit to make it happy simultaneously with both old and new.

