### PR TITLE
ci: Fix Windows CI with special LLVM pre-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,10 +608,10 @@ jobs:
             openexr_ver: v3.3.2
             openimageio_ver: release
             skip_tests: 1
-            setenvs: export LLVM_VERSION=18.1.8
-                            OSL_CMAKE_FLAGS="-DUSE_LLVM_BTCODE=ON"
+            setenvs: export OSL_CMAKE_FLAGS="-DUSE_LLVM_BTCODE=ON"
                             PUGIXML_VERSION=v1.14
                             OpenImageIO_BUILD_MISSING_DEPS="Freetype;TIFF;libdeflate;libjpeg-turbo"
+                            LLVM_GOOGLE_DRIVE_ID="1uy7PNVlTQ-H56unXGOS6siRWtNcdS1J7"
           - desc: Windows-2025 VS2022
             runner: windows-2025
             nametag: windows-2025
@@ -621,10 +621,10 @@ jobs:
             openexr_ver: v3.3.2
             openimageio_ver: release
             skip_tests: 1
-            setenvs: export LLVM_VERSION=18.1.8
-                            OSL_CMAKE_FLAGS="-DUSE_LLVM_BTCODE=ON"
+            setenvs: export OSL_CMAKE_FLAGS="-DUSE_LLVM_BTCODE=ON"
                             PUGIXML_VERSION=v1.14
                             OpenImageIO_BUILD_MISSING_DEPS="Freetype;TIFF;libdeflate;libjpeg-turbo"
+                            LLVM_GOOGLE_DRIVE_ID="1uy7PNVlTQ-H56unXGOS6siRWtNcdS1J7"
 
 
   optix-gpu:

--- a/src/build-scripts/gh-win-installdeps.bash
+++ b/src/build-scripts/gh-win-installdeps.bash
@@ -122,6 +122,15 @@ ls -R -l "$DEP_DIR"
 
 if [[ "$LLVM_VERSION" != "" ]] ; then
     source src/build-scripts/build_llvm.bash
+elif [[ "$LLVM_GOOGLE_DRIVE_ID" != "" ]] then
+    mkdir -p $HOME/llvm
+    pushd $HOME/llvm
+    #LLVM_GOOGLE_DRIVE_ID="1uy7PNVlTQ-H56unXGOS6siRWtNcdS1J7"
+    LLVM_ZIP_FILENAME=llvm-build.zip
+    time curl -L "https://drive.usercontent.google.com/download?id=${LLVM_GOOGLE_DRIVE_ID}&confirm=xxx" -o $LLVM_ZIP_FILENAME
+    unzip $LLVM_ZIP_FILENAME > /dev/null
+    export LLVM_ROOT=$PWD/llvm-build
+    popd
 fi
 echo "LLVM_ROOT = $LLVM_ROOT"
 


### PR DESCRIPTION
Fixes #2003 

Recap: GHA Windows runners recently upgraded their MSVS to a version whose std headers no longer get along with the LLVM 18 we had been using for CI (which we download from the LLVM project's hosted binary builds). But upgrading to LLVM 19 or 20 didn't help, because all of the LLVM-hosted binaries of those releases were built with the flags selecting the static runtime library, which is different from the dynamic choice that's a more common default and which we used for both our build of OSL and its other dependencies. You can't mix and match. (The reason for this switch is related to their changing to build by default using a certain malloc repacement library, which somehow leads to needing the static runtime.)

To dig us out of this, Chris Kulla was kind enough to build us an LLVM 20.1 from source, using the old dynamic runtime choice, and host that as a zip file on a google drive.

This PR makes use of that as the LLVM we us for our Windows CI jobs, and now we pass CI again.

This doesn't seem like a sustainable long-term solution, because if the LLVM project is changing the default linkage, we don't want to need to maintain separate custom builds just for us, surely we can adapt by changing how compile flags on OSL and all of our dependencies. But at least this gets us unstuck for right now.

Also as a reminder, our OSL Windows CI at the moment just does the build, not a testsuite run. We'll tackle that separately.

