### PR TITLE
[testrender] Fix named camera spaces

### DIFF
--- a/src/testrender/cuda/optix_raytracer.cu
+++ b/src/testrender/cuda/optix_raytracer.cu
@@ -245,6 +245,10 @@ __raygen__setglobals()
         OSL::pvt::test_str_2            = render_params.test_str_2;
     }
 
+    OSL::pvt::num_named_xforms  = render_params.num_named_xforms;
+    OSL::pvt::xform_name_buffer = render_params.xform_name_buffer;
+    OSL::pvt::xform_buffer      = render_params.xform_buffer;
+
     if (render_params.bg_id < 0)
         return;
 

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -1097,7 +1097,7 @@ OptixRaytracer::render(int xres OSL_MAYBE_UNUSED, int yres OSL_MAYBE_UNUSED)
     params.num_named_xforms  = nxforms;
     params.xform_name_buffer = DEVICE_ALLOC(sizeof(ustringhash) * nxforms);
     params.xform_buffer      = DEVICE_ALLOC(sizeof(Transformation) * nxforms);
-    
+
     std::vector<ustringhash> names;
     std::vector<Transformation> xforms;
     names.reserve(nxforms);

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -1103,15 +1103,15 @@ OptixRaytracer::render(int xres OSL_MAYBE_UNUSED, int yres OSL_MAYBE_UNUSED)
     names.reserve(nxforms);
     xforms.reserve(nxforms);
 
-    for (auto &pair : m_named_xforms) {
+    for (auto& pair : m_named_xforms) {
         names.push_back(pair.first);
         xforms.push_back(*pair.second);
     }
 
     COPY_TO_DEVICE(params.xform_name_buffer, names.data(),
-                   sizeof(ustringhash)*nxforms);
+                   sizeof(ustringhash) * nxforms);
     COPY_TO_DEVICE(params.xform_buffer, xforms.data(),
-                   sizeof(Transformation)*nxforms);
+                   sizeof(Transformation) * nxforms);
     CUDA_SYNC_CHECK();
 
     // Mesh data

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -115,7 +115,7 @@ OptixRaytracer::OptixRaytracer()
     CUDA_CHECK(cudaSetDevice(0));
     CUDA_CHECK(cudaStreamCreate(&m_cuda_stream));
 
-	cache = OIIO::ImageCache::create ();
+    cache = OIIO::ImageCache::create ();
 }
 
 
@@ -1095,24 +1095,25 @@ OptixRaytracer::render(int xres OSL_MAYBE_UNUSED, int yres OSL_MAYBE_UNUSED)
     params.test_str_2            = test_str_2;
 
     // Named transforms
-    int nxforms = m_named_xforms.size();
+    int nxforms              = m_named_xforms.size();
     params.num_named_xforms  = nxforms;
-    params.xform_name_buffer = DEVICE_ALLOC(sizeof(ustringhash)*nxforms);
-    params.xform_buffer      = DEVICE_ALLOC(sizeof(Transformation)*nxforms);
+    params.xform_name_buffer = DEVICE_ALLOC(sizeof(ustringhash) * nxforms);
+    params.xform_buffer      = DEVICE_ALLOC(sizeof(Transformation) * nxforms);
     
     std::vector<ustringhash> names;
     std::vector<Transformation> xforms;
     names.reserve(nxforms);
     xforms.reserve(nxforms);
 
-    for (auto &pair : m_named_xforms)
-    {
+    for (auto &pair : m_named_xforms) {
         names.push_back(pair.first);
         xforms.push_back(*pair.second);
     }
 
-    COPY_TO_DEVICE(params.xform_name_buffer, names.data(), sizeof(ustringhash)*nxforms);
-    COPY_TO_DEVICE(params.xform_buffer, xforms.data(), sizeof(Transformation)*nxforms);
+    COPY_TO_DEVICE(params.xform_name_buffer, names.data(),
+                   sizeof(ustringhash)*nxforms);
+    COPY_TO_DEVICE(params.xform_buffer, xforms.data(),
+                   sizeof(Transformation)*nxforms);
     CUDA_SYNC_CHECK();
 
     // Mesh data

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -114,6 +114,8 @@ OptixRaytracer::OptixRaytracer()
 
     CUDA_CHECK(cudaSetDevice(0));
     CUDA_CHECK(cudaStreamCreate(&m_cuda_stream));
+
+	cache = OIIO::ImageCache::create ();
 }
 
 
