### PR TITLE
fix(bsdl): Correct colored Fresnel sampling

### DIFF
--- a/src/libbsdl/CMakeLists.txt
+++ b/src/libbsdl/CMakeLists.txt
@@ -8,3 +8,12 @@ include(bsdl.cmake)
 # but for other color spaces tell this function which ones
 # and it will bake Jakob-Hanika coefficient tables.
 add_bsdl_library(BSDL) # SPECTRAL_COLOR_SPACES "ACEScg")
+
+
+if (OSL_BUILD_TESTS AND BUILD_TESTING)
+    add_executable (bsdl_test bsdl_test.cpp)
+    set_target_properties (bsdl_test PROPERTIES FOLDER "Unit Tests")
+    target_include_directories (bsdl_test BEFORE PRIVATE ${OpenImageIO_INCLUDES})
+    target_link_libraries (bsdl_test PRIVATE BSDL OpenImageIO::OpenImageIO)
+    add_test (unit_bsdl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bsdl_test)
+endif()

--- a/src/libbsdl/bsdl_test.cpp
+++ b/src/libbsdl/bsdl_test.cpp
@@ -1,0 +1,93 @@
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
+#define BSDL_UNROLL()
+
+#include <BSDL/config.h>
+
+using BSDLConfig = bsdl::BSDLDefaultConfig;
+
+#include <BSDL/MTX/bsdf_schlick_impl.h>
+
+#include <OpenImageIO/unittest.h>
+
+using namespace bsdl;
+
+
+
+struct TestDielectricBSDF : mtx::DielectricBSDF<mtx::SchlickFresnel> {
+    using Base = mtx::DielectricBSDF<mtx::SchlickFresnel>;
+    using Base::Base;
+    using Base::reflection_probability;
+};
+
+
+
+static void
+test_colored_schlick_sampling()
+{
+    const float rgb[] = { 0.1f, 0.2f, 0.8f };
+    const Power F([&](int i) { return rgb[i]; }, 0.0f);
+    const mtx::SchlickFresnel fresnel(F, F, 5.0f, 1.5f, false);
+    const GGXDist dist(0.25f, 0.0f);
+    const Imath::V3f wo(0.0f, 0.0f, 1.0f);
+    const TestDielectricBSDF bsdf(dist, fresnel, wo.z, 0.25f, true, 0.0f);
+
+    const float probability = (rgb[0] + rgb[1] + rgb[2]) / 3.0f;
+    OIIO_CHECK_EQUAL_THRESH(bsdf.reflection_probability(F), probability, 1e-6f);
+    OIIO_CHECK_EQUAL_THRESH(bsdf.reflection_probability(Power::UNIT()), 1.0f,
+                            1e-6f);
+
+    const Sample reflected   = bsdf.sample(wo, 0.5f, 0.5f, probability - 0.01f);
+    const Sample transmitted = bsdf.sample(wo, 0.5f, 0.5f, probability + 0.01f);
+    OIIO_CHECK_ASSERT(reflected.wi.z > 0.0f);
+    OIIO_CHECK_ASSERT(transmitted.wi.z < 0.0f);
+
+    const float rgb2[] = { 0.2f, 0.4f, 0.6f };
+    const Power F2([&](int i) { return rgb2[i]; }, 0.0f);
+    const mtx::SchlickFresnel fresnel2(F2, F2, 5.0f, 1.5f, false);
+    const TestDielectricBSDF bsdf2(dist, fresnel2, wo.z, 0.25f, true, 0.0f);
+    const float probability2 = (rgb2[0] + rgb2[1] + rgb2[2]) / 3.0f;
+
+    const Sample reflected2   = bsdf2.sample(wo, 0.5f, 0.5f, 0.3f);
+    const Sample transmitted2 = bsdf2.sample(wo, 0.5f, 0.5f, 0.8f);
+    const Sample reflected1   = bsdf.sample(wo, 0.5f, 0.5f, 0.3f);
+    const Sample transmitted1 = bsdf.sample(wo, 0.5f, 0.5f, 0.8f);
+    OIIO_CHECK_EQUAL_THRESH(reflected1.pdf / reflected2.pdf,
+                            probability / probability2, 1e-6f);
+    const float transmission_probability  = 1.0f - probability;
+    const float transmission_probability2 = 1.0f - probability2;
+    OIIO_CHECK_EQUAL_THRESH(transmitted1.pdf / transmitted2.pdf,
+                            transmission_probability
+                                / transmission_probability2,
+                            1e-6f);
+    for (int i = 0; i < 3; ++i) {
+        OIIO_CHECK_EQUAL_THRESH(reflected1.weight[i] / reflected2.weight[i],
+                                (rgb[i] * probability2)
+                                    / (rgb2[i] * probability),
+                                1e-6f);
+        OIIO_CHECK_EQUAL_THRESH(transmitted1.weight[i] / transmitted2.weight[i],
+                                ((1.0f - rgb[i]) * transmission_probability2)
+                                    / ((1.0f - rgb2[i])
+                                       * transmission_probability),
+                                1e-6f);
+    }
+
+    const float spectral[] = { 0.2f, 0.4f, 0.6f, 0.8f };
+    const Power Fs([&](int i) { return spectral[i]; }, 500.0f);
+    const mtx::SchlickFresnel spectral_fresnel(Fs, Fs, 5.0f, 1.5f, false);
+    const TestDielectricBSDF spectral_bsdf(dist, spectral_fresnel, wo.z, 0.25f,
+                                           true, 500.0f);
+    OIIO_CHECK_EQUAL_THRESH(spectral_bsdf.reflection_probability(Fs), 0.5f,
+                            1e-6f);
+}
+
+
+
+int
+main(int /*argc*/, char* /*argv*/[])
+{
+    test_colored_schlick_sampling();
+    return unit_test_failures;
+}

