### PR TITLE
fix(testrender): Fix discontinuities in principal directions

### DIFF
--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -40,9 +40,13 @@ class OptixRenderer;  // FIXME -- should not be here
 inline OSL_HOSTDEVICE void
 ortho(const Vec3& n, Vec3& x, Vec3& y)
 {
-    x = (fabsf(n.x) > .01f ? Vec3(n.z, 0, -n.x) : Vec3(0, -n.z, n.y))
-            .normalize();
-    y = n.cross(x);
+    // https://research.pixar.com/docs/2017.Others.DBCHKLV.pdf
+    float sign = copysignf(1.0f, n.z);
+    const float a = -1.0f / (sign + n.z);
+    const float b = n.x * n.y * a;
+    // Negate to match previous implementation
+    x = -Vec3(1.0f + sign * n.x * n.x * a, sign * b, -sign * n.x);
+    y = -Vec3(b, sign + n.y * n.y * a, -n.y);
 }
 
 

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -41,6 +41,7 @@ inline OSL_HOSTDEVICE void
 ortho(const Vec3& n, Vec3& x, Vec3& y)
 {
     // https://research.pixar.com/docs/2017.Others.DBCHKLV.pdf
+    // Duff, et al. "Building an Orthonormal Basis, Revisited", JCGT 6(1) 2017.
     float sign    = copysignf(1.0f, n.z);
     const float a = -1.0f / (sign + n.z);
     const float b = n.x * n.y * a;

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -41,7 +41,7 @@ inline OSL_HOSTDEVICE void
 ortho(const Vec3& n, Vec3& x, Vec3& y)
 {
     // https://research.pixar.com/docs/2017.Others.DBCHKLV.pdf
-    float sign = copysignf(1.0f, n.z);
+    float sign    = copysignf(1.0f, n.z);
     const float a = -1.0f / (sign + n.z);
     const float b = n.x * n.y * a;
     // Negate to match previous implementation

--- a/src/testrender/raytracer.h
+++ b/src/testrender/raytracer.h
@@ -44,9 +44,9 @@ ortho(const Vec3& n, Vec3& x, Vec3& y)
     float sign    = copysignf(1.0f, n.z);
     const float a = -1.0f / (sign + n.z);
     const float b = n.x * n.y * a;
-    // Negate to match previous implementation
-    x = -Vec3(1.0f + sign * n.x * n.x * a, sign * b, -sign * n.x);
-    y = -Vec3(b, sign + n.y * n.y * a, -n.y);
+
+    x = Vec3(1.0f + sign * n.x * n.x * a, sign * b, -sign * n.x);
+    y = Vec3(b, sign + n.y * n.y * a, -n.y);
 }
 
 

--- a/src/testrender/sampling.h
+++ b/src/testrender/sampling.h
@@ -16,7 +16,7 @@ struct TangentFrame {
     // build frame from unit normal
     static OSL_HOSTDEVICE TangentFrame from_normal(const Vec3& n)
     {
-        // https://graphics.pixar.com/library/OrthonormalB/paper.pdf
+        // https://research.pixar.com/docs/2017.Others.DBCHKLV.pdf
         const float sign = copysignf(1.0f, n.z);
         const float a    = -1 / (sign + n.z);
         const float b    = n.x * n.y * a;

--- a/src/testrender/sampling.h
+++ b/src/testrender/sampling.h
@@ -17,6 +17,7 @@ struct TangentFrame {
     static OSL_HOSTDEVICE TangentFrame from_normal(const Vec3& n)
     {
         // https://research.pixar.com/docs/2017.Others.DBCHKLV.pdf
+        // Duff, et al. "Building an Orthonormal Basis, Revisited", JCGT 6(1) 2017.
         const float sign = copysignf(1.0f, n.z);
         const float a    = -1 / (sign + n.z);
         const float b    = n.x * n.y * a;


### PR DESCRIPTION
### Description

This is just a cosmetic improvement.

It's much nicer to have continuous values when working with derivatives.
E.g. here is OLD result of `Dx(P)`

<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/880cbba2-499d-4769-8e92-a858ea9b9a70" />

### Checklist:

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
