### PR TITLE
[testrender] Enable mipmap in optix by switching to cached ImageBuf

### DIFF
--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -114,6 +114,8 @@ OptixRaytracer::OptixRaytracer()
 
     CUDA_CHECK(cudaSetDevice(0));
     CUDA_CHECK(cudaStreamCreate(&m_cuda_stream));
+
+    cache = OIIO::ImageCache::create();
 }
 
 
@@ -930,7 +932,7 @@ OptixRaytracer::get_texture_handle(ustring filename,
     auto itr = m_samplers.find(filename);
     if (itr == m_samplers.end()) {
         // Open image to check the number of mip levels
-        OIIO::ImageBuf image;
+        OIIO::ImageBuf image(filename, 0, 0, cache);
         if (!image.init_spec(filename, 0, 0)) {
             errhandler().errorfmt("Could not load: {} (hash {})", filename,
                                   filename);
@@ -1001,7 +1003,7 @@ OptixRaytracer::get_texture_handle(ustring filename,
         tex_desc.filterMode          = cudaFilterModeLinear;
         tex_desc.readMode            = cudaReadModeElementType;
         tex_desc.normalizedCoords    = 1;
-        tex_desc.maxAnisotropy       = 1;
+        tex_desc.maxAnisotropy       = 16;
         tex_desc.maxMipmapLevelClamp = float(nmiplevels - 1);
         tex_desc.minMipmapLevelClamp = 0;
         tex_desc.mipmapFilterMode    = cudaFilterModeLinear;

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -939,7 +939,7 @@ OptixRaytracer::get_texture_handle(ustring filename,
 #if 1
         // Workaround until OpenImageIO fix nmiplevels() call
         int32_t nmiplevels = 0;
-        auto inp = OIIO::ImageInput::open(filename.c_str());
+        auto inp           = OIIO::ImageInput::open(filename.c_str());
         while (inp->seek_subimage(0, nmiplevels))
             nmiplevels++;
 #else

--- a/src/testrender/optixraytracer.cpp
+++ b/src/testrender/optixraytracer.cpp
@@ -114,8 +114,6 @@ OptixRaytracer::OptixRaytracer()
 
     CUDA_CHECK(cudaSetDevice(0));
     CUDA_CHECK(cudaStreamCreate(&m_cuda_stream));
-
-    cache = OIIO::ImageCache::create();
 }
 
 
@@ -932,13 +930,21 @@ OptixRaytracer::get_texture_handle(ustring filename,
     auto itr = m_samplers.find(filename);
     if (itr == m_samplers.end()) {
         // Open image to check the number of mip levels
-        OIIO::ImageBuf image(filename, 0, 0, cache);
+        OIIO::ImageBuf image;
         if (!image.init_spec(filename, 0, 0)) {
             errhandler().errorfmt("Could not load: {} (hash {})", filename,
                                   filename);
             return (TextureHandle*)nullptr;
         }
+#if 1
+        // Workaround until OpenImageIO fix nmiplevels() call
+        int32_t nmiplevels = 0;
+        auto inp = OIIO::ImageInput::open(filename.c_str());
+        while (inp->seek_subimage(0, nmiplevels))
+            nmiplevels++;
+#else
         int32_t nmiplevels = std::max(image.nmiplevels(), 1);
+#endif
         int32_t img_width  = image.xmax() + 1;
         int32_t img_height = image.ymax() + 1;
 

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/ustring.h>
 
 #include <OSL/oslexec.h>
@@ -145,8 +144,6 @@ private:
     // CUdeviceptrs that need to be freed after we are done
     std::vector<CUdeviceptr> m_ptrs_to_free;
     std::vector<cudaArray_t> m_arrays_to_free;
-
-    std::shared_ptr<OIIO::ImageCache> cache;
 };
 
 

--- a/src/testrender/optixraytracer.h
+++ b/src/testrender/optixraytracer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <OpenImageIO/imagecache.h>
 #include <OpenImageIO/ustring.h>
 
 #include <OSL/oslexec.h>
@@ -144,6 +145,8 @@ private:
     // CUdeviceptrs that need to be freed after we are done
     std::vector<CUdeviceptr> m_ptrs_to_free;
     std::vector<cudaArray_t> m_arrays_to_free;
+
+    std::shared_ptr<OIIO::ImageCache> cache;
 };
 
 


### PR DESCRIPTION
### Description
This PR workarounds this [issue](https://github.com/AcademySoftwareFoundation/OpenImageIO/issues/5409)

I also increased maxAnisotropy to the maximum to prevent overblurring and match CPU results better.

### Tests
Expect some Optix tests may fail.

### Checklist:
- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [ ] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [ ] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