@@ -930,7 +932,7 @@ OptixRaytracer::get_texture_handle(ustring filename,
     auto itr = m_samplers.find(filename);
     if (itr == m_samplers.end()) {
         // Open image to check the number of mip levels
-        OIIO::ImageBuf image;
+        OIIO::ImageBuf image(filename, 0, 0, cache);
         if (!image.init_spec(filename, 0, 0)) {
             errhandler().errorfmt("Could not load: {} (hash {})", filename,
                                   filename);
@@ -1091,6 +1093,27 @@ OptixRaytracer::render(int xres OSL_MAYBE_UNUSED, int yres OSL_MAYBE_UNUSED)
     params.color_system          = d_color_system;
     params.test_str_1            = test_str_1;
     params.test_str_2            = test_str_2;
+
+    // Named transforms
+    int nxforms = m_named_xforms.size();
+    params.num_named_xforms  = nxforms;
+    params.xform_name_buffer = DEVICE_ALLOC(sizeof(ustringhash)*nxforms);
+    params.xform_buffer      = DEVICE_ALLOC(sizeof(Transformation)*nxforms);
+    
+    std::vector<ustringhash> names;
+    std::vector<Transformation> xforms;
+    names.reserve(nxforms);
+    xforms.reserve(nxforms);
+
+    for (auto &pair : m_named_xforms)
+    {
+        names.push_back(pair.first);
+        xforms.push_back(*pair.second);
+    }
+
+    COPY_TO_DEVICE(params.xform_name_buffer, names.data(), sizeof(ustringhash)*nxforms);
+    COPY_TO_DEVICE(params.xform_buffer, xforms.data(), sizeof(Transformation)*nxforms);
+    CUDA_SYNC_CHECK();
 
     // Mesh data
     params.verts           = d_vertices;

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -114,8 +114,6 @@ OptixRaytracer::OptixRaytracer()
 
     CUDA_CHECK(cudaSetDevice(0));
     CUDA_CHECK(cudaStreamCreate(&m_cuda_stream));
-
-    cache = OIIO::ImageCache::create ();
 }
 
 
@@ -932,7 +930,7 @@ OptixRaytracer::get_texture_handle(ustring filename,
     auto itr = m_samplers.find(filename);
     if (itr == m_samplers.end()) {
         // Open image to check the number of mip levels
-        OIIO::ImageBuf image(filename, 0, 0, cache);
+        OIIO::ImageBuf image;
         if (!image.init_spec(filename, 0, 0)) {
             errhandler().errorfmt("Could not load: {} (hash {})", filename,
                                   filename);

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include <OpenImageIO/ustring.h>
 #include <OpenImageIO/imagecache.h>
+#include <OpenImageIO/ustring.h>
+
 
 #include <OSL/oslexec.h>
 

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <OpenImageIO/ustring.h>
+#include <OpenImageIO/imagecache.h>
 
 #include <OSL/oslexec.h>
 
@@ -144,6 +145,8 @@ private:
     // CUdeviceptrs that need to be freed after we are done
     std::vector<CUdeviceptr> m_ptrs_to_free;
     std::vector<cudaArray_t> m_arrays_to_free;
+
+    std::shared_ptr<OIIO::ImageCache> cache;
 };
 
 

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -4,9 +4,7 @@
 
 #pragma once
 
-#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/ustring.h>
-
 
 #include <OSL/oslexec.h>
 
@@ -146,8 +144,6 @@ private:
     // CUdeviceptrs that need to be freed after we are done
     std::vector<CUdeviceptr> m_ptrs_to_free;
     std::vector<cudaArray_t> m_arrays_to_free;
-
-    std::shared_ptr<OIIO::ImageCache> cache;
 };
 
 

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -136,8 +136,8 @@ struct Camera {
         float k    = OIIO::fast_tan(fov * float(M_PI / 360));
         Vec3 right = dir.cross(up).normalize();
         // fov is horizontal
-        cx         = right * k;
-        cy         = (cx.cross(dir)).normalize() * k * yres / xres;
+        cx = right * k;
+        cy = (cx.cross(dir)).normalize() * k * yres / xres;
     }
 
     // Get a ray for the given screen coordinates.
@@ -148,7 +148,8 @@ struct Camera {
         // components with magnitudes slightly greater than 1.0, which can cause
         // downstream computations to blow up and produce NaNs. Normalizing the
         // vector again avoids this issue.
-        const Vec3 v = (cx * (x * invw - 0.5f) * 2.f + cy * (0.5f - y * invh) * 2.f + dir)
+        const Vec3 v = (cx * (x * invw - 0.5f) * 2.f
+                        + cy * (0.5f - y * invh) * 2.f + dir)
 #ifndef __CUDACC__
                            .normalize();
 #else

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -135,8 +135,9 @@ struct Camera {
     {
         float k    = OIIO::fast_tan(fov * float(M_PI / 360));
         Vec3 right = dir.cross(up).normalize();
-        cx         = right * (xres * k / yres);
-        cy         = (cx.cross(dir)).normalize() * k;
+        // fov is horizontal
+        cx         = right * k;
+        cy         = (cx.cross(dir)).normalize() * k * yres / xres;
     }
 
     // Get a ray for the given screen coordinates.
@@ -147,7 +148,7 @@ struct Camera {
         // components with magnitudes slightly greater than 1.0, which can cause
         // downstream computations to blow up and produce NaNs. Normalizing the
         // vector again avoids this issue.
-        const Vec3 v = (cx * (x * invw - 0.5f) + cy * (0.5f - y * invh) + dir)
+        const Vec3 v = (cx * (x * invw - 0.5f) * 2.f + cy * (0.5f - y * invh) * 2.f + dir)
 #ifndef __CUDACC__
                            .normalize();
 #else

--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -518,49 +518,51 @@ SimpleRaytracer::prepare_camera_spaces()
     Vec3 right = camera.cx.normalized();
     Vec3 up    = camera.cy.normalized();
 
-    Matrix44 camera_to_world = {right.x,      right.y,      right.z,      0,
-                                up.x,         up.y,         up.z,         0,
-                                camera.dir.x, camera.dir.y, camera.dir.z, 0,
-                                camera.eye.x, camera.eye.y, camera.eye.z, 1};
+    Matrix44 camera_to_world = { right.x,      right.y,      right.z,      0,
+                                 up.x,         up.y,         up.z,         0,
+                                 camera.dir.x, camera.dir.y, camera.dir.z, 0,
+                                 camera.eye.x, camera.eye.y, camera.eye.z, 1 };
 
-    name_transform("camera", camera_to_world );
+    name_transform("camera", camera_to_world);
 
     // Seems never used once moved to named transforms
     m_world_to_camera = camera_to_world.inverse();
-    Matrix44 M = m_world_to_camera;
-    float depthrange = (double)m_yon-(double)m_hither;
+    Matrix44 M        = m_world_to_camera;
+    float depthrange  = (double)m_yon - (double)m_hither;
+    // clang-format off
     if (m_projection == RS::Hashes::perspective) {
         float tanhalffov = tanf (0.5f * m_fov * M_PI/180.0);
-        Matrix44 camera_to_screen (1/tanhalffov, 0, 0, 0,
+        Matrix44 camera_to_screen ( 1/tanhalffov, 0, 0, 0,
                                     0, 1/tanhalffov, 0, 0,
                                     0, 0, m_yon/depthrange, 1,
                                     0, 0, -m_yon*m_hither/depthrange, 0);
         M = M * camera_to_screen;
     } else {
-        Matrix44 camera_to_screen (1, 0, 0, 0,
+        Matrix44 camera_to_screen ( 1, 0, 0, 0,
                                     0, 1, 0, 0,
                                     0, 0, 1/depthrange, 0,
                                     0, 0, -m_hither/depthrange, 1);
         M = M * camera_to_screen;
     }
-    name_transform("screen", M.inverse() );
+    name_transform("screen", M.inverse());
 
-    float aspect = (float)camera.yres / (float)camera.xres;
+    float aspect     = (float)camera.yres / (float)camera.xres;
     float screenleft = -1.0, screenwidth = 2.0;
-    float screenbottom = -1.0*aspect, screenheight = 2.0*aspect;
+    float screenbottom = -1.0 * aspect, screenheight = 2.0 * aspect;
     Matrix44 screen_to_ndc (1/screenwidth, 0, 0, 0,
                             0, 1/screenheight, 0, 0,
                             0, 0, 1, 0,
                             -screenleft/screenwidth, -screenbottom/screenheight, 0, 1);
     M = M * screen_to_ndc;
-    name_transform("NDC", M.inverse() );
+    name_transform("NDC", M.inverse());
 
     Matrix44 ndc_to_raster (camera.xres, 0, 0, 0,
                             0, camera.yres, 0, 0,
                             0, 0, 1, 0,
                             0, 0, 0, 1);
     M = M * ndc_to_raster;
-    name_transform("raster", M.inverse() );
+    name_transform("raster", M.inverse());
+    // clang-format on
 }
 
 

--- a/src/testrender/simpleraytracer.cpp
+++ b/src/testrender/simpleraytracer.cpp
@@ -332,6 +332,7 @@ SimpleRaytracer::parse_scene_xml(const std::string& scenefile)
             if (fov_attr)
                 fov = OIIO::Strutil::from_string<float>(fov_attr.value());
 
+            m_fov = fov;
             camera.lookat(eye, dir, up, fov);
         } else if (strcmp(node.name(), "Sphere") == 0) {
             // load sphere
@@ -506,6 +507,60 @@ SimpleRaytracer::parse_scene_xml(const std::string& scenefile)
     if (scene.num_prims() == 0)
         errhandler().severefmt("No primitives in scene");
     camera.finalize();
+    prepare_camera_spaces();
+}
+
+
+
+void
+SimpleRaytracer::prepare_camera_spaces()
+{
+    Vec3 right = camera.cx.normalized();
+    Vec3 up    = camera.cy.normalized();
+
+    Matrix44 camera_to_world = {right.x,      right.y,      right.z,      0,
+                                up.x,         up.y,         up.z,         0,
+                                camera.dir.x, camera.dir.y, camera.dir.z, 0,
+                                camera.eye.x, camera.eye.y, camera.eye.z, 1};
+
+    name_transform("camera", camera_to_world );
+
+    // Seems never used once moved to named transforms
+    m_world_to_camera = camera_to_world.inverse();
+    Matrix44 M = m_world_to_camera;
+    float depthrange = (double)m_yon-(double)m_hither;
+    if (m_projection == RS::Hashes::perspective) {
+        float tanhalffov = tanf (0.5f * m_fov * M_PI/180.0);
+        Matrix44 camera_to_screen (1/tanhalffov, 0, 0, 0,
+                                    0, 1/tanhalffov, 0, 0,
+                                    0, 0, m_yon/depthrange, 1,
+                                    0, 0, -m_yon*m_hither/depthrange, 0);
+        M = M * camera_to_screen;
+    } else {
+        Matrix44 camera_to_screen (1, 0, 0, 0,
+                                    0, 1, 0, 0,
+                                    0, 0, 1/depthrange, 0,
+                                    0, 0, -m_hither/depthrange, 1);
+        M = M * camera_to_screen;
+    }
+    name_transform("screen", M.inverse() );
+
+    float aspect = (float)camera.yres / (float)camera.xres;
+    float screenleft = -1.0, screenwidth = 2.0;
+    float screenbottom = -1.0*aspect, screenheight = 2.0*aspect;
+    Matrix44 screen_to_ndc (1/screenwidth, 0, 0, 0,
+                            0, 1/screenheight, 0, 0,
+                            0, 0, 1, 0,
+                            -screenleft/screenwidth, -screenbottom/screenheight, 0, 1);
+    M = M * screen_to_ndc;
+    name_transform("NDC", M.inverse() );
+
+    Matrix44 ndc_to_raster (camera.xres, 0, 0, 0,
+                            0, camera.yres, 0, 0,
+                            0, 0, 1, 0,
+                            0, 0, 0, 1);
+    M = M * ndc_to_raster;
+    name_transform("raster", M.inverse() );
 }
 
 
@@ -577,48 +632,6 @@ bool
 SimpleRaytracer::get_inverse_matrix(ShaderGlobals* /*sg*/, Matrix44& result,
                                     ustringhash to, float /*time*/)
 {
-    if (to == OSL::Hashes::camera || to == OSL::Hashes::screen
-        || to == OSL::Hashes::NDC || to == RS::Hashes::raster) {
-        // clang-format off
-        Matrix44 M = m_world_to_camera;
-        if (to == OSL::Hashes::screen || to == OSL::Hashes::NDC || to == RS::Hashes::raster) {
-            float depthrange = (double)m_yon-(double)m_hither;
-            if (m_projection == RS::Hashes::perspective) {
-                float tanhalffov = tanf (0.5f * m_fov * M_PI/180.0);
-                Matrix44 camera_to_screen (1/tanhalffov, 0, 0, 0,
-                                           0, 1/tanhalffov, 0, 0,
-                                           0, 0, m_yon/depthrange, 1,
-                                           0, 0, -m_yon*m_hither/depthrange, 0);
-                M = M * camera_to_screen;
-            } else {
-                Matrix44 camera_to_screen (1, 0, 0, 0,
-                                           0, 1, 0, 0,
-                                           0, 0, 1/depthrange, 0,
-                                           0, 0, -m_hither/depthrange, 1);
-                M = M * camera_to_screen;
-            }
-            if (to == OSL::Hashes::NDC || to == RS::Hashes::raster) {
-                float screenleft = -1.0, screenwidth = 2.0;
-                float screenbottom = -1.0, screenheight = 2.0;
-                Matrix44 screen_to_ndc (1/screenwidth, 0, 0, 0,
-                                        0, 1/screenheight, 0, 0,
-                                        0, 0, 1, 0,
-                                        -screenleft/screenwidth, -screenbottom/screenheight, 0, 1);
-                M = M * screen_to_ndc;
-                if (to == RS::Hashes::raster) {
-                    Matrix44 ndc_to_raster (camera.xres, 0, 0, 0,
-                                            0, camera.yres, 0, 0,
-                                            0, 0, 1, 0,
-                                            0, 0, 0, 1);
-                    M = M * ndc_to_raster;
-                }
-            }
-        }
-        // clang-format on
-        result = M;
-        return true;
-    }
-
     TransformMap::const_iterator found = m_named_xforms.find(to);
     if (found != m_named_xforms.end()) {
         result = *(found->second);

--- a/src/testrender/simpleraytracer.h
+++ b/src/testrender/simpleraytracer.h
@@ -85,6 +85,7 @@ public:
                                float yon, int xres, int yres);
 
     virtual void parse_scene_xml(const std::string& scenefile);
+    virtual void prepare_camera_spaces();
     virtual void prepare_render();
     void prepare_lights();
     void prepare_geometry();
@@ -113,7 +114,7 @@ public:
     int getBackgroundShaderID() const { return backgroundShaderID; }
     int getBackgroundResolution() const { return backgroundResolution; }
 
-private:
+protected:
     // Camera parameters
     Matrix44 m_world_to_camera;
     ustringhash m_projection;
@@ -121,6 +122,11 @@ private:
     float m_shutter[2];
     float m_screen_window[4];
 
+    // Named transforms
+    typedef std::map<ustringhash, std::shared_ptr<Transformation>> TransformMap;
+    TransformMap m_named_xforms;
+
+private:
     int backgroundShaderID   = -1;
     int backgroundResolution = 1024;
     int aa                   = 1;
@@ -139,10 +145,6 @@ private:
     class ErrorHandler;  // subclass ErrorHandler for SimpleRaytracer
     std::unique_ptr<OIIO::ErrorHandler> m_errhandler;
     bool m_had_error = false;
-
-    // Named transforms
-    typedef std::map<ustringhash, std::shared_ptr<Transformation>> TransformMap;
-    TransformMap m_named_xforms;
 
     // Attribute and userdata retrieval -- for fast dispatch, use a hash
     // table to map attribute names to functions that retrieve them. We

--- a/testsuite/render-background/scene.xml
+++ b/testsuite/render-background/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 100, 300" look_at="0,0,0" fov="70" />
+   <Camera eye="0, 100, 300" look_at="0,0,0" fov="50.0468" />
 
    <ShaderGroup>
      string filename "../common/textures/kitchen_probe.hdr";

--- a/testsuite/render-bumptest/bumptest.xml
+++ b/testsuite/render-bumptest/bumptest.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 100, 300" look_at="0,0,0" fov="70" />
+   <Camera eye="0, 100, 300" look_at="0,0,0" fov="38.5907" />
    <Option max_bounces="int 10" />
    <ShaderGroup>shader metal layer1;</ShaderGroup>
    <Quad corner="-2000,0,0" edge_x="0,0,4000" edge_y="4000,0,0" /> <!-- Botm -->

--- a/testsuite/render-bunny/bunny.xml
+++ b/testsuite/render-bunny/bunny.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 1.5, 25" dir="0,0,-1" fov="14.5" />
+   <Camera eye="0, 1.5, 25" dir="0,0,-1" fov="7.27914" />
 
    <ShaderGroup>color Cs 0.35 0.35 0.35; shader matte layer1;</ShaderGroup>
    <Model filename="data/bunny.obj" /> <!-- Grey -->

--- a/testsuite/render-cornell/cornell.xml
+++ b/testsuite/render-cornell/cornell.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="50, 50, 300" dir="0,0,-1" fov="60" />
+   <Camera eye="50, 50, 300" dir="0,0,-1" fov="32.2042" />
    
    <ShaderGroup>color Cs 0.75 0.25 0.25; shader matte layer1;</ShaderGroup>
    <Quad corner="0, 0, 0" edge_x="0,100,0" edge_y="0,0,150" /> <!-- Left -->

--- a/testsuite/render-displacement/scene.xml
+++ b/testsuite/render-displacement/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 1.5, 25" dir="0,0,-1" fov="14.5" />
+   <Camera eye="0, 1.5, 25" dir="0,0,-1" fov="7.27914" />
 
    <ShaderGroup name="main">color Cs 0.35 0.35 0.35; shader matte layer1;</ShaderGroup>
    <ShaderGroup name="main" type="displacement"> 

--- a/testsuite/render-furnace-diffuse/scene.xml
+++ b/testsuite/render-furnace-diffuse/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 100, 300" look_at="0,0,0" fov="70" />
+   <Camera eye="0, 100, 300" look_at="0,0,0" fov="50.0468" />
 
    <ShaderGroup>float Kb 0.5; shader furnace layer1;</ShaderGroup>
    <Background />

--- a/testsuite/render-microfacet/scene.xml
+++ b/testsuite/render-microfacet/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 100, 300" look_at="0,0,0" fov="70" />
+   <Camera eye="0, 100, 300" look_at="0,0,0" fov="50.0468" />
 
    <ShaderGroup>
       string filename "../common/textures/kitchen_probe.hdr";

--- a/testsuite/render-mx-anisotropic-vdf/scene.xml
+++ b/testsuite/render-mx-anisotropic-vdf/scene.xml
@@ -1,5 +1,5 @@
 <World>
-    <Camera eye="0, 1, 80" look_at="0,1,0" fov="14.0" />
+    <Camera eye="0, 1, 80" look_at="0,1,0" fov="7.02622" />
 
     <!-- Environment light -->
     <ShaderGroup is_light="yes">

--- a/testsuite/render-mx-burley-diffuse/scene.xml
+++ b/testsuite/render-mx-burley-diffuse/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="30" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20.2562" />
    <Option max_bounces="int 5" />
 
    <ShaderGroup>

--- a/testsuite/render-mx-conductor/scene.xml
+++ b/testsuite/render-mx-conductor/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="30" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20.2562" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-dielectric-glass/scene.xml
+++ b/testsuite/render-mx-dielectric-glass/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="30" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20.2562" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-dielectric/scene.xml
+++ b/testsuite/render-mx-dielectric/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="30" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20.2562" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-furnace-burley-diffuse/scene.xml
+++ b/testsuite/render-mx-furnace-burley-diffuse/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="4.2" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="12.5552" />
    <Option max_bounces="int 10" />
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-furnace-oren-nayar/scene.xml
+++ b/testsuite/render-mx-furnace-oren-nayar/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="4.2" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="12.5552" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-furnace-sheen/scene.xml
+++ b/testsuite/render-mx-furnace-sheen/scene.xml
@@ -1,6 +1,6 @@
 <World>
    <Option max_bounces="int 5" />
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="4.2" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="12.5552" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-generalized-schlick-glass/scene.xml
+++ b/testsuite/render-mx-generalized-schlick-glass/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="30" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20.2562" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-generalized-schlick/scene.xml
+++ b/testsuite/render-mx-generalized-schlick/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="30" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20.2562" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-layer/scene.xml
+++ b/testsuite/render-mx-layer/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="30" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20.2562" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-mx-medium-vdf-glass/scene.xml
+++ b/testsuite/render-mx-medium-vdf-glass/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="50, 50, 300" dir="0,0,-1" fov="60" />
+   <Camera eye="50, 50, 300" dir="0,0,-1" fov="32.2042" />
    
    <ShaderGroup>color Cs 0.75 0.25 0.25; shader matte layer1;</ShaderGroup>
    <Quad corner="0, 0, 0" edge_x="0,100,0" edge_y="0,0,150" /> <!-- Left -->

--- a/testsuite/render-mx-medium-vdf/scene.xml
+++ b/testsuite/render-mx-medium-vdf/scene.xml
@@ -1,5 +1,5 @@
 <World>
-    <Camera eye="0, 0, 80" look_at="0,0,0" fov="14.0" />
+    <Camera eye="0, 0, 80" look_at="0,0,0" fov="7.02622" />
 
     <!-- Environment light -->
     <ShaderGroup is_light="yes">

--- a/testsuite/render-mx-sheen/scene.xml
+++ b/testsuite/render-mx-sheen/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="30" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20.2562" />
 
    <ShaderGroup>
       shader envmap layer1;

--- a/testsuite/render-oren-nayar/scene.xml
+++ b/testsuite/render-oren-nayar/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 100, 300" look_at="0,0,0" fov="70" />
+   <Camera eye="0, 100, 300" look_at="0,0,0" fov="50.0468" />
 
    <ShaderGroup>
       param float scale_s 20;

--- a/testsuite/render-raytypes/scene.xml
+++ b/testsuite/render-raytypes/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 0, 10" look_at="0,0,0" fov="20" />
+   <Camera eye="0, 0, 10" look_at="0,0,0" fov="13.234" />
 
    <ShaderGroup>
      string filename "../common/textures/kitchen_probe.hdr";

--- a/testsuite/render-spi-thinlayer/scene.xml
+++ b/testsuite/render-spi-thinlayer/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 100, 300" look_at="0,0,0" fov="70" />
+   <Camera eye="0, 100, 300" look_at="0,0,0" fov="50.0468" />
 
    <ShaderGroup>
       string filename "../common/textures/kitchen_probe.hdr";

--- a/testsuite/render-uv/scene.xml
+++ b/testsuite/render-uv/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 250, 400" look_at="0,0,0" fov="40" />
+   <Camera eye="0, 250, 400" look_at="0,0,0" fov="27.2781" />
 
    <ShaderGroup>
       shader uv layer1;

--- a/testsuite/render-veachmis/veach.xml
+++ b/testsuite/render-veachmis/veach.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 100, 300" look_at="0,0,0" fov="70" />
+   <Camera eye="0, 100, 300" look_at="0,0,0" fov="50.0468" />
    <Option max_bounces="int 1" />
    <ShaderGroup>
       param float scale_s 20;

--- a/testsuite/render-ward/scene.xml
+++ b/testsuite/render-ward/scene.xml
@@ -1,5 +1,5 @@
 <World>
-   <Camera eye="0, 100, 300" look_at="0,0,0" fov="70" />
+   <Camera eye="0, 100, 300" look_at="0,0,0" fov="50.0468" />
 
    <ShaderGroup>
       param float scale_s 20;


### PR DESCRIPTION
### Description

* Fixed "camera", "screen", "NDC", and "raster" transformation spaces.
* Moved them to named spaces and fetch on the Optix side.
* Fixed camera FOV. Here are the before/after results for 90°.
  <img width="547" height="275" alt="image" src="https://github.com/user-attachments/assets/95401261-58e5-4e15-8177-f328f80e871f" />
* The code was implying that the FOV is horizontal...
```
void
SimpleRaytracer::camera_params(const Matrix44& world_to_camera,
                               ustringhash projection, float hfov, float hither,
                               float yon, int xres, int yres)
{
    m_world_to_camera  = world_to_camera;
    m_projection       = projection;
    m_fov              = hfov;
```
...but implemented as vertical
```
    float k    = OIIO::fast_tan(fov * float(M_PI / 360));
    cx         = right * (xres * k / yres);
    cy         = (cx.cross(dir)).normalize() * k;
```


### Tests

Some tests with testrender failed due to the FOV fix and reinterpretation, but I've recalculated FOV in .xml scenes to make them look similar to previous results. It won't be a perfect match and would require updating ref images anyway.

### Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested in the testsuite**.
- [ ] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
