### PR TITLE
deps: Raise llvm minimum to 14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,24 +51,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - desc: gcc9/C++17 llvm11 py3.7 oiio2.5 sse4 batch-b8avx2
-          #   nametag: linux-vfx2021
-          #   runner: ubuntu-latest
-          #   container: aswftesting/ci-osl:2021-clang11
-          #   vfxyear: 2021
-          #   old_node: 1
-          #   cxx_std: 17
-          #   openexr_ver: v3.1.3
-          #   openimageio_ver: v2.5.4.0
-          #   python_ver: 3.7
-          #   pybind11_ver: v2.7.0
-          #   simd: sse4.2
-          #   batched: b8_AVX2_noFMA
-          #   setenvs: export USE_OPENVDB=0
-          - desc: gcc9/C++17 llvm13 py3.9 exr3.1 oiio-rel avx2
+          - desc: gcc9/C++17 llvm14 py3.9 exr3.1 oiio-rel avx2
             nametag: linux-vfx2022
             runner: ubuntu-latest
-            container: aswftesting/ci-osl:2022-clang13
+            container: aswftesting/ci-osl:2022-clang14
             vfxyear: 2022
             old_node: 1
             cxx_std: 17
@@ -77,10 +63,10 @@ jobs:
             pybind11_ver: v2.9.0
             simd: avx2,f16c
             batched: b8_AVX2
-          - desc: clang12/C++17 llvm12 oiio-main py3.9 avx2 batch-avx512
-            nametag: linux-clang12-llvm12-batch
+          - desc: clang14/C++17 llvm14 oiio-main py3.9 avx2 batch-avx512
+            nametag: linux-clang14-llvm14-batch
             runner: ubuntu-latest
-            container: aswftesting/ci-osl:2022-clang12
+            container: aswftesting/ci-osl:2022-clang14
             vfxyear: 2022
             old_node: 1
             cxx_std: 17
@@ -91,10 +77,10 @@ jobs:
             simd: avx2,f16c
             batched: b8_AVX2,b8_AVX512,b16_AVX512
             setenvs: USE_OPENVDB=0
-          - desc: gcc9/C++17 llvm11 py3.9 exr3.1 oiio3.0 sse2 batch-b4sse2
+          - desc: gcc9/C++17 llvm14 py3.9 exr3.1 oiio3.0 sse2 batch-b4sse2
             nametag: linux-vfx2022-clang
             runner: ubuntu-latest
-            container: aswftesting/ci-osl:2022-clang13
+            container: aswftesting/ci-osl:2022-clang14
             vfxyear: 2022
             old_node: 1
             cxx_std: 17
@@ -104,10 +90,10 @@ jobs:
             pybind11_ver: v2.9.0
             simd: sse2
             batched: b4_SSE2
-          - desc: oldest everything gcc9/C++17 llvm11 py3.9 oiio2.5 no-simd
+          - desc: oldest everything gcc9/C++17 llvm14 py3.9 oiio2.5 no-simd
             nametag: linux-oldest
             runner: ubuntu-latest
-            container: aswftesting/ci-osl:2022-clang11
+            container: aswftesting/ci-osl:2022-clang14
             vfxyear: 2022
             old_node: 1
             cxx_std: 17
@@ -280,7 +266,7 @@ jobs:
             # ^^ exclude python-oslquery test until the ASWF container properly
             #    includes OIIO's python bindings, then we can remove that.
 
-          # Address and leak sanitizers
+          # Address and leak sanitizers (debug build)
           - desc: sanitizers
             nametag: sanitizer
             runner: ubuntu-latest
@@ -386,8 +372,8 @@ jobs:
                             USE_OPENVDB=0
                             OPENCOLORIO_CMAKE_FLAGS="-DCMAKE_CXX_COMPILER=g++"
 
-          - desc: Debug gcc9/C++17 llvm11 py3.10 oiio2.5 exr3.1 sse4
-            nametag: linux-debug-gcc7-llvm11
+          - desc: Debug gcc9/C++17 llvm14 py3.10 oiio2.5 exr3.1 sse4
+            nametag: linux-debug-gcc9-llvm14
             runner: ubuntu-22.04
             cxx_compiler: g++-9
             cxx_std: 17
