### PR TITLE
build: support LLVM 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,7 +469,7 @@ jobs:
             openimageio_ver: main
             python_ver: "3.13"
             setenvs: export LLVMBREWVER="@19"
-          - desc: MacOS-15-ARM aclang16/C++17/py3.13 llvm21 oiio-main
+          - desc: MacOS-15-ARM aclang16/C++17/py3.13 llvm23 oiio-main
             runner: macos-15
             nametag: macos15-arm
             cc_compiler: /usr/bin/clang

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ NEW or CHANGED minimum dependencies since the last major release are **bold**.
 
 * A suitable C++17 compiler to build OSL itself, which may be any of:
    - GCC 9.3 or newer (tested through gcc 14)
-   - Clang 5 or newer (tested through clang 22)
+   - Clang 5 or newer (tested through clang 23)
    - Microsoft Visual Studio 2017 or newer
    - **Intel LLVM-based icx compiler version 2022 or newer** (note: the classic `icc` compiler is no longer supported).
 
@@ -49,7 +49,7 @@ NEW or CHANGED minimum dependencies since the last major release are **bold**.
     DYLD_LIBRARY_PATH on OS X).
 
 * [LLVM](http://www.llvm.org) **14.0 or newer**, 15, 16, 17, 18, 19, 20, 21,
-  22, including clang libraries.
+  22, 23, including clang libraries.
 
 * (optional) For GPU rendering on NVIDIA GPUs:
     * [OptiX](https://developer.nvidia.com/rtx/ray-tracing/optix) 7.0 or higher.

--- a/src/cmake/externalpackages.cmake
+++ b/src/cmake/externalpackages.cmake
@@ -58,7 +58,7 @@ checked_find_package (pugixml REQUIRED
 # LLVM library setup
 checked_find_package (LLVM REQUIRED
                       VERSION_MIN 14.0
-                      VERSION_MAX 22.9
+                      VERSION_MAX 23.9
                       PRINT LLVM_SYSTEM_LIBRARIES CLANG_LIBRARIES
                             LLVM_SHARED_MODE)
 # ensure include directory is added (in case of non-standard locations

--- a/src/cmake/modules/FindLLVM.cmake
+++ b/src/cmake/modules/FindLLVM.cmake
@@ -116,19 +116,26 @@ if (LLVM_SHARED_MODE STREQUAL "shared")
     endif ()
 endif ()
 
-foreach (COMPONENT clangFrontend clangDriver clangSerialization
-                   clangParse clangSema clangAnalysis clangAST
-                   clangASTMatchers clangEdit clangLex
-                   clangSupport clangAPINotes clangBasic
-                   clangOptions clangAnalysisLifetimeSafety)
-    find_library ( _CLANG_${COMPONENT}_LIBRARY
-                  NAMES ${COMPONENT}
-                  PATHS ${LLVM_LIB_DIR}
-                  NO_DEFAULT_PATH)
-    if (_CLANG_${COMPONENT}_LIBRARY)
-        list (APPEND CLANG_LIBRARIES ${_CLANG_${COMPONENT}_LIBRARY})
-    endif ()
-endforeach ()
+# libclang-cpp contains all the clang components we need, so the separate
+# static archives are only a fallback for when it isn't present (such as an
+# LLVM built with LLVM_LINK_LLVM_DYLIB=OFF). Linking both is redundant, and
+# some LLVM distributions build the static archives in a form the system
+# linker can't consume.
+if (NOT _CLANG_CPP_LIBRARY)
+    foreach (COMPONENT clangFrontend clangDriver clangSerialization
+                       clangParse clangSema clangAnalysis clangAST
+                       clangASTMatchers clangEdit clangLex
+                       clangSupport clangAPINotes clangBasic
+                       clangOptions clangAnalysisLifetimeSafety)
+        find_library ( _CLANG_${COMPONENT}_LIBRARY
+                      NAMES ${COMPONENT}
+                      PATHS ${LLVM_LIB_DIR}
+                      NO_DEFAULT_PATH)
+        if (_CLANG_${COMPONENT}_LIBRARY)
+            list (APPEND CLANG_LIBRARIES ${_CLANG_${COMPONENT}_LIBRARY})
+        endif ()
+    endforeach ()
+endif ()
 
 
 # shared llvm library may not be available, this is not an error if we use LLVM_STATIC.

--- a/src/liboslexec/llvm_util.cpp
+++ b/src/liboslexec/llvm_util.cpp
@@ -78,7 +78,6 @@ OSL_GCC_PRAGMA(GCC diagnostic ignored "-Wmaybe-uninitialized")
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/Utils.h>
-#include <llvm/Transforms/Utils/UnifyFunctionExitNodes.h>
 
 #include <llvm/Support/DynamicLibrary.h>
 
@@ -1558,14 +1557,22 @@ LLVM_Util::make_jit_execengine(std::string* err, TargetISA requestedISA,
     // control is now handled via per-instruction fast-math flags in IR.
     options.UnsafeFPMath = false;
 #endif
+#if OSL_LLVM_VERSION < 230
+    // NoInfsFPMath, NoNaNsFPMath, and NoSignedZerosFPMath were removed from
+    // TargetOptions in LLVM 23; like UnsafeFPMath before them, FP math
+    // control is now handled via per-instruction fast-math flags in IR.
+    // The values we set here all matched LLVM's own defaults, so simply
+    // dropping them for LLVM 23+ preserves the existing behavior.
+    //
     // Since there are OSL language functions isinf and isnan,
     // we cannot assume there will not be infs and NANs
     options.NoInfsFPMath = false;
     options.NoNaNsFPMath = false;
-    // We will not be setting up any exception handling for FP math
-    options.NoTrappingFPMath = true;
     // Debatable, but perhaps some tests care about the sign of +0 vs. -0
     options.NoSignedZerosFPMath = false;
+#endif
+    // We will not be setting up any exception handling for FP math
+    options.NoTrappingFPMath = true;
     // We will NOT be changing rounding mode dynamically
     options.HonorSignDependentRoundingFPMathOption = false;
 
@@ -1824,8 +1831,12 @@ LLVM_Util::nvptx_target_machine()
         // control is now handled via per-instruction fast-math flags in IR.
         options.UnsafeFPMath = 1;
 #endif
-        options.NoInfsFPMath                           = 1;
-        options.NoNaNsFPMath                           = 1;
+#if OSL_LLVM_VERSION < 230
+        // Removed from TargetOptions in LLVM 23; fast-math relaxations are
+        // now expressed with per-instruction fast-math flags in IR.
+        options.NoInfsFPMath = 1;
+        options.NoNaNsFPMath = 1;
+#endif
         options.HonorSignDependentRoundingFPMathOption = 0;
         options.FloatABIType          = llvm::FloatABI::Default;
         options.AllowFPOpFusion       = llvm::FPOpFusion::Fast;


### PR DESCRIPTION
* LLVM 23 removed `<llvm/Transforms/Utils/UnifyFunctionExitNodes.h>`. We included it but never used anything from it, so just drop the include.

* LLVM 23 removed NoInfsFPMath, NoNaNsFPMath, and NoSignedZerosFPMath from TargetOptions, following UnsafeFPMath in LLVM 22. FP math control is now expressed with per-instruction fast-math flags in the IR.

* Only fall back on the individual static clang archives when libclang-cpp is not available (an LLVM built with LLVM_LINK_LLVM_DYLIB=OFF). We were linking both, which is redundant since libclang-cpp already contains those components.

Assisted-by: Claude Code / claude-opus-5