--- a/src/libbsdl/include/BSDL/MTX/bsdf_dielectric_decl.h
+++ b/src/libbsdl/include/BSDL/MTX/bsdf_dielectric_decl.h
@@ -42,7 +42,7 @@ template<typename Fresnel> struct DielectricBSDF {
 
     BSDL_INLINE_METHOD
     DielectricBSDF(const GGXDist& dist, const Fresnel& fresnel, float cosNO,
-                   float roughness, bool dorefr);
+                   float roughness, bool dorefr, float lambda_0);
 
     DielectricBSDF() = default;
 
@@ -58,9 +58,12 @@ template<typename Fresnel> struct DielectricBSDF {
     static constexpr const char* NS = "mtx";
 
 protected:
+    BSDL_INLINE_METHOD float reflection_probability(const Power& F) const;
+
     GGXDist d;
     Fresnel f;
     float E_ms;
+    float lambda_0;
     bool dorefr;
 };
 

--- a/src/libbsdl/include/BSDL/MTX/bsdf_dielectric_impl.h
+++ b/src/libbsdl/include/BSDL/MTX/bsdf_dielectric_impl.h
@@ -67,8 +67,9 @@ template<typename Fresnel>
 BSDL_INLINE_METHOD
 DielectricBSDF<Fresnel>::DielectricBSDF(const GGXDist& dist,
                                         const Fresnel& fresnel, float cosNO,
-                                        float roughness, bool dorefr)
-    : d(dist), f(fresnel), dorefr(dorefr)
+                                        float roughness, bool dorefr,
+                                        float lambda_0)
+    : d(dist), f(fresnel), lambda_0(lambda_0), dorefr(dorefr)
 {
     if (!dorefr) {
         TabulatedEnergyCurve<spi::MiniMicrofacetGGX> curve(roughness, 0.0f);
@@ -83,7 +84,7 @@ DielectricReflFront::DielectricReflFront(float cosNO, float roughness_index,
     : DielectricBSDF<DielectricFresnel>(
         GGXDist(roughness_index, 0),
         DielectricFresnel::from_table_index(fresnel_index, false), cosNO,
-        roughness_index, false)
+        roughness_index, false, 1)
 {
 }
 
@@ -93,7 +94,7 @@ DielectricBothFront::DielectricBothFront(float cosNO, float roughness_index,
     : DielectricBSDF<DielectricFresnel>(
         GGXDist(roughness_index, 0),
         DielectricFresnel::from_table_index(fresnel_index, false), cosNO,
-        roughness_index, true)
+        roughness_index, true, 1)
 {
 }
 
@@ -103,8 +104,17 @@ DielectricBothBack::DielectricBothBack(float cosNO, float roughness_index,
     : DielectricBSDF<DielectricFresnel>(
         GGXDist(roughness_index, 0),
         DielectricFresnel::from_table_index(fresnel_index, true), cosNO,
-        roughness_index, true)
+        roughness_index, true, 1)
 {
+}
+
+template<typename Fresnel>
+BSDL_INLINE_METHOD float
+DielectricBSDF<Fresnel>::reflection_probability(const Power& F) const
+{
+    // Fresnel may return Power::UNIT(), so mask the inactive RGB lane before
+    // averaging.
+    return F.cliped_rgb(lambda_0).avg(lambda_0);
 }
 
 template<typename Fresnel>
@@ -125,18 +135,19 @@ DielectricBSDF<Fresnel>::eval(Imath::V3f wo, Imath::V3f wi) const
         const float D  = d.D(m);
         const float G1 = d.G1(wo);
         const Power F  = f.eval(cosMO);
-        if (F.max() <= 0)
+        const float P  = reflection_probability(F);
+        if (P <= 0)
             return {};
         if constexpr (BSDLConfig::use_bvn_refraction) {
             // Reflection optimized density
             const float D_refl_D = d.D_refl_D(wo, m);
             const float D_refl   = D_refl_D * D;
-            const Power out = F * (d.G2_G1(wi, wo) * G1 / (D_refl_D * F.max()));
-            const float pdf = D_refl / (4.0f * cosNO) * F.max();
+            const Power out      = F * (d.G2_G1(wi, wo) * G1 / (D_refl_D * P));
+            const float pdf      = D_refl / (4.0f * cosNO) * P;
             return { wi, out, pdf, 0 };
         } else {
-            const Power out = F * d.G2_G1(wi, wo);
-            const float pdf = (G1 * D * F.max()) / (4.0f * cosNO);
+            const Power out = F * (d.G2_G1(wi, wo) / P);
+            const float pdf = (G1 * D * P) / (4.0f * cosNO);
             return { wi, out, pdf, 0 };
         }
     } else if (cosNI < 0) {
@@ -148,8 +159,10 @@ DielectricBSDF<Fresnel>::eval(Imath::V3f wo, Imath::V3f wi) const
         const float cosHI = Ht.dot(wi);
         if (cosHO <= 0 || cosHI >= 0)
             return {};
-        const Power Ft = Power::UNIT() - f.eval(cosHO);
-        if (Ht.z <= 0 || Ft.max() <= 0)
+        const Power F  = f.eval(cosHO);
+        const Power Ft = Power::UNIT() - F;
+        const float Pt = 1 - reflection_probability(F);
+        if (Ht.z <= 0 || Pt <= 0)
             return {};
         const float D  = d.D(Ht);
         const float G1 = d.G1(wo);
@@ -159,16 +172,15 @@ DielectricBSDF<Fresnel>::eval(Imath::V3f wo, Imath::V3f wi) const
             // Reflection optimized density
             const float D_refl_D = d.D_refl_D(wo, Ht);
             const float D_refl   = D_refl_D * D;
-            float pdf            = D_refl * J * Ft.max();
+            float pdf            = D_refl * J * Pt;
             const Power out      = Ft
                               * (d.G2_G1({ wi.x, wi.y, -wi.z }, wo) * G1
-                                 / (D_refl_D * Ft.max()));
+                                 / (D_refl_D * Pt));
             return { wi, out, pdf, 0 };
         } else {
-            const Power out = Ft
-                              * (d.G2_G1({ wi.x, wi.y, -wi.z }, wo) / Ft.max());
+            const Power out = Ft * (d.G2_G1({ wi.x, wi.y, -wi.z }, wo) / Pt);
 
-            float pdf = J * G1 * D * Ft.max();
+            float pdf = J * G1 * D * Pt;
             return { wi, out, pdf, 0 };
         }
 
