### PR TITLE
fix(build): Correctly serialize CUDA build in testrender

### DIFF
--- a/src/testrender/CMakeLists.txt
+++ b/src/testrender/CMakeLists.txt
@@ -85,6 +85,10 @@ target_link_libraries (testrender
         pugixml::pugixml
         Threads::Threads)
 
+if (OSL_USE_OPTIX)
+    add_dependencies(testrender testrender_ptx)
+endif ()
+
 osl_optix_target (testrender)
 
 install ( TARGETS testrender RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )


### PR DESCRIPTION
When building with CUDA / OptiX, src/testrender/CMakeLists.txt was not specifying a dependency of testrender on testrender_ptx, allowing GNU Make to run these two sets of instructions as parallel jobs. When building on multiple cores, this could result in llvm crashing when the testrender build steps would try to access files still being build by the testrender_ptx build steps.

Fixes #2156 and is the same fix which was previously applied to testshade in [PR 2012](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/pull/2012).

Assisted-by: Claude/Sonnet 5