### PR TITLE
ci: Adjust comparison threshold for render-microfacet test

### DIFF
--- a/testsuite/render-microfacet/run.py
+++ b/testsuite/render-microfacet/run.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
-failthresh = 0.02
-failrelative = 0.01
+failthresh = 0.04
+failrelative = 0.03
 failpercent = 1
 allowfailures = 5
 idiff_program = "idiff"


### PR DESCRIPTION
Something must have changed on the GHA runners? Or a compiler version? On one test job, we started failing this one test, the noise pattern changed a few days ago, independently of any change to OSL repo.

Bumping up the comparison thresholds slightly appears to do the trick.
