### PR TITLE
deps: Raise minimum supported Python version from 3.7 to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,20 +51,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - desc: gcc9/C++17 llvm11 py3.7 oiio2.5 sse4 batch-b8avx2
-            nametag: linux-vfx2021
-            runner: ubuntu-latest
-            container: aswftesting/ci-osl:2021-clang11
-            vfxyear: 2021
-            old_node: 1
-            cxx_std: 17
-            openexr_ver: v3.1.3
-            openimageio_ver: v2.5.4.0
-            python_ver: 3.7
-            pybind11_ver: v2.7.0
-            simd: sse4.2
-            batched: b8_AVX2_noFMA
-            setenvs: export USE_OPENVDB=0
+          # - desc: gcc9/C++17 llvm11 py3.7 oiio2.5 sse4 batch-b8avx2
+          #   nametag: linux-vfx2021
+          #   runner: ubuntu-latest
+          #   container: aswftesting/ci-osl:2021-clang11
+          #   vfxyear: 2021
+          #   old_node: 1
+          #   cxx_std: 17
+          #   openexr_ver: v3.1.3
+          #   openimageio_ver: v2.5.4.0
+          #   python_ver: 3.7
+          #   pybind11_ver: v2.7.0
+          #   simd: sse4.2
+          #   batched: b8_AVX2_noFMA
+          #   setenvs: export USE_OPENVDB=0
           - desc: gcc9/C++17 llvm13 py3.9 exr3.1 oiio-rel avx2
             nametag: linux-vfx2022
             runner: ubuntu-latest
@@ -104,16 +104,16 @@ jobs:
             pybind11_ver: v2.9.0
             simd: sse2
             batched: b4_SSE2
-          - desc: oldest everything gcc9/C++17 llvm9 py3.7 oiio2.5 no-simd
+          - desc: oldest everything gcc9/C++17 llvm11 py3.9 oiio2.5 no-simd
             nametag: linux-oldest
             runner: ubuntu-latest
-            container: aswftesting/ci-osl:2021-clang11
-            vfxyear: 2021
+            container: aswftesting/ci-osl:2022-clang11
+            vfxyear: 2022
             old_node: 1
             cxx_std: 17
             openexr_ver: v3.1.0
             openimageio_ver: v2.5.4.0
-            python_ver: 3.7
+            python_ver: 3.9
             pybind11_ver: v2.7.0
             # simd: 0
             setenvs: export PUGIXML_VERSION=v1.8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,7 @@ NEW or CHANGED minimum dependencies since the last major release are **bold**.
   be operative.
 * (optional) Python: If you are building the Python bindings or running the
   testsuite:
-    * **Python >= 3.7** (tested through 3.13)
+    * **Python >= 3.9** (tested through 3.13)
     * **pybind11 >= 2.7** (tested through 3.0)
     * NumPy (tested through 2.2.4)
 * (optional) Qt5 >= 5.6 or Qt6 (tested Qt5 through 5.15 and Qt6 through 6.8).

--- a/src/cmake/pythonutils.cmake
+++ b/src/cmake/pythonutils.cmake
@@ -31,7 +31,7 @@ macro (find_python)
     endif ()
     checked_find_package (Python3 ${PYTHON_VERSION}
                           ${_req}
-                          VERSION_MIN 3.7
+                          VERSION_MIN 3.9
                           COMPONENTS Interpreter Development
                           PRINT Python3_VERSION Python3_EXECUTABLE
                                 Python3_LIBRARIES


### PR DESCRIPTION
This also means ceasing testing against VFX Platform 2021, which was the last year that 3.7 was dictated.

This obviously is only for main (future 1.15), and does not affect the current supported release family.