@@ -397,11 +383,11 @@ jobs:
             python_ver: "3.10"
             simd: sse4.2
             setenvs: export CMAKE_BUILD_TYPE=Debug
-                            LLVM_VERSION=11.0.0 LLVM_DISTRO_NAME=ubuntu-20.04
+                            LLVM_VERSION=14.0.0 LLVM_DISTRO_NAME=ubuntu-18.04
                             PUGIXML_VERSION=v1.9
                             CTEST_TEST_TIMEOUT=240
-          - desc: gcc10/C++17 llvm11 oiio-2.5 avx2
-            nametag: linux-2021ish-gcc10-llvm11
+          - desc: gcc10/C++17 llvm14 oiio-2.5 avx2
+            nametag: linux-2021ish-gcc10-llvm14
             runner: ubuntu-22.04
             cxx_compiler: g++-10
             cxx_std: 17
@@ -411,7 +397,7 @@ jobs:
             pybind11_ver: v2.8.1
             python_ver: "3.10"
             simd: avx2,f16c
-            setenvs: export LLVM_VERSION=11.0.0 LLVM_DISTRO_NAME=ubuntu-20.04
+            setenvs: export LLVM_VERSION=14.0.0 LLVM_DISTRO_NAME=ubuntu-18.04
                             OPENIMAGEIO_CMAKE_FLAGS="-DBUILD_FMT_VERSION=7.0.1"
                             PUGIXML_VERSION=v1.10
           - desc: latest releases gcc11/C++17 llvm17 oiio-3.0 exr3.2 py3.12 avx2 batch-b16avx512

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,17 +19,17 @@ Dependencies
 OSL requires the following dependencies or tools.
 NEW or CHANGED minimum dependencies since the last major release are **bold**.
 