@@ -196,8 +208,8 @@ DielectricBSDF<Fresnel>::sample(Imath::V3f wo, float randu, float randv,
     const float cosMO = wo.dot(m);
     if (cosMO <= 0)
         return {};
-    const float F       = f.eval(cosMO).max();
-    bool choose_reflect = randw < F;
+    const float P       = reflection_probability(f.eval(cosMO));
+    bool choose_reflect = randw < P;
     const Imath::V3f wi = choose_reflect ? reflect(wo, m)
                                          : refract(wo, m, f.refraction_eta());
     if ((choose_reflect && wi.z <= 0) || (!choose_reflect && wi.z >= 0))
@@ -245,7 +257,8 @@ DielectricLobe<BSDF_ROOT>::DielectricLobe(T* lobe, const BsdfGlobals& globals,
     DielectricFresnel fresnel(globals.relative_eta(IOR), globals.backfacing);
     E_ms = 0;
     spec = DielectricBSDF<DielectricFresnel>(GGXDist(roughness, aniso, rx < ry),
-                                             fresnel, cosNO, roughness, dorefr);
+                                             fresnel, cosNO, roughness, dorefr,
+                                             globals.lambda_0);
     if (dorefl && !dorefr) {
         E_ms = TabulatedEnergyCurve<DielectricReflFront>(roughness,
                                                          fresnel.table_index())

--- a/src/libbsdl/include/BSDL/MTX/bsdf_schlick_impl.h
+++ b/src/libbsdl/include/BSDL/MTX/bsdf_schlick_impl.h
@@ -73,7 +73,8 @@ SchlickLobe<BSDF_ROOT>::SchlickLobe(T* lobe, const BsdfGlobals& globals,
 
     E_ms = 0;
     spec = DielectricBSDF<SchlickFresnel>(GGXDist(roughness, aniso, rx < ry),
-                                          fresnel, cosNO, roughness, dorefr);
+                                          fresnel, cosNO, roughness, dorefr,
+                                          globals.lambda_0);
     if (dorefl && !dorefr) {
         // Energy compensation reuses the dielectric Fresnel albedo tables,
         // which assumes the Schlick curve matches the true dielectric Fresnel.


### PR DESCRIPTION
Assisted-by: OpenAI Codex / GPT-5.6

### Description

The BSDL sampler shared by testrender's MaterialX dielectric and
generalized-Schlick closures selects reflection with probability `max(F)` and
transmission with the remaining probability. For RGB `F = (0.2, 0.5, 0.8)`,
this gives a reflection probability of `0.8` and a transmission probability of
`0.2`. The transmission evaluation instead uses `max(1 - F) = 0.8` as the
transmission probability when computing the PDF and sample weight. A
transmission sample selected with probability `0.2` is therefore evaluated as
though it had been selected with probability `0.8`.

This change restores the arithmetic-average selection used by testrender's
original implementation of the MaterialX generalized-Schlick closure for
neutral reflection and transmission tints:

```cpp
pR = average(F);
pT = 1 - pR;
```

For the example above, this gives `pR = 0.5` and `pT = 0.5`.

This is also consistent with testrender's BSDF lobe-selection policy. With
neutral path throughput, path-weighted albedo selection reduces to the
arithmetic average over the active channels.

The same complementary probabilities are used for event selection, the
reported PDF, and the reciprocal sample weight. In particular, once reflection
is selected with probability `pR`, its returned weight must include `1 / pR`
because the full sampling density is `pR` times the conditional microfacet
density.

The internal dielectric helper receives `lambda_0` so that the average covers
three channels in RGB mode and four channels in spectral mode. Fresnel may
return `Power::UNIT()`, which populates all four lanes, so the inactive RGB
lane is masked before averaging. No separate scatter-mode handling is
introduced.

Open question for review: this change adds a required argument to the
header-only `DielectricBSDF` constructor. Defaulting it to `0` would preserve
existing RGB call sites but would silently treat existing spectral call sites
as RGB. Should direct constructor users be required to pass `lambda_0`, or
should an RGB-default compatibility overload be provided?

This is an internal BSDL sampling correction with no OSL language change, so no
documentation update is needed.

### Tests

Local validation on Windows:

- CMake configuration completed successfully.
- The Release `genluts`, `testrender`, and `oslc` targets built successfully;
  `genluts` regenerated all BSDL lookup tables.
- The focused `unit_bsdl` test passes. It covers RGB and spectral averaging,
  inactive RGB-lane masking, the colored reflection/transmission sampling
  boundary, and the corresponding PDF and reciprocal-weight factors.
- The existing generalized-Schlick tests compiled their shaders and rendered
  their output images. CTest could not compare the images because the locally
  configured `idiff` and `oiiotool` executables are unavailable.
- `git diff --check` passes.
- [Fork CI](https://github.com/tdavidovicNV/OpenShadingLanguage/actions/runs/33467738438)
  completed for commit `717d5aaf`: 22 of 23 matrix jobs passed. This includes
  clang-format 17, and `unit_bsdl` passed across the build/test configurations.
- The sanitizer job failed during dependency setup, before OSL was built,
  because the cached `TIFF::tiff` target references a missing `WebP::webp`
  target. This is unrelated to the change.

Codex was used to trace the sampling/PDF mismatch, compare the correction with
the original MaterialX implementation and other renderer policies, and draft
the fix and PR description. I reviewed the resulting changes and build output.

### Checklist

- [x] **I have read the guidelines** on [contributions](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/CONTRIBUTING.md) and [code review procedures](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/CodeReview.md).
- [x] **I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/main/docs/dev/AI_Policy.md)**
  and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL`
  line in the pull request description above.
- [x] **I have updated the documentation** if my PR adds features or changes
  behavior.
- [x] **I am sure that this PR's changes are tested in the testsuite**.
- [x] **I have run and passed the testsuite in CI** *before* submitting the
  PR, by pushing the changes to my fork and seeing that the automated CI
  passed there. (Exceptions: If most tests pass and you can't figure out why
  the remaining ones fail, it's ok to submit the PR and ask for help. Or if
  any failures seem entirely unrelated to your change; sometimes things break
  on the GitHub runners.)
- [x] **My code follows the prevailing code style of this project** and I
  fixed any problems reported by the clang-format CI test.
