### PR TITLE
ci: fix broken CI with recent OIIO change and libtiff vs webp

### DIFF
--- a/src/build-scripts/gh-installdeps.bash
+++ b/src/build-scripts/gh-installdeps.bash
@@ -204,7 +204,7 @@ if [[ "$OPENIMAGEIO_VERSION" != "" ]] ; then
     export ENABLE_BMP=0 ENABLE_cineon=0 ENABLE_DDS=0 ENABLE_DPX=0 ENABLE_FITS=0
     export ENABLE_ICO=0 ENABLE_iff=0 ENABLE_jpeg2000=0 ENABLE_PNM=0 ENABLE_PSD=0
     export ENABLE_RLA=0 ENABLE_SGI=0 ENABLE_SOCKET=0 ENABLE_SOFTIMAGE=0
-    export ENABLE_TARGA=0 ENABLE_WEBP=0 ENABLE_jpegxl=0 ENABLE_libuhdr=0
+    export ENABLE_TARGA=0 ENABLE_jpegxl=0 ENABLE_libuhdr=0
     # We don't need to run OIIO's tests
     export OPENIMAGEIO_CMAKE_FLAGS+=" -DOIIO_BUILD_TESTING=OFF -DOIIO_BUILD_TESTS=0"
     # Don't let warnings in OIIO break OSL's CI run


### PR DESCRIPTION
The CI "sanitizer" job builds against OIIO main.  After recent changes to OIIO main, libtiff 4.1 is the minimum, but the GH runner has libtiff 4.0.9 pre-installed, so it ends up auto-building libtiff. But we specifically try to disable building webp support, so there is a conflict when needing the WebP::webp target (which was never built).

Solution: Don't disable webp building.

Simultaneously fixing the OIIO build to be smarter about this as well.