-* Build system: [CMake](https://cmake.org/) **3.19 or newer** (tested
+* Build system: [CMake](https://cmake.org/) 3.19 or newer (tested
   through 4.0)
 
 * A suitable C++17 compiler to build OSL itself, which may be any of:
-   - **GCC 9.3** or newer (tested through gcc 13.1)
-   - **Clang 5** or newer (tested through clang 19)
+   - GCC 9.3 or newer (tested through gcc 13.1)
+   - Clang 5 or newer (tested through clang 20)
    - Microsoft Visual Studio 2017 or newer
-   - Intel C++ compiler **icc version 19** or newer or LLVM-based icx compiler
+   - Intel C++ compiler icc version 19 or newer or LLVM-based icx compiler
      version 2022 or newer.
 
-* **[OpenImageIO](http://openimageio.org) 2.5 or newer** (tested through 3.0
+* [OpenImageIO](http://openimageio.org) 2.5 or newer (tested through 3.0
   and main)
 
     OSL uses OIIO both for its texture mapping functionality as well as
@@ -49,15 +49,15 @@ NEW or CHANGED minimum dependencies since the last major release are **bold**.
     $OpenImageIO_ROOT/lib to be in your LD_LIBRARY_PATH (or
     DYLD_LIBRARY_PATH on OS X).
 
-* [LLVM](http://www.llvm.org) 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, including
-  clang libraries.
+* [LLVM](http://www.llvm.org) **14.0 or newer**, 15, 16, 17, 18, 19, 20,
+  including clang libraries.
 
 * (optional) For GPU rendering on NVIDIA GPUs:
     * [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) 7.0 or higher.
     * [Cuda](https://developer.nvidia.com/cuda-downloads) 9.0 or higher. It is
       recommended that you use 11.0 or higher.
 
-* [Imath](https://github.com/AcademySoftwareFoundation/Imath) **3.1 or newer**.
+* [Imath](https://github.com/AcademySoftwareFoundation/Imath) 3.1 or newer.
 * [Flex](https://github.com/westes/flex) 2.5.35 or newer and
   [GNU Bison](https://www.gnu.org/software/bison/) 2.7 or newer.
   Note that on some MacOS/xcode releases, the system-installed Bison is too
@@ -70,7 +70,7 @@ NEW or CHANGED minimum dependencies since the last major release are **bold**.
 * (optional) Python: If you are building the Python bindings or running the
   testsuite:
     * **Python >= 3.9** (tested through 3.13)
-    * **pybind11 >= 2.7** (tested through 3.0)
+    * pybind11 >= 2.7 (tested through 3.0)
     * NumPy (tested through 2.2.4)
 * (optional) Qt5 >= 5.6 or Qt6 (tested Qt5 through 5.15 and Qt6 through 6.8).
   If not found at build time, the `osltoy` application will be disabled.

--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ help:
 	@echo "  Finding and Using Dependencies:"
 	@echo "      USE_QT=0                 Skip anything that needs Qt"
 	@echo "  LLVM-related options:"
-	@echo "      LLVM_VERSION=12.0        Specify which LLVM version to use"
+	@echo "      LLVM_VERSION=19.0        Specify which LLVM version to use"
 	@echo "      LLVM_DIRECTORY=xx        Specify where LLVM lives"
 	@echo "      LLVM_NAMESPACE=xx        Specify custom LLVM namespace"
 	@echo "      LLVM_STATIC=1            Use static LLVM libraries"

--- a/src/cmake/cuda_macros.cmake
+++ b/src/cmake/cuda_macros.cmake
@@ -134,12 +134,6 @@ function ( MAKE_CUDA_BITCODE src suffix generated_bc extra_clang_args )
         set (CLANG_MSVC_FIX -Wno-ignored-attributes -Wno-unknown-attributes)
     endif ()
 
-    if (NOT LLVM_OPAQUE_POINTERS AND ${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
-        # Until we fully support opaque pointers, we need to disable
-        # them when using LLVM 15.
-        list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)
-    endif ()
-
     if (NOT CUDA_NO_FTZ)
         set (CLANG_FTZ_FLAG "-fcuda-flush-denormals-to-zero")
     endif ()
@@ -221,14 +215,10 @@ function ( CUDA_SHADEOPS_COMPILE prefix output_bc output_ptx input_srcs headers 
         list ( APPEND shadeops_bc_list ${shadeops_bc} )
     endforeach ()
 
-    if (LLVM_NEW_PASS_MANAGER)
-      # There is no --nvptx-assign-valid-global-names flag for the new
-      # pass manager, but it appears to run this pass by default.
-      string(REPLACE "-O" "O" opt_tool_flags ${CUDA_OPT_FLAG_CLANG})
-      set (opt_tool_flags -passes="default<${opt_tool_flags}>")
-    else()
-      set (opt_tool_flags ${CUDA_OPT_FLAG_CLANG} --nvptx-assign-valid-global-names)
-    endif ()
+    # There is no --nvptx-assign-valid-global-names flag for the new
+    # pass manager, but it appears to run this pass by default.
+    string(REPLACE "-O" "O" opt_tool_flags ${CUDA_OPT_FLAG_CLANG})
+    set (opt_tool_flags -passes="default<${opt_tool_flags}>")
 
     # Link all of the individual LLVM bitcode files, and emit PTX for the linked bitcode
     add_custom_command ( OUTPUT ${linked_bc} ${linked_ptx}

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -57,7 +57,7 @@ checked_find_package (pugixml REQUIRED
 
 # LLVM library setup
 checked_find_package (LLVM REQUIRED
-                      VERSION_MIN 11.0
+                      VERSION_MIN 14.0
                       VERSION_MAX 20.9
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES
                             LLVM_SHARED_MODE)
@@ -79,36 +79,7 @@ if (LLVM_VERSION VERSION_GREATER_EQUAL 15.0 AND CMAKE_COMPILER_IS_CLANG
          "If you are using LLVM 15 or higher, you should also use clang version "
          "15 or higher, or you may get build errors.${ColorReset}\n")
 endif ()
-if (LLVM_VERSION VERSION_GREATER_EQUAL 16.0)
-    if (CMAKE_CXX_STANDARD VERSION_LESS 17)
-        message (WARNING "${ColorYellow}LLVM 16+ requires C++17 or higher. "
-            "Please set CMAKE_CXX_STANDARD to 17 or higher.${ColorReset}\n")
-    endif ()
-    if (CMAKE_COMPILER_IS_GNUCC AND (GCC_VERSION VERSION_LESS 7.0))
-        message (WARNING "${ColorYellow}LLVM 16+ requires gcc 7.0 or higher.${ColorReset}\n")
-    endif ()
-    if (CMAKE_COMPILER_IS_CLANG
-        AND NOT (CLANG_VERSION_STRING VERSION_GREATER_EQUAL 5.0
-                 OR APPLECLANG_VERSION_STRING VERSION_GREATER_EQUAL 5.0))
-        message (WARNING "${ColorYellow}LLVM 16+ requires clang 5.0 or higher.${ColorReset}\n")
-    endif ()
-endif ()
 
-# Use opaque pointers starting with LLVM 16
-if (${LLVM_VERSION} VERSION_GREATER_EQUAL 16.0)
-  set(LLVM_OPAQUE_POINTERS ON)
-  add_compile_definitions (OSL_LLVM_OPAQUE_POINTERS)
-else()
-  set(LLVM_OPAQUE_POINTERS OFF)
-endif()
-
-# Enable new pass manager for LLVM 16+
-if (${LLVM_VERSION} VERSION_GREATER_EQUAL 16.0)
-  set(LLVM_NEW_PASS_MANAGER ON)
-  add_compile_definitions (OSL_LLVM_NEW_PASS_MANAGER)
-else()
-  set(LLVM_NEW_PASS_MANAGER OFF)
-endif()
 
 
 checked_find_package (partio)

--- a/src/cmake/llvm_macros.cmake
+++ b/src/cmake/llvm_macros.cmake
@@ -74,12 +74,6 @@ function ( EMBED_LLVM_BITCODE_IN_CPP src_list suffix output_name list_to_append_
         list (TRANSFORM include_dirs PREPEND -I
             OUTPUT_VARIABLE ALL_INCLUDE_DIRS)
 
-        if (NOT LLVM_OPAQUE_POINTERS AND ${LLVM_VERSION} VERSION_GREATER_EQUAL 15.0)
-            # Until we fully support opaque pointers, we need to disable
-            # them when using LLVM 15.
-            list (APPEND LLVM_COMPILE_FLAGS -Xclang -no-opaque-pointers)
-        endif ()
-
         # Command to turn the .cpp file into LLVM assembly language .s, into
         # LLVM bitcode .bc, then back into a C++ file with the bc embedded!
         add_custom_command ( OUTPUT ${src_bc}

--- a/src/include/OSL/llvm_util.h
+++ b/src/include/OSL/llvm_util.h
@@ -1240,7 +1240,6 @@ private:
     llvm::Value* op_combine_4x_vectors(llvm::Value* half_vec_1,
                                        llvm::Value* half_vec_2);
 
-    void setup_legacy_optimization_passes(int optlevel, bool target_host);
     void setup_new_optimization_passes(int optlevel, bool target_host);
 };
 

--- a/src/liboslexec/batched_backendllvm.cpp
+++ b/src/liboslexec/batched_backendllvm.cpp
@@ -1304,25 +1304,6 @@ BatchedBackendLLVM::llvm_store_value(llvm::Value* new_val, llvm::Value* dst_ptr,
         if (!type.is_closure_based() && t.aggregate > 1)
             dst_ptr = ll.GEP(dst_type, dst_ptr, 0, component);
 
-#ifndef OSL_LLVM_OPAQUE_POINTERS
-        if ((const llvm::Type*)ll.type_ptr(ll.llvm_typeof(new_val))
-            != ll.llvm_typeof(dst_ptr)) {
-            std::cerr << " new_val type=";
-            {
-                llvm::raw_os_ostream os_cerr(std::cerr);
-                ll.llvm_typeof(new_val)->print(os_cerr);
-            }
-            std::cerr << " dest_ptr type=";
-            {
-                llvm::raw_os_ostream os_cerr(std::cerr);
-                ll.llvm_typeof(dst_ptr)->print(os_cerr);
-            }
-            std::cerr << std::endl;
-        }
-        OSL_ASSERT((const llvm::Type*)ll.type_ptr(ll.llvm_typeof(new_val))
-                   == ll.llvm_typeof(dst_ptr));
-#endif
-
         // Finally, store the value.
         ll.op_store(new_val, dst_ptr);
         return true;

--- a/src/liboslexec/batched_llvm_gen.cpp
+++ b/src/liboslexec/batched_llvm_gen.cpp
@@ -1056,18 +1056,6 @@ LLVMGEN(llvm_gen_andor)
     // sometimes we could not force the data type to be an bool and it remains
     // an int, for those cases we will need to convert the boolean to int
     if (!result.forced_llvm_bool()) {
-#ifndef OSL_LLVM_OPAQUE_POINTERS
-        llvm::Type* resultType = rop.ll.llvm_typeof(
-            rop.llvm_get_pointer(result));
-        OSL_ASSERT(
-            (resultType
-             == reinterpret_cast<llvm::Type*>(rop.ll.type_wide_int_ptr()))
-            || (resultType
-                == reinterpret_cast<llvm::Type*>(rop.ll.type_int_ptr())));
-        llvm::Type* typeOfR = rop.ll.llvm_typeof(i1_res);
-        OSL_ASSERT(typeOfR == rop.ll.type_wide_bool()
-                   || typeOfR == rop.ll.type_bool());
-#endif
         i1_res = rop.ll.op_bool_to_int(i1_res);
     }
 
@@ -2170,15 +2158,6 @@ LLVMGEN(llvm_gen_bitwise_binary_op)
     // We allowed boolean values to pass through or,and,xor
     // so we might need to promote to integer before storage
     if (!Result.forced_llvm_bool()) {
-#ifndef OSL_LLVM_OPAQUE_POINTERS
-        llvm::Type* resultType = rop.ll.llvm_typeof(
-            rop.llvm_get_pointer(Result));
-        OSL_ASSERT(
-            (resultType
-             == reinterpret_cast<llvm::Type*>(rop.ll.type_wide_int_ptr()))
-            || (resultType
-                == reinterpret_cast<llvm::Type*>(rop.ll.type_int_ptr())));
-#endif
         llvm::Type* typeOfR = rop.ll.llvm_typeof(r);
         if (typeOfR == rop.ll.type_wide_bool()
             || typeOfR == rop.ll.type_bool()) {
@@ -3075,15 +3054,6 @@ LLVMGEN(llvm_gen_compare_op)
             final_result = rop.ll.llvm_mask_to_native(final_result);
         }
     } else {
-#ifndef OSL_LLVM_OPAQUE_POINTERS
-        llvm::Type* resultType = rop.ll.llvm_typeof(
-            rop.llvm_get_pointer(Result));
-        OSL_ASSERT(
-            (resultType
-             == reinterpret_cast<llvm::Type*>(rop.ll.type_wide_int_ptr()))
-            || (resultType
-                == reinterpret_cast<llvm::Type*>(rop.ll.type_int_ptr())));
-#endif
         final_result = rop.ll.op_bool_to_int(final_result);
     }
 


### PR DESCRIPTION
Drop support for llvm 11, 12, 13.

Simplify lots of conditional compilation.

With 14 as the minimum, the new pass manager and opaque pointers are both supported, so we are able to get rid of all code related to support of the legacy pass manager, as well as typed pointers. This is a lot of removed code!

When updating INSTALL.md, I noticed that we still had **bold** for "new minimum dependencies" left over from when we first released 1.14. So I'm unbolding them now, except for the ones we actually have changed for 1.15.

I had originally intended to pull the minimum to 15, but actually that makes it more difficult to continue CI testing vs VFX Platform 2022, since the ASWF-docker container for 2022 only support up to LLVM 14. And simultaneously, once I removed the code for legacy PM and typed pointers, there was, in comparison, only a small amount of additional simplification we could squeeze out of moving the minimum to llvm 15. So for OSL 1.15, we will have a minimum llvm 14, and then for OSL 1.16 when we would feel more comfortable droping all VFX Platform 2022 support and move to the 2023 containers as our oldest testing environment, we can bump to llvm 15.

Closes #2013 
